### PR TITLE
SGA website link update

### DIFF
--- a/intranet/templates/dashboard/links.html
+++ b/intranet/templates/dashboard/links.html
@@ -12,7 +12,7 @@
         <td>
           <strong class="link-heading">Organizations</strong><br />
           <a href="http://colonialathletics.org/">TJ Athletics</a><br />
-          <a href="https://leadership.tjhsst.edu/sga">TJ SGA</a><br />
+          <a href="https://sga.tjhsst.edu">TJ SGA</a><br />
 
           <strong class="link-heading">Reporting an Issue</strong><br />
           <a href="https://integrity.tjhsst.edu/">Academic Integrity</a><br />


### PR DESCRIPTION
SGA wanted their website link to be updated to sga.tjhsst.edu