### PR TITLE
Move  from pycrypto to pycryptodome

### DIFF
--- a/Ion.egg-info/requires.txt
+++ b/Ion.egg-info/requires.txt
@@ -74,7 +74,7 @@ ptyprocess==0.5.2
 pyasn1==0.3.2
 pycodestyle==2.3.1
 pycparser==2.18
-pycrypto==2.6.1
+pycryptodome==3.6.4
 pyflakes==1.5.0
 Pygments==2.2.0
 PyNaCl==1.1.2

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -74,7 +74,7 @@ ptyprocess==0.5.2
 pyasn1==0.3.2
 pycodestyle==2.3.1
 pycparser==2.18
-pycrypto==2.6.1
+pycryptodome==3.6.4
 pyflakes==1.5.0
 Pygments==2.2.0
 PyNaCl==1.1.2

--- a/intranet/apps/files/views.py
+++ b/intranet/apps/files/views.py
@@ -78,6 +78,8 @@ def files_auth(request):
         iv = Random.new().read(16)
         obj = AES.new(key, AES.MODE_CFB, iv)
         message = request.POST.get("password")
+        if isinstance(message, str):
+            message = message.encode("utf-8")
         ciphertext = obj.encrypt(message)
         request.session["files_iv"] = base64.b64encode(iv).decode()
         request.session["files_text"] = base64.b64encode(ciphertext).decode()

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ ptyprocess==0.5.2
 pyasn1==0.3.2
 pycodestyle==2.3.1
 pycparser==2.18
-pycrypto==2.6.1
+pycryptodome==3.6.4
 pyflakes==1.5.0
 Pygments==2.2.0
 PyNaCl==1.1.2


### PR DESCRIPTION
pycrypto has had no new releases since October of 2013.  [pycryptodome](https://github.com/Legrandin/pycryptodome) is a fork of pycrypto that is actively maintained. pycryptodome should be a simple drop-in replacement.