### PR TITLE
fixed 400 bad request bug

### DIFF
--- a/intranet/apps/files/views.py
+++ b/intranet/apps/files/views.py
@@ -178,7 +178,7 @@ def files_type(request, fstype=None):
                 messages.error(request, e)
                 return redirect("files")
 
-    default_dir = sftp.pwd
+    default_dir = normpath(sftp.pwd)
 
     def can_access_path(fsdir):
         return normpath(fsdir).startswith(default_dir)
@@ -305,7 +305,7 @@ def files_type(request, fstype=None):
 
     logger.debug(files)
 
-    current_dir = sftp.pwd  # current directory
+    current_dir = normpath(sftp.pwd)  # current directory
     dir_list = current_dir.split("/")
     if len(dir_list) > 1 and len(dir_list[-1]) == 0:
         dir_list.pop()
@@ -377,7 +377,7 @@ def files_delete(request, fstype=None):
             messages.error(request, e)
             return redirect("files")
 
-    default_dir = sftp.pwd
+    default_dir = normpath(sftp.pwd)
 
     def can_access_path(fsdir):
         return normpath(fsdir).startswith(default_dir)
@@ -463,7 +463,7 @@ def files_upload(request, fstype=None):
                     messages.error(request, e)
                     return redirect("files")
 
-            default_dir = sftp.pwd
+            default_dir = normpath(sftp.pwd)
 
             def can_access_path(fsdir):
                 return normpath(fsdir).startswith(default_dir)


### PR DESCRIPTION
if dir was set to /R/ then the page would constantly redirect to the same page until 400 bad request
this was because code checked if /R started with /R/, since only one path was normalized
since /R does not start with /R/, then it would redirect to the same page
fixed by normalizing the working directory path