### PR TITLE
Make import_fixtures.sh re-invoke itself correctly

### DIFF
--- a/scripts/import_fixtures.sh
+++ b/scripts/import_fixtures.sh
@@ -21,7 +21,7 @@ done
 
 if [ "$(whoami)" != "postgres" ]; then
     echo "Not running as postgres user, switching user..."
-    sudo -u postgres $0
+    sudo -u postgres bash $0
     exit
 fi
 


### PR DESCRIPTION
In dev environments (or at least in certain configurations), NFS permissions prohibit `postgres` from running the script. The only solution I have found (short of running the import commands manually) is to run `sudo -u postgres bash scripts/import_fixtures.sh` in the first place.