### PR TITLE
Change feedback form button to "Submit"

### DIFF
--- a/intranet/templates/feedback/form.html
+++ b/intranet/templates/feedback/form.html
@@ -54,7 +54,7 @@
             {% csrf_token %}
             {{ form.as_p }}
             <br />
-            <input type="submit" />
+            <input type="submit" value="Submit" />
     </form>
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
Changes the label on the button from "Submit Query" to simply "Submit", because from the user's point of view feedback is often not a query.