### PR TITLE
Fixed CSS transform interfering with layout

### DIFF
--- a/intranet/static/css/login.scss
+++ b/intranet/static/css/login.scss
@@ -1,7 +1,12 @@
 @import "colors";
+height {
+    height: 100%;
+}
+
 body {
     text-align: center;
     overflow-x: hidden;
+    height: 100%;
     // Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#f2f2f4+0,d2d2d2+100
     //background: #f2f2f4;
     //background: -moz-radial-gradient(center, ellipse cover, #f2f2f4 0%, #d2d2d2 100%);

--- a/intranet/static/css/page_base.scss
+++ b/intranet/static/css/page_base.scss
@@ -4,8 +4,7 @@ b {
 }
 
 body {
-    margin-top: 40px;
-    padding: 16px 26px 10px 26px;
+    padding: 56px 26px 10px 26px;
     //min-width: 1000px;
 }
 

--- a/intranet/static/js/common.js
+++ b/intranet/static/js/common.js
@@ -180,6 +180,9 @@ runEgg = function(q) {
                 else eggTdfw();
             }, 100);
             break;
+        case "tenartni":
+            $("body").css({transition: "transform 2s ease", transform: "scaleX(-1)"});
+            break;
         default:
             return false;
     }


### PR DESCRIPTION
CSS transforms can now be applied without breaking the layout.

Previously, using a transform on body would interfere with the position of the header. For example, here is a `transform: scale(1);` (which shouldn't do anything): 
![image](https://user-images.githubusercontent.com/22824647/49890495-2fd2a300-fe12-11e8-968b-3f6338c3275d.png)

Now, transforms can be applied to body while maintaining the proper layout. Here is the same `transform: scale(1);`: 
![image](https://user-images.githubusercontent.com/22824647/49890616-817b2d80-fe12-11e8-8602-b098ce76f6a8.png)

This means that things like [do a barrel roll](https://github.com/tjcsl/ion/blob/master/intranet/static/js/common.js#L155-L160) will now work properly. 