### PR TITLE
Minor change to login screen footer 

### DIFF
--- a/intranet/static/css/login.css
+++ b/intranet/static/css/login.css
@@ -193,8 +193,8 @@ a.schedule-right {
 .footer {
     position: fixed;
     bottom: 0;
-    padding: 0 0 5px 5px;
-    font-size: 10px;
+    padding: 0 0 3px 6px;
+    font-size: 13px;
     color: gray;
     z-index: 99;
     text-align: left;


### PR DESCRIPTION
Addresses #373

Right now, the layout of the login page is extremely clean. However, until he uploaded that screenshot I had never even noticed those links. With just a little bit of change to the font size and padding a lot more people will probably notice it with minimal effect on the nice appearance that you guys currently have. Maybe try changing the footer css block to the following:

```css
.footer {
    position: fixed;
    bottom: 0;
    padding: 0 0 3px 6px;
    font-size: 13px;
    color: gray;
    z-index: 99;
    text-align: left;
    width: 100%;
    background: rgba(242,242,242,.5);
}
```
Differences: (click on images, fullscreen makes difference easier to see)

![before](https://cloud.githubusercontent.com/assets/14984764/13191809/6ceffba0-d734-11e5-85cf-7ba30b954ca6.png)
![after](https://cloud.githubusercontent.com/assets/14984764/13191810/6cf202e2-d734-11e5-8236-15270c529809.png)

It's a subtle difference, but it may be enough to give the footer more presence