### PR TITLE
Fix "last" mapping to "sn" in advanced search

### DIFF
--- a/intranet/apps/search/views.py
+++ b/intranet/apps/search/views.py
@@ -41,7 +41,7 @@ def query(q, admin=False):
                 "first_name",
                 "nickname",),
             "lastname": ("last_name",),
-            "last": ("sn",),
+            "last": ("last_name",),
             "nick": ("nickname",),
             "nickname": ("nickname",),
             "name": (


### PR DESCRIPTION
Advanced search with "last" attribute wasn't working because "last" was mapping to "sn", instead of "last_name". This fixes behavior so using "last:thistlethwaite" has identical behavior to "lastname:thistlethwaite"

@ovkulkarni 