### PR TITLE
Clear unused OAuth tokens

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -40,6 +40,7 @@ cron/eighth-absence.sh
 cron/eighth-evening.sh
 cron/eighth-morning.sh
 cron/env.sh
+cron/oauth-cleartokens.sh
 cron/reset-buses.sh
 docs/conf.py
 docs/favicon.ico

--- a/cron/oauth-cleartokens.sh
+++ b/cron/oauth-cleartokens.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# run at 10pm every day (0 20 * * *)
+
+timestamp=$(date +"%Y-%m-%d-%H%M")
+cd /usr/local/www/intranet3
+./cron/env.sh ./manage.py cleartokens
+echo "Expired OAuth tokens cleared at $timestamp." >> /var/log/ion/oauth-tokens.log

--- a/cron/oauth-cleartokens.sh
+++ b/cron/oauth-cleartokens.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# run at 10pm every day (0 20 * * *)
+# run at 10pm every day (0 22 * * *)
 
 timestamp=$(date +"%Y-%m-%d-%H%M")
 cd /usr/local/www/intranet3

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -459,7 +459,7 @@ OAUTH2_PROVIDER = {
         'write': 'Write scope'
     },
     # OAuth refresh tokens expire in 30 days
-    'REFRESH_TOKEN_EXPIRE_SECONDS' : 2592000,
+    'REFRESH_TOKEN_EXPIRE_SECONDS': 60*60*24*30,
 }
 OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
 

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -457,7 +457,9 @@ OAUTH2_PROVIDER = {
     'SCOPES': {
         'read': 'Read scope',
         'write': 'Write scope'
-    }
+    },
+    # OAuth refresh tokens expire in 30 days
+    'REFRESH_TOKEN_EXPIRE_SECONDS' : 2592000,
 }
 OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
 


### PR DESCRIPTION
Currently, [https://ion.tjhsst.edu/oauth/authorized_tokens](https://ion.tjhsst.edu/oauth/authorized_tokens) is a huge list of authorized tokens, where almost all of them will never be used again.  Sites using OAuth like Director and TJSTAR don't use tokens after the user logs out.
This PR will use a cron job to delete tokens more than 30 days old.