### PR TITLE
Make vagrant ssh as ubuntu

### DIFF
--- a/Ion.egg-info/PKG-INFO
+++ b/Ion.egg-info/PKG-INFO
@@ -1,4 +1,4 @@
-Metadata-Version: 1.1
+Metadata-Version: 2.1
 Name: Ion
 Version: 1.0
 Summary: The next-generation Intranet platform for TJHSST
@@ -6,7 +6,6 @@ Home-page: https://github.com/tjcsl/ion
 Author: The TJHSST Computer Systems Lab
 Author-email: intranet@tjhsst.edu
 License: GPL
-Description-Content-Type: UNKNOWN
 Description: **********
         Intranet 3
         **********
@@ -61,3 +60,4 @@ Classifier: Operating System :: POSIX :: Linux
 Classifier: Programming Language :: Python :: 3.4
 Classifier: Programming Language :: Python :: 3.5
 Classifier: Framework :: Django :: 1.9
+Description-Content-Type: text/x-rst; charset=UTF-8

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -88,4 +88,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     destination: ".ssh/#{devconfig['ssh_key']}.pub"
 
   config.vm.provision "shell", path: "config/provision_vagrant.sh"
+
+  if ARGV[0] == "ssh"
+      config.ssh.username = "ubuntu"
+  end
 end

--- a/config/provision_vagrant.sh
+++ b/config/provision_vagrant.sh
@@ -8,6 +8,10 @@ with open('/home/ubuntu/intranet/config/devconfig.json', 'r') as f:
     print(json.load(f)['$1'])"
 }
 
+sudo su - ubuntu
+cd /home/ubuntu
+sudo cp -pr /home/vagrant/.ssh /home/ubuntu
+sudo chown -R ubuntu: /home/ubuntu/.ssh
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     name="Ion",
     description="The next-generation Intranet platform for TJHSST",
     long_description=long_description,
+    long_description_content_type='text/x-rst; charset=UTF-8',
     author="The TJHSST Computer Systems Lab",
     author_email="intranet@tjhsst.edu",
     url="https://github.com/tjcsl/ion",


### PR DESCRIPTION
Currently, `vagrant ssh` logs in as `vagrant`, the default Vagrant configuration.  This is not expected behavior because all files in the intranet directory are owned by `ubuntu`.