### PR TITLE
Cleanup and update SCSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ localdata/
 fixtures/**/*.json
 fixtures/*.sql
 fixtures/README.txt
+.idea/
 
 *fixtures*.tar*

--- a/intranet/static/css/_reset.scss
+++ b/intranet/static/css/_reset.scss
@@ -1,47 +1,140 @@
 /* http://meyerweb.com/eric/tools/css/reset/
-   v2.0 | 20110126
-   License: none (public domain)
+v2.0 | 20110126
+License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
     margin: 0;
     padding: 0;
     border: 0;
-    font-size: 100%;
     font: inherit;
     vertical-align: baseline;
 }
+
 /* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
     display: block;
 }
+
 body {
     line-height: 1;
 }
-ol, ul {
+
+ol,
+ul {
     list-style: none;
 }
-blockquote, q {
+
+blockquote,
+q {
     quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-    content: '';
-    content: none;
+
+blockquote {
+    &:before,
+    &:after {
+        content: none;
+    }
 }
+
+q {
+    &:before,
+    &:after {
+        content: none;
+    }
+}
+
 table {
     border-collapse: collapse;
     border-spacing: 0;

--- a/intranet/static/css/about.scss
+++ b/intranet/static/css/about.scss
@@ -1,10 +1,13 @@
-@import 'colors';
+@import "colors";
+
 $color1: rgb(242, 242, 244);
+
 .center {
     &-wrapper {
         width: 600px;
         margin-left: -300px;
     }
+
     &-outer {
         position: relative;
         text-align: left;
@@ -14,6 +17,7 @@ $color1: rgb(242, 242, 244);
         margin-top: 400px;
         top: 0;
     }
+
     position: static;
     top: 0;
     margin-top: 0;
@@ -22,6 +26,7 @@ $color1: rgb(242, 242, 244);
     padding-top: 25px;
     padding-left: 50px;
     padding-right: 50px;
+
     h1 {
         width: auto;
         white-space: nowrap;
@@ -29,6 +34,7 @@ $color1: rgb(242, 242, 244);
         float: none;
         margin: 0;
     }
+
     h2 {
         font-weight: normal;
     }
@@ -46,6 +52,7 @@ $color1: rgb(242, 242, 244);
     width: 600px;
     height: 384px;
     overflow: hidden;
+
     > span {
         height: 384px;
         display: block;
@@ -59,7 +66,8 @@ $color1: rgb(242, 242, 244);
     position: absolute;
     top: 87px;
     right: 0;
-    > span> img {
+
+    > span > img {
         width: 180px;
     }
 }
@@ -85,14 +93,14 @@ p {
             margin-left: 0;
             left: 0;
         }
+
         &-outer {
             width: 100%;
             margin-left: 0;
             padding: 0;
             margin-top: 460px;
         }
-        padding-left: 0;
-        padding-right: 0;
+
         width: auto;
         padding: 40px;
     }
@@ -108,7 +116,8 @@ p {
         margin-left: -128px;
         width: 256px;
         height: 459px;
-        > span> img {
+
+        > span > img {
             width: auto;
         }
     }
@@ -119,18 +128,22 @@ ul.nav {
     top: 10px;
     left: 10px;
     z-index: 99;
+
     > li i.fa {
         display: block;
     }
+
     @media (max-width: 430px) {
         &.dashboard-link {
             width: 95px;
+
             > li i.fa {
                 padding-right: 3px;
             }
         }
         > li {
             height: 36px;
+
             i.fa {
                 font-size: 1em;
                 display: inline-block;

--- a/intranet/static/css/announcements.form.scss
+++ b/intranet/static/css/announcements.form.scss
@@ -5,32 +5,40 @@ div.cke_chrome {
 .announcements {
     table {
         width: 600px;
+
         th {
             min-width: 120px;
             vertical-align: top;
             padding-top: 10px;
         }
     }
-    input, button {
-        width: 100%;
+
+    input,
+    button {
         width: calc(100% - 8px);
     }
+
     .selectize-control {
         width: 100%;
     }
+
     .helptext {
         padding-left: 7px;
         display: inline-block;
     }
+
     .exp-buttons {
         padding-left: 7px;
     }
+
     .exp-suggest-item {
         cursor: pointer;
     }
+
     th label {
         display: inline-block;
     }
+
     @media (max-width: 855px) {
         table {
             width: 342px !important;

--- a/intranet/static/css/api.scss
+++ b/intranet/static/css/api.scss
@@ -12,6 +12,7 @@ a.brand {
     width: 40px;
     height: 40px;
     float: left;
+
     .no-svg {
         background-image: url("/static/img/logos/Header-Logo@2x.png");
         background-size: 30px 30px;

--- a/intranet/static/css/base.scss
+++ b/intranet/static/css/base.scss
@@ -1,8 +1,8 @@
-@import 'reset';
-@import 'colors';
-$font-stack: "Open Sans",
-"Helvetica Neue",
-sans-serif;
+@import "reset";
+@import "colors";
+
+$font-stack: "Open Sans", "Helvetica Neue", sans-serif;
+
 body {
     font-family: $font-stack;
     font-size: 13px;
@@ -42,6 +42,7 @@ a {
         text-decoration: none;
         color: rgb(32, 66, 224);
     }
+
     &:hover {
         text-decoration: underline;
     }
@@ -49,6 +50,7 @@ a {
 
 a.ui-link {
     color: inherit;
+
     &:hover {
         color: $grey;
     }
@@ -76,7 +78,7 @@ input[type="reset"] {
     margin: 2px 0;
     font-size: 13px;
     font-weight: bold;
-    text-shadow: 0 1px 0 rgba(255, 255, 255, .9);
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.9);
     white-space: nowrap;
     -webkit-border-radius: 3px;
     -moz-border-radius: 3px;
@@ -89,10 +91,9 @@ input[type="reset"] {
     //filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f7f7f4', endColorstr='#eaeaea',GradientType=0 );
     border: 1px solid rgb(221, 221, 221);
     border-bottom-color: rgb(197, 197, 197);
-    -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, .05);
-    -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, .05);
-    -pie-box-shadow: none;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, .05);
+    -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
     vertical-align: middle;
     cursor: pointer;
     -webkit-user-select: none;
@@ -104,7 +105,8 @@ input[type="reset"] {
     -moz-appearance: none;
     -o-appearance: none;
     appearance: none;
-    behavior: url("/static/js/PIE/PIE.htc");
+    behavior: url("/static/js/vendor/PIE/PIE.htc");
+
     &:hover {
         text-decoration: none;
         color: $grey;
@@ -113,14 +115,16 @@ input[type="reset"] {
         background: -moz-linear-gradient(top, #eaeaea 0%, #dadada 100%);
         background: -webkit-linear-gradient(top, #eaeaea 0%, #dadada 100%);
         background: linear-gradient(to bottom, #eaeaea 0%, #dadada 100%);
-        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#eaeaea', endColorstr='#dadada', GradientType=0);
+        filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#eaeaea', endColorstr='#dadada', GradientType=0);
     }
+
     &:active {
         background-color: #dadada;
         background-image: none;
         border-color: rgb(181, 181, 181);
-        box-shadow: inset 0 1px 5px rgba(0, 0, 0, .15);
+        box-shadow: inset 0 1px 5px rgba(0, 0, 0, 0.15);
     }
+
     &:focus {
         outline: none;
         // Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#eaeaea+0,dadada+100;ButtonHover
@@ -128,8 +132,9 @@ input[type="reset"] {
         background: -moz-linear-gradient(top, #eaeaea 0%, #dadada 100%);
         background: -webkit-linear-gradient(top, #eaeaea 0%, #dadada 100%);
         background: linear-gradient(to bottom, #eaeaea 0%, #dadada 100%);
-        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#eaeaea', endColorstr='#dadada', GradientType=0);
+        filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#eaeaea', endColorstr='#dadada', GradientType=0);
     }
+
     &:disabled {
         &,
         &:hover {
@@ -160,16 +165,17 @@ textarea {
     -webkit-border-radius: 3px;
     -moz-border-radius: 3px;
     border-radius: 3px;
-    -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, .075);
-    -moz-box-shadow: inset 0 1px 2px rgba(0, 0, 0, .075);
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, .075);
+    -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075);
+    -moz-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075);
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075);
     //-webkit-transition: border 0.05s ease-in 0;
     //-moz-transition: border 0.05s ease-in 0;
     //-o-transition: border 0.05s ease-in 0;
     //transition: border 0.05s ease-in;
     vertical-align: middle;
     font-family: $font-stack;
-    behavior: url("/static/js/PIE/PIE.htc");
+    behavior: url("/static/js/vendor/PIE/PIE.htc");
+
     &:focus {
         outline: none;
         border-color: rgb(77, 144, 254);
@@ -187,7 +193,6 @@ input.error {
     color: rgb(255, 72, 72);
 }
 
-
 /*
 input:-webkit-autofill {
     box-shadow: 0 0 0 50px white inset;
@@ -200,6 +205,7 @@ input:-webkit-autofill {
 
 .right {
     float: right;
+
     &-buttons {
         text-align: right;
     }
@@ -217,9 +223,11 @@ form {
         padding-right: 8px;
         text-align: left;
     }
+
     th {
         vertical-align: middle;
     }
+
     .errorlist {
         list-style: none;
         padding-left: 0;
@@ -252,7 +260,7 @@ tr td:not(:last-child) {
 }
 
 table.zebra tbody tr:nth-child(odd) {
-    background-color: rgba(0, 0, 0, .05);
+    background-color: rgba(0, 0, 0, 0.05);
 }
 
 table.list-table {
@@ -273,6 +281,7 @@ td.list-item {
     }
     .primary-content {
         margin: 0 !important;
+
         &,
         * {
             visibility: visible;
@@ -281,13 +290,6 @@ td.list-item {
     body {
         margin-top: 0 !important;
         background-color: transparent;
-    }
-    * {
-        -webkit-transition: initial !important;
-        -moz-transition: initial !important;
-        -ms-transition: initial !important;
-        -o-transition: initial !important;
-        transition: initial !important;
     }
 }
 
@@ -303,6 +305,7 @@ input {
         padding: 0 5px;
         margin: 0;
     }
+
     &.large-button {
         font-size: 14px;
         padding: 20px 40px;
@@ -318,8 +321,9 @@ table.fancy-table {
     th {
         padding: 5px 10px;
     }
+
     tbody tr:nth-child(odd) {
-        background-color: rgba(0, 0, 0, .05);
+        background-color: rgba(0, 0, 0, 0.05);
     }
 }
 
@@ -344,151 +348,166 @@ body.fire * {
 
 @-webkit-keyframes fire {
     0% {
-        text-shadow: 0 -2px 2px #A00000, 0 -4px 2px #F08000, 0 -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -4px 2px #f08000, 0 -6px 2px #ff0;
     }
     10% {
-        text-shadow: 0 -2px 2px #A00000, -1px -4px 2px #F08000, -6px -5px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, -1px -4px 2px #f08000,
+        -6px -5px 2px #ff0;
     }
     20% {
-        text-shadow: 0 -1px 2px #A00000, -1px -3px 2px #F08000, -2px -5px 2px #FF0
+        text-shadow: 0 -1px 2px #a00000, -1px -3px 2px #f08000,
+        -2px -5px 2px #ff0;
     }
     30% {
-        text-shadow: 0 -2px 2px #A00000, -1px -4px 2px #F08000, -6px -5px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, -1px -4px 2px #f08000,
+        -6px -5px 2px #ff0;
     }
     50% {
-        text-shadow: 0 -2px 2px #A00000, 0 -5px 2px #F08000, 0 -8px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -5px 2px #f08000, 0 -8px 2px #ff0;
     }
     60% {
-        text-shadow: 0 -2px 2px #A00000, 1px -4px 2px #F08000, 2px -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 1px -4px 2px #f08000, 2px -6px 2px #ff0;
     }
     70% {
-        text-shadow: 0 -1px 2px #A00000, 1px -3px 2px #F08000, 2px -5px 2px #FF0
+        text-shadow: 0 -1px 2px #a00000, 1px -3px 2px #f08000, 2px -5px 2px #ff0;
     }
     80% {
-        text-shadow: 0 -2px 2px #A00000, 1px -4px 2px #F08000, 2px -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 1px -4px 2px #f08000, 2px -6px 2px #ff0;
     }
     100% {
-        text-shadow: 0 -2px 2px #A00000, 0 -4px 2px #F08000, 0 -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -4px 2px #f08000, 0 -6px 2px #ff0;
     }
 }
 
 @-moz-keyframes fire {
     0% {
-        text-shadow: 0 -2px 2px #A00000, 0 -4px 2px #F08000, 0 -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -4px 2px #f08000, 0 -6px 2px #ff0;
     }
     10% {
-        text-shadow: 0 -2px 2px #A00000, -1px -4px 2px #F08000, -6px -5px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, -1px -4px 2px #f08000,
+        -6px -5px 2px #ff0;
     }
     20% {
-        text-shadow: 0 -1px 2px #A00000, -1px -3px 2px #F08000, -2px -5px 2px #FF0
+        text-shadow: 0 -1px 2px #a00000, -1px -3px 2px #f08000,
+        -2px -5px 2px #ff0;
     }
     30% {
-        text-shadow: 0 -2px 2px #A00000, -1px -4px 2px #F08000, -6px -5px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, -1px -4px 2px #f08000,
+        -6px -5px 2px #ff0;
     }
     50% {
-        text-shadow: 0 -2px 2px #A00000, 0 -5px 2px #F08000, 0 -8px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -5px 2px #f08000, 0 -8px 2px #ff0;
     }
     60% {
-        text-shadow: 0 -2px 2px #A00000, 1px -4px 2px #F08000, 2px -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 1px -4px 2px #f08000, 2px -6px 2px #ff0;
     }
     70% {
-        text-shadow: 0 -1px 2px #A00000, 1px -3px 2px #F08000, 2px -5px 2px #FF0
+        text-shadow: 0 -1px 2px #a00000, 1px -3px 2px #f08000, 2px -5px 2px #ff0;
     }
     80% {
-        text-shadow: 0 -2px 2px #A00000, 1px -4px 2px #F08000, 2px -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 1px -4px 2px #f08000, 2px -6px 2px #ff0;
     }
     100% {
-        text-shadow: 0 -2px 2px #A00000, 0 -4px 2px #F08000, 0 -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -4px 2px #f08000, 0 -6px 2px #ff0;
     }
 }
 
 @-ms-keyframes fire {
     0% {
-        text-shadow: 0 -2px 2px #A00000, 0 -4px 2px #F08000, 0 -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -4px 2px #f08000, 0 -6px 2px #ff0;
     }
     10% {
-        text-shadow: 0 -2px 2px #A00000, -1px -4px 2px #F08000, -6px -5px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, -1px -4px 2px #f08000,
+        -6px -5px 2px #ff0;
     }
     20% {
-        text-shadow: 0 -1px 2px #A00000, -1px -3px 2px #F08000, -2px -5px 2px #FF0
+        text-shadow: 0 -1px 2px #a00000, -1px -3px 2px #f08000,
+        -2px -5px 2px #ff0;
     }
     30% {
-        text-shadow: 0 -2px 2px #A00000, -1px -4px 2px #F08000, -6px -5px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, -1px -4px 2px #f08000,
+        -6px -5px 2px #ff0;
     }
     50% {
-        text-shadow: 0 -2px 2px #A00000, 0 -5px 2px #F08000, 0 -8px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -5px 2px #f08000, 0 -8px 2px #ff0;
     }
     60% {
-        text-shadow: 0 -2px 2px #A00000, 1px -4px 2px #F08000, 2px -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 1px -4px 2px #f08000, 2px -6px 2px #ff0;
     }
     70% {
-        text-shadow: 0 -1px 2px #A00000, 1px -3px 2px #F08000, 2px -5px 2px #FF0
+        text-shadow: 0 -1px 2px #a00000, 1px -3px 2px #f08000, 2px -5px 2px #ff0;
     }
     80% {
-        text-shadow: 0 -2px 2px #A00000, 1px -4px 2px #F08000, 2px -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 1px -4px 2px #f08000, 2px -6px 2px #ff0;
     }
     100% {
-        text-shadow: 0 -2px 2px #A00000, 0 -4px 2px #F08000, 0 -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -4px 2px #f08000, 0 -6px 2px #ff0;
     }
 }
 
 @-o-keyframes fire {
     0% {
-        text-shadow: 0 -2px 2px #A00000, 0 -4px 2px #F08000, 0 -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -4px 2px #f08000, 0 -6px 2px #ff0;
     }
     10% {
-        text-shadow: 0 -2px 2px #A00000, -1px -4px 2px #F08000, -6px -5px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, -1px -4px 2px #f08000,
+        -6px -5px 2px #ff0;
     }
     20% {
-        text-shadow: 0 -1px 2px #A00000, -1px -3px 2px #F08000, -2px -5px 2px #FF0
+        text-shadow: 0 -1px 2px #a00000, -1px -3px 2px #f08000,
+        -2px -5px 2px #ff0;
     }
     30% {
-        text-shadow: 0 -2px 2px #A00000, -1px -4px 2px #F08000, -6px -5px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, -1px -4px 2px #f08000,
+        -6px -5px 2px #ff0;
     }
     50% {
-        text-shadow: 0 -2px 2px #A00000, 0 -5px 2px #F08000, 0 -8px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -5px 2px #f08000, 0 -8px 2px #ff0;
     }
     60% {
-        text-shadow: 0 -2px 2px #A00000, 1px -4px 2px #F08000, 2px -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 1px -4px 2px #f08000, 2px -6px 2px #ff0;
     }
     70% {
-        text-shadow: 0 -1px 2px #A00000, 1px -3px 2px #F08000, 2px -5px 2px #FF0
+        text-shadow: 0 -1px 2px #a00000, 1px -3px 2px #f08000, 2px -5px 2px #ff0;
     }
     80% {
-        text-shadow: 0 -2px 2px #A00000, 1px -4px 2px #F08000, 2px -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 1px -4px 2px #f08000, 2px -6px 2px #ff0;
     }
     100% {
-        text-shadow: 0 -2px 2px #A00000, 0 -4px 2px #F08000, 0 -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -4px 2px #f08000, 0 -6px 2px #ff0;
     }
 }
 
 @keyframes fire {
     0% {
-        text-shadow: 0 -2px 2px #A00000, 0 -4px 2px #F08000, 0 -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -4px 2px #f08000, 0 -6px 2px #ff0;
     }
     10% {
-        text-shadow: 0 -2px 2px #A00000, -1px -4px 2px #F08000, -6px -5px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, -1px -4px 2px #f08000,
+        -6px -5px 2px #ff0;
     }
     20% {
-        text-shadow: 0 -1px 2px #A00000, -1px -3px 2px #F08000, -2px -5px 2px #FF0
+        text-shadow: 0 -1px 2px #a00000, -1px -3px 2px #f08000,
+        -2px -5px 2px #ff0;
     }
     30% {
-        text-shadow: 0 -2px 2px #A00000, -1px -4px 2px #F08000, -6px -5px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, -1px -4px 2px #f08000,
+        -6px -5px 2px #ff0;
     }
     50% {
-        text-shadow: 0 -2px 2px #A00000, 0 -5px 2px #F08000, 0 -8px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -5px 2px #f08000, 0 -8px 2px #ff0;
     }
     60% {
-        text-shadow: 0 -2px 2px #A00000, 1px -4px 2px #F08000, 2px -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 1px -4px 2px #f08000, 2px -6px 2px #ff0;
     }
     70% {
-        text-shadow: 0 -1px 2px #A00000, 1px -3px 2px #F08000, 2px -5px 2px #FF0
+        text-shadow: 0 -1px 2px #a00000, 1px -3px 2px #f08000, 2px -5px 2px #ff0;
     }
     80% {
-        text-shadow: 0 -2px 2px #A00000, 1px -4px 2px #F08000, 2px -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 1px -4px 2px #f08000, 2px -6px 2px #ff0;
     }
     100% {
-        text-shadow: 0 -2px 2px #A00000, 0 -4px 2px #F08000, 0 -6px 2px #FF0
+        text-shadow: 0 -2px 2px #a00000, 0 -4px 2px #f08000, 0 -6px 2px #ff0;
     }
 }
 
@@ -557,16 +576,26 @@ body.fire * {
     53%,
     80%,
     to {
-        -webkit-animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+        -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
         -webkit-transform: translate3d(0, 0, 0);
     }
     40%,
     43% {
-        -webkit-animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
+        -webkit-animation-timing-function: cubic-bezier(
+                        0.755,
+                        0.05,
+                        0.855,
+                        0.06
+        );
         -webkit-transform: translate3d(0, -30px, 0);
     }
     70% {
-        -webkit-animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
+        -webkit-animation-timing-function: cubic-bezier(
+                        0.755,
+                        0.05,
+                        0.855,
+                        0.06
+        );
         -webkit-transform: translate3d(0, -15px, 0);
     }
     90% {
@@ -580,16 +609,16 @@ body.fire * {
     53%,
     80%,
     to {
-        animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+        animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
         transform: translate3d(0, 0, 0);
     }
     40%,
     43% {
-        animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
+        animation-timing-function: cubic-bezier(0.755, 0.05, 0.855, 0.06);
         transform: translate3d(0, -30px, 0);
     }
     70% {
-        animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
+        animation-timing-function: cubic-bezier(0.755, 0.05, 0.855, 0.06);
         transform: translate3d(0, -15px, 0);
     }
     90% {
@@ -737,12 +766,14 @@ body.fire * {
     text-indent: -9999px;
     appearance: none;
     box-shadow: none;
-    border-radius: none;
+    border-radius: unset;
     border: none;
     cursor: pointer;
+
     &:focus {
         outline: none;
     }
+
     span {
         display: block;
         position: absolute;
@@ -751,6 +782,7 @@ body.fire * {
         right: 2px;
         height: 2px;
         background-color: white;
+
         &::before,
         &::after {
             position: absolute;
@@ -761,36 +793,45 @@ body.fire * {
             background-color: white;
             content: "";
         }
+
         &::before {
             top: -5px;
         }
+
         &::after {
             bottom: -5px;
         }
     }
+
     &--htla {
         span {
             transition: transform 0.3s;
+
             &::before {
                 transform-origin: top right;
                 transition: transform 0.3s, width 0.3s, top 0.3s;
             }
+
             &::after {
                 transform-origin: bottom right;
                 transition: transform 0.3s, width 0.3s, bottom 0.3s;
             }
         }
+
         /* active state, i.e. menu open */
         &.is-active span {
             transform: rotate(180deg);
+
             &::before,
             &::after {
                 width: 50%;
             }
+
             &::before {
                 top: 0;
                 transform: translateX(8px) rotate(-45deg);
             }
+
             &::after {
                 bottom: 0;
                 transform: translateX(8px) rotate(45deg);

--- a/intranet/static/css/board.scss
+++ b/intranet/static/css/board.scss
@@ -1,12 +1,15 @@
-@import 'colors';
+@import "colors";
+
 .board {
     min-width: 290px;
     /* for 320x480 screens */
     max-width: 1000px;
     margin-bottom: 100px;
+
     h2 {
         padding-left: 10px;
         line-height: 38px;
+
         &.category {
             font-size: 18px;
             font-weight: normal;
@@ -34,8 +37,9 @@ h4 {
     padding: 6px 10px;
     margin-bottom: 6px;
     overflow-x: auto;
-    behavior: url("/static/js/PIE/PIE.htc");
-    h3> a.boardpost-link {
+    behavior: url("/static/js/vendor/PIE/PIE.htc");
+
+    h3 > a.boardpost-link {
         cursor: pointer;
         color: $grey !important;
     }
@@ -54,17 +58,21 @@ h4 {
 
 .boardpost-icon {
     cursor: pointer;
+
     &-wrapper {
         float: right;
         display: none;
+
         > a {
             color: $grey;
             text-decoration: none !important;
             padding-left: 2px;
+
             &:hover {
                 color: rgb(32, 66, 224);
             }
         }
+
         .boardpost:hover & {
             display: block;
         }
@@ -74,6 +82,7 @@ h4 {
 .boardpost-comment {
     position: relative;
     padding: 3px 5px;
+
     &-icons {
         position: absolute;
         right: 5px;
@@ -91,6 +100,7 @@ h4 {
     @media (max-width: 500px) {
         width: 100%;
     }
+
     &-header {
         font-size: 14px;
         text-align: center;

--- a/intranet/static/css/bus.scss
+++ b/intranet/static/css/bus.scss
@@ -3,6 +3,7 @@
 svg {
     width: 100%;
     max-height: 80vh;
+
     path.a {
         cursor: pointer;
     }
@@ -28,9 +29,6 @@ svg {
     i.fa {
         vertical-align: middle;
         font-size: 18px;
-    }
-
-    .action-button {
     }
 }
 
@@ -92,9 +90,11 @@ span.bus-number {
             top: 40px;
             height: calc(100vh - 40px);
             background-color: #0048ab;
+
             .search-widget {
                 background-color: white;
             }
+
             .selectize-input {
                 padding: 4px 0;
             }

--- a/intranet/static/css/dashboard.scss
+++ b/intranet/static/css/dashboard.scss
@@ -1,13 +1,16 @@
 @import "colors";
+
 .announcements {
     padding-right: 432px;
     min-width: 290px;
     /* for 320x480 screens */
     max-width: 1000px;
     margin-bottom: 100px;
+
     &.no-widgets {
         padding-right: 0;
     }
+
     h2 {
         padding-left: 10px;
         line-height: 38px;
@@ -29,34 +32,45 @@
     padding: 6px 10px;
     margin-bottom: 6px;
     overflow-x: auto;
-    behavior: url("/static/js/PIE/PIE.htc");
+    behavior: url("/static/js/vendor/PIE/PIE.htc");
+
     h3 {
         cursor: pointer;
+
         > a.announcement-link {
             cursor: pointer;
             color: $grey !important;
         }
     }
+
     &.announcement-meta h3 {
         cursor: initial;
     }
+
     &.pinned h3 {
         color: rgb(181, 0, 0);
     }
+
     .announcement-content {
-        b, strong {
+        b,
+        strong {
             font-weight: bold;
         }
-        i, em {
+
+        i,
+        em {
             font-style: italic;
         }
+
         u {
             text-decoration: underline;
         }
+
         ol {
             list-style-type: decimal;
             list-style-position: inside;
         }
+
         p {
             margin-bottom: 5px;
         }
@@ -77,13 +91,16 @@
 .announcement-icon-wrapper {
     float: right;
     display: none;
+
     .announcement:hover & {
         display: block;
     }
+
     > a {
         color: $grey;
         text-decoration: none !important;
         padding-left: 2px;
+
         &:hover {
             color: rgb(32, 66, 224);
         }
@@ -97,13 +114,16 @@
         .announcement-icon-wrapper:hover .announcement-toggle:hover {
             color: rgb(32, 66, 224);
         }
+
         .announcement-icon-wrapper:hover .announcement-toggle {
             color: $grey;
         }
     }
+
     &-icon {
         cursor: pointer;
     }
+
     &.hidden .announcement-toggle-content {
         display: none;
     }
@@ -128,7 +148,6 @@
         margin-bottom: 100%;
     }
 }
-
 
 /*
  * between 800px and 662px, show a two column widget view
@@ -156,13 +175,6 @@
 */
 
 @media print {
-    * {
-        transition: initial !important;
-        -webkit-transition: initial !important;
-        -moz-transition: initial !important;
-        -ms-transition: initial !important;
-        -o-transition: initial !important;
-    }
     div.main div.announcements.primary-content {
         position: absolute;
         top: 0;
@@ -177,6 +189,7 @@
         &-icon-wrapper {
             visibility: hidden !important;
         }
+
         &.announcement-meta {
             display: none;
         }
@@ -200,7 +213,7 @@ div[data-placeholder]:not(:focus):not([data-div-placeholder-content]):before {
     margin-bottom: 10px;
     position: relative;
     max-height: 100vh;
-    transition: max-height .2s ease-in-out;
+    transition: max-height 0.2s ease-in-out;
 
     &:hover {
         cursor: pointer;
@@ -209,6 +222,7 @@ div[data-placeholder]:not(:focus):not([data-div-placeholder-content]):before {
     &.collapsed {
         max-height: 50px;
         overflow: hidden;
+
         &::after {
             content: "";
             position: absolute;
@@ -216,7 +230,11 @@ div[data-placeholder]:not(:focus):not([data-div-placeholder-content]):before {
             bottom: 0;
             left: 0;
             pointer-events: none;
-            background-image: linear-gradient(to bottom, rgba(255,255,255, 0), yellow 90%);
+            background-image: linear-gradient(
+                            to bottom,
+                            rgba(255, 255, 255, 0),
+                            yellow 90%
+            );
             width: 100%;
             height: 4em;
         }
@@ -236,6 +254,7 @@ div[data-placeholder]:not(:focus):not([data-div-placeholder-content]):before {
     width: 27px;
     text-align: center;
     cursor: pointer;
+
     &:hover,
     .announcement h3:hover &,
     .event h3:hover & {

--- a/intranet/static/css/dashboard.widgets.scss
+++ b/intranet/static/css/dashboard.widgets.scss
@@ -1,7 +1,7 @@
 @import "colors";
-$font-stack: "Open Sans",
-"Helvetica Neue",
-sans-serif;
+
+$font-stack: "Open Sans", "Helvetica Neue", sans-serif;
+
 .widgets {
     display: block;
     position: absolute;
@@ -20,7 +20,8 @@ sans-serif;
     overflow: hidden;
     background-color: #f2f2f2;
     margin-bottom: 10px;
-    behavior: url("/static/js/PIE/PIE.htc");
+    behavior: url("/static/js/vendor/PIE/PIE.htc");
+
     .info {
         font-size: 12px;
         color: rgb(144, 144, 144);
@@ -47,8 +48,9 @@ sans-serif;
     -webkit-border-radius: 5px 5px 0 0;
     -moz-border-radius: 5px 5px 0 0;
     border-radius: 5px 5px 0 0;
-    behavior: url("/static/js/PIE/PIE.htc");
+    behavior: url("/static/js/vendor/PIE/PIE.htc");
     position: relative;
+
     h2 {
         font-size: 14px;
         float: left;
@@ -106,12 +108,15 @@ sans-serif;
     height: 30px;
     line-height: 30px;
     padding: 0 8px;
+
     .info {
         display: none;
     }
+
     a {
         float: right;
     }
+
     .no-touch &:hover .info {
         display: inline;
     }
@@ -119,18 +124,22 @@ sans-serif;
 
 .eighth-block {
     &.clickable {
-        margin-botton: 2px;
+        margin-bottom: 2px;
         cursor: pointer;
+
         &:hover .block-header a {
             text-decoration: underline;
         }
     }
+
     &.open .info {
         display: inline;
     }
+
     &.warning a {
         color: rgb(255, 72, 72);
     }
+
     &.cancelled .block-signup {
         color: rgb(255, 72, 72);
         font-weight: bold;
@@ -142,6 +151,7 @@ sans-serif;
     background-color: rgb(231, 231, 233);
     height: 0;
     overflow: hidden;
+
     .eighth-block.open & {
         max-height: 90px;
         height: auto;
@@ -155,10 +165,12 @@ sans-serif;
 
 .block-header {
     position: relative;
+
     .block-letter {
         width: auto;
         padding: 0 4px;
     }
+
     .block-letter-date {
         max-width: 106px;
         overflow: hidden;
@@ -169,7 +181,7 @@ sans-serif;
     }
 }
 
-.eighth-widget> .widget-title {
+.eighth-widget > .widget-title {
     margin-bottom: 2px;
 }
 
@@ -177,7 +189,6 @@ sans-serif;
 .block-sponsorship {
     position: absolute;
     left: 114px;
-    width: 100%;
     /* "Modify" text */
     width: calc(100% - 167px);
     overflow: hidden;
@@ -194,13 +205,11 @@ sans-serif;
     left: 114px;
     top: 13px;
     font-size: 10px;
-    width: 100%;
     width: calc(100% - 167px);
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
 }
-
 
 /* Attendance Locked/Signup Unlocked */
 
@@ -211,6 +220,7 @@ sans-serif;
         color: rgb(0, 132, 62);
         /* green */
     }
+
     &.no-attendance-lock .block-letter {
         background-color: rgb(0, 132, 62);
         color: rgb(242, 242, 242);
@@ -225,21 +235,23 @@ sans-serif;
             /* 13x13px not 8x13px */
             left: 112px;
         }
+
         > i {
             padding-right: 1px;
         }
     }
+
     /* Open Passes */
     &.open-passes {
         .eighth-block & {
             left: 113px;
         }
+
         > i {
             padding-right: 2px;
         }
     }
 }
-
 
 /* No Act Selected */
 
@@ -249,7 +261,6 @@ sans-serif;
     /* color: rgb(255, 72, 72); red */
 }
 
-
 /* make sure "Not sponsoring an activity" always shows;
    there is no button on the right so it can take 100% */
 
@@ -257,9 +268,7 @@ div.eighth-block .block-sponsorship.no-activity-selected {
     width: 100%;
 }
 
-
 /* No Sponsorship Today */
-
 
 /* red on white block letter icon */
 
@@ -270,25 +279,26 @@ div.eighth-block .block-sponsorship.no-activity-selected {
         /* red */
         color: rgb(242, 242, 242);
     }
+
     &.no-attendance.today.no-attendance-lock {
-        .block-sponsorship, .btn-link {
+        .block-sponsorship,
+        .btn-link {
             color: rgb(255, 72, 72); //red
         }
     }
 }
 
-
 /* Open Passes */
-
 
 /* needs to override */
 
-div.eighth-block.open-passes> div.block-header {
+div.eighth-block.open-passes > div.block-header {
     > .block-sponsorship,
     > .btn-link {
         color: rgb(255, 107, 0);
         /* orange */
     }
+
     /* orange on white block letter icon */
     > .block-letter {
         background-color: rgb(255, 107, 0);
@@ -303,9 +313,11 @@ div.eighth-block.open-passes> div.block-header {
     white-space: nowrap;
     margin-top: -4px;
     margin-bottom: -4px;
+
     &.with-timeleft {
         margin-bottom: 4px;
     }
+
     .eighth-block:last-child & {
         margin-bottom: 4px;
     }
@@ -330,9 +342,11 @@ div.eighth-block.open-passes> div.block-header {
     white-space: nowrap;
     text-align: center;
     margin-right: 1px;
-    .chevron> i {
+
+    .chevron > i {
         text-align: left;
     }
+
     @media (max-width: 960px) {
         width: calc(100% - 148px);
     }
@@ -346,12 +360,12 @@ a#eighth-sponsor {
         float: left;
         width: 10px;
     }
+
     &-right {
         float: right;
         width: 10px;
     }
 }
-
 
 /* Extra widgets */
 
@@ -365,6 +379,7 @@ a#eighth-sponsor {
             }
         }
     }
+
     &.extra-widgets-show {
         display: none;
         width: 100%;
@@ -391,7 +406,7 @@ a#eighth-sponsor {
     /*0 -4px;*/
     font-size: 9px;
     font-weight: bold;
-    text-shadow: 0 1px 0 rgba(255, 255, 255, .9);
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.9);
     white-space: nowrap;
     -webkit-border-radius: 3px;
     -moz-border-radius: 3px;
@@ -401,11 +416,10 @@ a#eighth-sponsor {
     background: -moz-linear-gradient(top, #f7f7f4 0%, #eaeaea 100%);
     background: -webkit-linear-gradient(top, #f7f7f4 0%, #eaeaea 100%);
     background: linear-gradient(to bottom, #f7f7f4 0%, #eaeaea 100%);
-    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f7f7f4', endColorstr='#eaeaea', GradientType=0);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f7f7f4', endColorstr='#eaeaea', GradientType=0);
     border: 1px solid rgb(221, 221, 221);
     border-bottom-color: rgb(197, 197, 197);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, .05);
-    -pie-box-shadow: none;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
     vertical-align: middle;
     cursor: pointer;
     -webkit-user-select: none;
@@ -417,7 +431,7 @@ a#eighth-sponsor {
     -moz-appearance: none;
     -o-appearance: none;
     appearance: none;
-    behavior: url("/static/js/PIE/PIE.htc");
+    behavior: url("/static/js/vendor/PIE/PIE.htc");
 }
 
 a.btn-link {
@@ -427,11 +441,14 @@ a.btn-link {
     &:active {
         color: $grey;
     }
+
     .block-header & {
         text-align: center;
+
         .eighth-widget & {
             width: 37px;
         }
+
         .sponsor-widget & {
             width: 66px;
         }
@@ -443,45 +460,54 @@ a.btn-link {
         /* make arrow take less space */
         margin: 0 -2px 0 0;
     }
+
     &.fa-check {
         /* make check take less space */
         margin: 0 -3px 0 -2px;
     }
 }
 
-
 /* BIRTHDAYS */
 
 .birthdays-widget {
     .widget-content {
         padding: 5px 15px;
+
         table {
             width: 100%;
         }
-        b, strong {
+
+        b,
+        strong {
             font-weight: bold;
         }
-        i, em {
+
+        i,
+        em {
             font-style: italic;
         }
     }
+
     .widget-title form {
         display: inline;
         float: right;
     }
+
     .birthday-field {
         font-family: $font-stack;
         background: transparent;
         border: 1px solid rgb(216, 216, 216);
-        padding: 0px 4px;
+        padding: 0 4px;
         height: 18px;
         width: 16px;
         text-align: center;
     }
+
     .slash {
         color: black;
         font-weight: normal;
     }
+
     input {
         &[name="birthday_month"] {
             margin-right: -3px;
@@ -489,21 +515,23 @@ a.btn-link {
             padding-right: 5px;
             text-align: right;
         }
+
         &[name="birthday_day"] {
             margin-left: -2px;
             border-left: 0;
             text-align: left;
         }
+
         &[name="birthday_day"]:focus,
         &[name="birthday_month"]:focus {
             outline: 0;
         }
+
         &[type="submit"] {
             margin-top: -3px;
         }
     }
 }
-
 
 /* LINKS */
 
@@ -511,17 +539,19 @@ a.btn-link {
     .widget-content {
         padding: 5px 10px;
     }
+
     table {
         width: 100%;
     }
+
     .link-heading {
         font-weight: bold;
     }
+
     a {
         margin-left: 5px;
     }
 }
-
 
 /* SENIORS */
 
@@ -529,6 +559,7 @@ a.btn-link {
     .widget-content {
         padding: 5px;
     }
+
     .seniors-clock .clock {
         font-size: 16px;
         padding-right: 2px;

--- a/intranet/static/css/eighth.admin.scss
+++ b/intranet/static/css/eighth.admin.scss
@@ -16,26 +16,33 @@ h4 {
 
 .admin-dashboard {
     width: 100%;
+
     h3 {
         width: 100%;
         border-bottom: 1px solid rgb(1, 94, 222);
     }
+
     .admin-section {
         height: 200px;
         width: 50%;
+
         &.attendance {
             height: 220px;
         }
     }
+
     li {
         line-height: 25px;
+
         .fa {
             font-size: 18px;
         }
     }
+
     .fa-ul {
         margin-left: 35px;
         margin-top: 6px;
+
         a {
             color: inherit;
         }
@@ -52,25 +59,29 @@ h4 {
 
 tr .admin-section {
     &:first-of-type {
-        padding-right: 20px
+        padding-right: 20px;
     }
+
     &:last-of-type:not(:first-of-type) {
-        padding-left: 20px
+        padding-left: 20px;
     }
 }
 
 .schedule-activity-grid {
     margin-top: 10px;
+
     .selectize-control {
         width: auto;
         min-width: 150px;
     }
+
     tr {
         &.spacer {
             height: 5px;
         }
+
         &.divider {
-            background-color: #CCC;
+            background-color: #ccc;
             height: 1px;
             width: 100%;
         }
@@ -86,9 +97,10 @@ tr .admin-section {
     -webkit-border-radius: 3px;
     -moz-border-radius: 3px;
     border-radius: 3px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, .5);
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
     //border: 1px solid rgb(129, 129, 129);
     z-index: 3;
+
     &.closed {
         display: none;
     }
@@ -119,7 +131,8 @@ td[data-field="admin_comments"] {
 
 select {
     display: none;
-    &[multiple="multiple"]+ .selectize-loading .selectize-input {
+
+    &[multiple="multiple"] + .selectize-loading .selectize-input {
         overflow: inherit;
     }
 }
@@ -143,9 +156,8 @@ table.fancy-table td {
 }
 
 table.fancy-table tbody tr:nth-child(odd) {
-    background-color: rgba(0, 0, 0, .05);
+    background-color: rgba(0, 0, 0, 0.05);
 }
-
 
 /* SELECTIZE */
 
@@ -164,6 +176,7 @@ table.choose-fields td {
         #id_name {
             width: 60px;
         }
+
         th,
         td {
             padding: 0 3px 0 0;
@@ -176,6 +189,7 @@ table.choose-fields td {
         &:last-of-type:not(:first-of-type) {
             padding-left: 5px;
         }
+
         &:first-of-type {
             padding-right: 5px;
         }
@@ -184,6 +198,7 @@ table.choose-fields td {
 
 .admin-section .selectize-control.single .selectize-input {
     background: white;
+
     &.dropdown-active {
         outline: none;
         border-color: rgb(0, 72, 171);
@@ -195,5 +210,5 @@ a.button,
 input[type="button"],
 input[type="submit"],
 input[type="reset"] {
-    border: 1px solid rgba(0, 72, 171, .3);
+    border: 1px solid rgba(0, 72, 171, 0.3);
 }

--- a/intranet/static/css/eighth.attendance.scss
+++ b/intranet/static/css/eighth.attendance.scss
@@ -1,8 +1,10 @@
 @import "colors";
+
 $red: rgb(255, 72, 72);
 $green: rgb(0, 180, 0);
 $orange: rgb(255, 135, 0);
-input[type=checkbox] {
+
+input[type="checkbox"] {
     zoom: 1.25;
     margin-right: -1px;
 }
@@ -43,6 +45,7 @@ input[type=checkbox] {
     td {
         padding-right: 20px;
     }
+
     tr {
         line-height: 25px;
     }
@@ -81,6 +84,7 @@ form .accept-all-passes {
     tr {
         line-height: 25px;
     }
+
     td.form {
         text-align: center;
     }
@@ -104,6 +108,7 @@ form .accept-all-passes {
             left: 650px;
             background: #f0f0f0;
             padding: 0 30px;
+
             &.eighth-admin {
                 top: 266px;
             }
@@ -160,6 +165,7 @@ a.pass-form-submit-link.button {
     a {
         color: $grey;
     }
+
     &[data-user-id]:hover {
         font-weight: bold;
     }
@@ -171,6 +177,7 @@ a.pass-form-submit-link.button {
 
 .sponsoring-wizard-table {
     min-width: 500px;
+
     a.button {
         float: right;
     }
@@ -200,11 +207,9 @@ td.email-col {
     .selectize-control *,
     .selectize-control * * {
         display: inline;
-        padding: 0;
-        margin: 0;
         border: 0;
         padding: 0 5px;
-        margin-right: 10px;
+        margin: 0 10px 0 0;
     }
     table.take-attendance-roster {
         position: absolute;
@@ -214,7 +219,7 @@ td.email-col {
         //width: calc(100% - 25px);
         table-layout: fixed;
     }
-    .user-col> a {
+    .user-col > a {
         display: inline-block;
         page-break-inside: avoid;
         height: auto;
@@ -226,6 +231,7 @@ td.email-col {
         tbody tr {
             border-left: 1px solid black;
             border-right: 1px solid black;
+
             &,
             td {
                 border-bottom: 1px solid black;
@@ -238,53 +244,66 @@ td.email-col {
                 overflow: hidden;
                 text-overflow: ellipsis;
             }
+
             td {
                 border-right: 1px solid black;
+
                 &.user-col,
                 &.sid-col,
                 &.email-col {
                     padding-left: 5px;
                 }
+
                 &.email-col {
                     border-right: none;
                 }
+
                 &:last-child {
                     border-right: none;
                 }
             }
         }
+
         thead tr.members-header {
             &,
             td {
                 border: 1px solid black;
                 padding-bottom: 5px;
             }
+
             th {
                 border-right: 1px solid black;
+
                 &.user-col,
                 &.sid-col,
                 &.email-col {
                     padding-left: 5px;
                 }
+
                 &.email-col {
                     border-right: none;
                 }
+
                 &.grade-col {
                     text-align: center;
                     padding: 0 8px;
                 }
+
                 &:last-child {
                     border-right: none;
                 }
             }
         }
+
         .email-col {
             display: block;
             border-bottom: 0;
         }
+
         .sid-col {
             display: none;
         }
+
         &.no-members {
             &,
             tbody,
@@ -296,6 +315,7 @@ td.email-col {
     }
     .pass-container {
         display: none;
+
         &.has-passes {
             display: block;
         }

--- a/intranet/static/css/eighth.common.scss
+++ b/intranet/static/css/eighth.common.scss
@@ -1,13 +1,16 @@
 .eighth-header {
     display: inline-block;
     width: 100%;
+
     h2 {
         float: left;
     }
+
     .start-date {
         float: right;
         text-align: right;
     }
+
     @media (max-width: 550px) {
         .extra-title {
             display: none;

--- a/intranet/static/css/eighth.maintenance.scss
+++ b/intranet/static/css/eighth.maintenance.scss
@@ -1,6 +1,7 @@
 p {
     margin-bottom: 5px;
 }
+
 pre {
     font-family: monospace;
     max-height: 400px;
@@ -11,41 +12,51 @@ pre {
     background-color: white;
     border: 1px solid #ccc;
 }
+
 #account-list {
     height: 500px;
     width: 100%;
-    border :1px solid #ccc;
+    border: 1px solid #ccc;
     overflow-y: scroll;
     box-sizing: border-box;
     position: relative;
 }
+
 #account-list:focus {
     outline: 0;
 }
+
 #account-list-search {
-    font-family: 'FontAwesome', 'Open Sans';
+    font-family: "FontAwesome", "Open Sans", sans-serif;
     width: 100%;
     box-sizing: border-box;
     margin-bottom: 5px;
 }
+
 #edit-title {
     margin-bottom: 15px;
 }
-#account-list-container, #edit-area, #edit-area-buttons {
+
+#account-list-container,
+#edit-area,
+#edit-area-buttons {
     float: left;
     box-sizing: border-box;
     margin: 0;
 }
+
 #account-list-container {
     width: 30%;
     width: calc(250px);
 }
+
 #edit-area {
     width: 70%;
     width: calc(100% - 250px);
     padding-left: 15px;
     overflow-y: auto;
 }
+
 #edit-area-buttons {
     width: 70%;
     width: calc(100% - 250px);
@@ -54,9 +65,11 @@ pre {
     padding-left: 10px;
     border-top: 1px solid #ccc;
 }
+
 #edit-area input[readonly] {
     color: #aaa;
 }
+
 #account-list .account {
     padding: 5px;
     cursor: pointer;
@@ -64,27 +77,33 @@ pre {
     white-space: nowrap;
     text-overflow: ellipsis;
 }
+
 #account-list .account.selected {
     background-color: #ccc;
 }
+
 .form-group {
     margin-bottom: 10px;
 }
+
 .form-group input {
     box-sizing: border-box;
     width: 100%;
 }
+
 #ldap-loading {
     display: none;
     color: #aaa;
     margin-left: 5px;
     vertical-align: sub;
 }
+
 #account-list .loading {
     color: #aaa;
     text-align: center;
     padding: 10px;
 }
+
 #delete-modal-background {
     display: none;
     position: fixed;
@@ -95,21 +114,24 @@ pre {
     background-color: rgba(0, 0, 0, 0.6);
     z-index: 9999;
 }
+
 #delete-modal {
     width: 400px;
-    margin: 0 auto;
-    margin-top: 45px;
+    margin: 45px auto 0;
     padding: 10px;
     background-color: white;
     border: 1px solid #0048ab;
     border-radius: 5px;
 }
+
 #student-fields {
     display: none;
 }
+
 #type-switch {
     margin-top: 6px;
 }
+
 #type-switch span {
     background-color: rgba(0, 0, 0, 0.1);
     padding: 8px 10px;
@@ -122,7 +144,9 @@ pre {
         cursor: default;
     }
 }
-#no-db-user, #account-locked {
+
+#no-db-user,
+#account-locked {
     font-weight: bold;
     margin-bottom: 5px;
     display: none;

--- a/intranet/static/css/eighth.profile.scss
+++ b/intranet/static/css/eighth.profile.scss
@@ -4,6 +4,7 @@
         right: 10px;
         width: 200px;
     }
+
     &.eighth-signup {
         @media (max-width: 550px) {
             .eighth-table {
@@ -17,6 +18,7 @@
             }
         }
     }
+
     @media print {
         .preferred-user-picture {
             position: absolute;
@@ -24,6 +26,7 @@
         .user-container {
             position: relative;
             left: 125px;
+
             .button {
                 display: none;
             }
@@ -31,7 +34,7 @@
     }
 }
 
-.preferred-user-picture> img {
+.preferred-user-picture > img {
     width: 86px;
     height: 107.5px;
     background-size: 86px 107.5px;
@@ -45,10 +48,12 @@
 table.user-info-contact {
     tr {
         line-height: 10px;
+
         &.comments {
             line-height: initial;
         }
     }
+
     div#activity-detail & td {
         line-height: 16px;
     }
@@ -62,24 +67,30 @@ table.eighth-table {
     tr {
         height: 30px;
     }
+
     .button-container {
         position: relative;
     }
+
     .button-right {
         position: absolute;
         right: 0;
     }
+
     .button-center {
         position: absolute;
         left: 50%;
         margin-left: -75px;
     }
+
     .checkbox {
         width: 80px;
     }
+
     .center {
         text-align: center;
     }
+
     .button-row {
         width: 70px;
     }
@@ -88,19 +99,23 @@ table.eighth-table {
 section.user {
     &-info-eighth {
         overflow-x: scroll;
+
         > form {
             min-width: 700px;
         }
     }
+
     &-info-edit {
         clear: both;
         padding-top: 20px;
         min-width: 400px;
         overflow-x: scroll;
+
         > form {
             min-width: 700px;
         }
     }
+
     &-history {
         clear: both;
         padding-top: 20px;
@@ -141,22 +156,24 @@ div.primary-content.eighth-signup {
 #chartjs-tooltip {
     opacity: 0;
     position: absolute;
-    background: rgba(0, 0, 0, .7);
+    background: rgba(0, 0, 0, 0.7);
     color: white;
     padding: 3px 6px;
     border-radius: 3px;
-    -webkit-transition: all .1s ease;
-    transition: all .1s ease;
+    -webkit-transition: all 0.1s ease;
+    transition: all 0.1s ease;
     pointer-events: none;
     -webkit-transform: translate(-50%, 0);
     transform: translate(-50%, 0);
+
     &.below {
         -webkit-transform: translate(-50%, 0);
         transform: translate(-50%, 0);
+
         &:before {
             border: solid;
             border-color: #111 transparent;
-            border-color: rgba(0, 0, 0, .8) transparent;
+            border-color: rgba(0, 0, 0, 0.8) transparent;
             border-width: 0 8px 8px 8px;
             bottom: 1em;
             content: "";
@@ -168,13 +185,15 @@ div.primary-content.eighth-signup {
             transform: translate(-50%, -100%);
         }
     }
+
     &.above {
         -webkit-transform: translate(-50%, -100%);
         transform: translate(-50%, -100%);
+
         &:before {
             border: solid;
             border-color: #111 transparent;
-            border-color: rgba(0, 0, 0, .8) transparent;
+            border-color: rgba(0, 0, 0, 0.8) transparent;
             border-width: 8px 8px 0 8px;
             bottom: 1em;
             content: "";

--- a/intranet/static/css/eighth.schedule.scss
+++ b/intranet/static/css/eighth.schedule.scss
@@ -1,7 +1,7 @@
 /* Let form.schedule-activity-grid scroll with the browser;
  * give all other UI elements a fixed position. -JW, 05/15 */
 
-input[type=checkbox] {
+input[type="checkbox"] {
     zoom: 1.25;
     margin-right: -1px;
 }
@@ -20,6 +20,7 @@ tr.scheduled .block-name {
         overflow-x: scroll;
         position: absolute; // quick fix to display scrollbar at bottom
     }
+
     @media (min-width: 500px) {
         .primary-content {
             overflow: hidden;
@@ -46,6 +47,7 @@ tr.scheduled .block-name {
                 width: 100%;
                 z-index: 2;
             }
+
             &-grid {
                 position: static;
                 margin-top: 161px;
@@ -61,14 +63,18 @@ tr.scheduled .block-name {
 
 table.schedule-activity-grid {
     border-top: 1px rgb(194, 194, 194) solid;
+
     thead {
         background-color: white;
         z-index: 3 !important; // override sticky header library
         border-bottom: 1px solid rgb(194, 194, 194);
+
         th {
             padding-left: 0;
+
             &.special {
                 padding-right: 0;
+
                 > span {
                     width: 25px;
                     display: block;
@@ -94,10 +100,9 @@ tr.form-row.hidden {
     }
 }
 
-
 /* keep selectize and non-selectize inputs the same height */
 
-:not(.selectize-input)> input[type="text"] {
+:not(.selectize-input) > input[type="text"] {
     height: 23px;
 }
 
@@ -105,6 +110,7 @@ tr.form-row.hidden {
     > td {
         position: relative;
     }
+
     a.propagate {
         height: 22px;
         width: 5px;
@@ -114,7 +120,8 @@ tr.form-row.hidden {
         z-index: 3;
         margin-left: -7px;
     }
-    td[data-base-field='capacity'] a.propagate {
+
+    td[data-base-field="capacity"] a.propagate {
         margin-left: -12px;
     }
 }
@@ -128,10 +135,12 @@ tr.form-row.hidden {
         width: 220px;
         line-height: 40px;
         z-index: 998;
+
         > b {
             float: left;
             margin-right: 5px;
         }
+
         select,
         .selectize-control {
             width: 80px;
@@ -139,6 +148,7 @@ tr.form-row.hidden {
             float: right;
         }
     }
+
     &-method {
         position: fixed;
         float: right;
@@ -147,10 +157,12 @@ tr.form-row.hidden {
         width: 220px;
         line-height: 40px;
         z-index: 998;
+
         > b {
             float: left;
             margin-right: 5px;
         }
+
         select,
         .selectize-control {
             width: 80px;
@@ -158,6 +170,7 @@ tr.form-row.hidden {
             float: right;
         }
     }
+
     &-method,
     &-direction {
         @media (max-width: 858px) {
@@ -179,6 +192,7 @@ tr.form-row.hidden {
             display: none;
         }
     }
+
     @media (max-width: 1000px) {
         width: 350px;
     }
@@ -204,30 +218,36 @@ tr.form-row {
             background-color: white;
         }
     }
+
     &.hidden {
         .selectize-input,
         input,
         textarea {
-            background-color: rgba(181, 181, 181, .25);
+            background-color: rgba(181, 181, 181, 0.25);
         }
     }
+
     // this NEEDS to be separate
     ::-webkit-input-placeholder {
         color: black;
         font-weight: bold;
     }
+
     :-moz-placeholder {
         color: black;
         font-weight: bold;
     }
+
     ::-moz-placeholder {
         color: black;
         font-weight: bold;
     }
+
     :-ms-input-placeholder {
         color: black;
         font-weight: bold;
     }
+
     .capacity {
         font-size: 15px;
         font-style: italic;
@@ -236,14 +256,17 @@ tr.form-row {
             font-size: 12px;
             font-style: normal;
         }
+
         &:-moz-placeholder {
             font-size: 12px;
             font-style: normal;
         }
+
         &::-moz-placeholder {
             font-size: 12px;
             font-style: normal;
         }
+
         &:-ms-input-placeholder {
             font-size: 12px;
             font-style: normal;
@@ -263,7 +286,7 @@ tr.form-row {
     cursor: pointer;
     width: 400px;
     height: 65px;
-    margin-top: 20px; 
+    margin-top: 20px;
 }
 
 #admin_comments_modal {
@@ -272,6 +295,7 @@ tr.form-row {
     border-radius: 3px;
     white-space: pre-wrap;
 }
+
 #admin_comments_badge {
     cursor: pointer;
     margin-left: 5px;

--- a/intranet/static/css/eighth.signup.scss
+++ b/intranet/static/css/eighth.signup.scss
@@ -1,4 +1,5 @@
 @import "colors";
+
 $red: rgb(255, 72, 72);
 $orange: #ff6f00;
 $color1: #d8d8d8;
@@ -8,19 +9,22 @@ $color4: rgb(242, 242, 242);
 $color5: rgb(170, 170, 170);
 $color6: rgb(242, 242, 244);
 $color7: rgb(213, 213, 213);
-$color8: rgba(0, 0, 0, .05);
+$color8: rgba(0, 0, 0, 0.05);
 $headerblue: #0048ab;
+
 .primary-content {
     /* after this point (where body is 353px),
        the UI is impossible to use and things
        start overlapping
     */
     min-width: 273px;
+
     &.scroll-display {
         #activity-list {
             margin-top: 40px;
             height: calc(100% - 40px);
         }
+
         .middle-wrapper {
             position: absolute;
             top: 0;
@@ -30,6 +34,7 @@ $headerblue: #0048ab;
             background: #f0f0f0;
             border-bottom: 1px solid $color1;
         }
+
         .sticky-header.all-header {
             display: none;
         }
@@ -54,9 +59,11 @@ $headerblue: #0048ab;
     */
     -webkit-transform: translateZ(0);
     transform: translateZ(0);
+
     &-buttons {
         height: 100px;
         width: 100%;
+
         button {
             &,
             &:hover,
@@ -73,20 +80,22 @@ $headerblue: #0048ab;
                 border-radius: 0;
                 z-index: 500;
             }
+
             i {
                 left: 50%;
                 top: 50%;
             }
         }
     }
+
     .day {
         display: inline-block;
         vertical-align: top;
         width: 200px;
         height: 100px;
-        margin: 0;
-        margin-right: 1px;
+        margin: 0 1px 0 0;
         outline: 1px solid $color1;
+
         &-title {
             height: 24px;
             display: block;
@@ -109,6 +118,7 @@ $headerblue: #0048ab;
 
 .active-block {
     background-color: $color2;
+
     &:not(:hover) .block-letter {
         background-color: $color3;
     }
@@ -117,15 +127,18 @@ $headerblue: #0048ab;
 .block {
     .block-letter {
         margin-right: 5px;
+
         &.waitlist {
             background-color: $orange;
             color: white;
         }
     }
+
     &.cancelled {
         .selected-activity {
             color: $red;
         }
+
         .block-letter {
             background-color: $red; // red
             color: $color4;
@@ -162,6 +175,7 @@ $headerblue: #0048ab;
     line-height: 32px;
     display: block;
     padding: 3px;
+
     &:hover {
         background-color: $color3;
     }
@@ -170,6 +184,7 @@ $headerblue: #0048ab;
 .many-blocks {
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch;
+
     .block {
         height: 25px;
         line-height: 25px;
@@ -178,12 +193,14 @@ $headerblue: #0048ab;
 
 .day {
     text-align: left;
+
     a {
         &,
         &:hover {
             text-decoration: none;
             color: $grey;
         }
+
         div {
             white-space: nowrap;
             overflow: hidden;
@@ -196,15 +213,18 @@ $headerblue: #0048ab;
 .middle {
     margin: 10px 0;
     height: 50px;
+
     .middle-wrapper.only-unsignup & {
         height: 40px;
         margin: 0;
     }
+
     > .block-title {
         float: left;
         margin-left: 5px;
         // FIXME: hardcoded background color
         background-color: $color4;
+
         h2 {
             font-size: 20px;
             font-weight: bold;
@@ -212,10 +232,12 @@ $headerblue: #0048ab;
             padding-bottom: 0;
         }
     }
+
     h4 {
         font-size: 16px;
         margin: 0;
     }
+
     .middle-button-container {
         position: absolute;
         right: 26px;
@@ -225,12 +247,14 @@ $headerblue: #0048ab;
             right: 5px;
             z-index: 9;
         }
-        .history-button> a> span {
+
+        .history-button > a > span {
             @media (max-width: 500px) {
                 display: none;
             }
         }
     }
+
     &-wrapper {
         display: table;
         width: 100%;
@@ -239,8 +263,7 @@ $headerblue: #0048ab;
 
 .new-feature {
     background: $headerblue;
-    margin: 0 auto;
-    margin-bottom: 10px;
+    margin: 0 auto 10px;
     color: white;
     padding: 5px;
     border-radius: 5px;
@@ -248,11 +271,12 @@ $headerblue: #0048ab;
         max-width: 100%;
     }
     @media (min-width: 700px) and (max-width: 950px) {
-        max-width: 75%
+        max-width: 75%;
     }
     @media (min-width: 950px) {
-        max-width: 50%
+        max-width: 50%;
     }
+
     &-text {
         font-size: 15px;
     }
@@ -270,6 +294,7 @@ $headerblue: #0048ab;
         }
     }
 }
+
 .search {
     &-wrapper {
         position: relative;
@@ -282,6 +307,7 @@ $headerblue: #0048ab;
             overflow: hidden;
         }
     }
+
     &-hide {
         height: 0 !important;
         overflow: hidden !important;
@@ -291,6 +317,7 @@ $headerblue: #0048ab;
         -ms-transition: all 0.2s ease;
         -o-transition: all 0.2s ease;
     }
+
     &-noresults {
         display: none;
     }
@@ -312,11 +339,13 @@ $headerblue: #0048ab;
     */
     -webkit-transform: translateZ(0);
     transform: translateZ(0);
+
     .fa-search {
         margin-left: 5px;
         line-height: 30px;
         float: left;
     }
+
     .search-wrapper input {
         font-size: 14px;
         background: none;
@@ -344,37 +373,42 @@ $headerblue: #0048ab;
     overflow-y: scroll;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
+
     ul {
         padding: 0;
         list-style: none;
         cursor: pointer;
+
         > p {
             margin: 10px;
         }
     }
+
     li {
         height: 26px;
         line-height: 26px;
         padding: 0 10px;
         white-space: nowrap;
         overflow: hidden;
+
         &:nth-child(odd) {
             background-color: $color8;
         }
+
         &.selected {
             background-color: $color7;
             font-weight: bold;
         }
+
         &.signed-up {
             &:before,
             &::before {
                 content: "\F00C";
-                font-family: FontAwesome;
-                padding: 0 0 0 5px;
+                font-family: FontAwesome, sans-serif;
                 font-size: 13px;
                 color: green;
                 margin-left: -24px;
-                padding-right: 3px;
+                padding: 0 3px 0 5px;
             }
         }
     }
@@ -385,17 +419,21 @@ $headerblue: #0048ab;
         #activity-list {
             margin-top: 31px;
         }
+
         .search-header {
             display: block;
         }
     }
+
     .search-header {
         display: none;
     }
+
     h3.empty-state {
         color: $color5;
         text-align: center;
     }
+
     h5 .clear-button {
         float: right;
         margin-top: 4px;
@@ -420,14 +458,17 @@ $headerblue: #0048ab;
     z-index: 999;
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch;
+
     dt {
         float: left;
         padding-right: 5px;
     }
+
     dd,
     dt {
         font-size: 15px;
     }
+
     h2.user-name {
         padding-bottom: 0;
     }
@@ -438,6 +479,7 @@ h3 {
     &.activity-detail-header {
         font-size: 20px;
     }
+
     > a {
         &,
         &:link,
@@ -456,6 +498,7 @@ h3 {
         font-weight: bold;
         margin-bottom: 1em;
     }
+
     .signup-waitlist-current {
         color: $orange;
         margin-bottom: 1em;
@@ -496,6 +539,7 @@ h5 {
     font-weight: bold;
     padding: 0 10px;
     outline: 1px solid $color1;
+
     &.stuck {
         position: absolute;
         top: 31px;
@@ -504,14 +548,17 @@ h5 {
         z-index: 999;
         margin-right: 450px;
     }
+
     &.hidden {
         display: none;
     }
+
     &.no-activities {
         /* fixes sticky headers */
         visibility: hidden;
         height: 0;
     }
+
     &.search-header {
         margin-top: 1px;
     }
@@ -534,6 +581,7 @@ h5 {
             }
         }
     }
+
     &-name {
         overflow: hidden;
         white-space: nowrap;
@@ -541,6 +589,7 @@ h5 {
         display: inline-block;
         width: auto;
     }
+
     &-flags {
         overflow: hidden;
         white-space: nowrap;
@@ -548,6 +597,7 @@ h5 {
         display: inline-block;
         width: auto;
     }
+
     &-rooms {
         position: absolute;
         left: 60%;
@@ -560,6 +610,7 @@ h5 {
         font-weight: lighter;
         opacity: 0.7;
     }
+
     &-sponsors {
         overflow: hidden;
         white-space: nowrap;
@@ -568,12 +619,14 @@ h5 {
         float: right;
         font-weight: lighter;
         opacity: 0.7;
+
         .activity-ids {
             width: 35px;
             display: inline-block;
             text-align: right;
         }
     }
+
     &-icon {
         background-image: url("/static/img/Eighth-Icons.svg");
         background-size: auto 20px;
@@ -583,22 +636,28 @@ h5 {
         height: 20px;
         width: 20px;
         margin-top: 3px;
+
         .no-svg & {
             background-image: url("/static/img/Eighth-Icons@2x.png");
         }
+
         @for $i from 0 through 10 {
             &.pie-#{$i} {
-                background-position: -20px*$i 0;
+                background-position: -20px * $i 0;
             }
         }
+
         &.cancelled {
             background-position: -220px 0;
         }
+
         &.restricted {
             background-position: -220px 0;
         }
+
         &.fav {
             background-position: -260px 0;
+
             &.fav-sel {
                 background-position: -240px 0;
             }
@@ -607,20 +666,13 @@ h5 {
 }
 
 @media print {
-    * {
-        transition: initial !important;
-        -webkit-transition: initial !important;
-        -moz-transition: initial !important;
-        -ms-transition: initial !important;
-        -o-transition: initial !important;
-    }
-    body> .main> div.primary-content {
+    body > .main > div.primary-content {
         margin-left: 0 !important;
     }
     div.day-picker {
         display: none;
     }
-    html> body {
+    html > body {
         min-width: initial;
     }
     div.main {
@@ -628,12 +680,14 @@ h5 {
     }
     div#activity-picker {
         height: auto;
+
         div#activity-detail {
             display: none;
             position: static;
             width: 100%;
             width: calc(100% - 15px);
             float: none;
+
             &.selected {
                 display: block;
             }
@@ -648,6 +702,7 @@ h5 {
             font-weight: normal;
             background: inherit;
         }
+
         &:nth-child(odd) {
             background-color: $color8 !important;
         }

--- a/intranet/static/css/emerg.scss
+++ b/intranet/static/css/emerg.scss
@@ -19,9 +19,11 @@ body.has-login-warning {
             left: -30%;
         }
     }
+
     .center {
         margin-top: -220px;
     }
+
     &.has-snow .center {
         margin-top: -229px;
         @media (max-width: 500px) and (max-height: 784px) {
@@ -31,10 +33,11 @@ body.has-login-warning {
             margin-top: -229px;
         }
     }
+
     @media (max-height: 784px) {
         .center {
             margin-top: -220px;
-            top: 392px
+            top: 392px;
         }
         &.has-snow .center {
             margin-top: -229px;
@@ -42,17 +45,19 @@ body.has-login-warning {
     }
 }
 
-.dash-warning, .login-warning {
+.dash-warning,
+.login-warning {
     background-color: yellow;
     border: 1px solid #d2d042;
     padding: 10px;
     border-radius: 4px;
     text-align: center;
-    transition: max-height .2s ease-in-out;
+    transition: max-height 0.2s ease-in-out;
 
     &.collapsed {
         max-height: 50px !important;
         overflow: hidden;
+
         &::after {
             content: "";
             position: absolute;
@@ -60,7 +65,11 @@ body.has-login-warning {
             bottom: 0;
             left: 0;
             pointer-events: none;
-            background-image: linear-gradient(to bottom, rgba(255,255,255, 0), yellow 90%);
+            background-image: linear-gradient(
+                            to bottom,
+                            rgba(255, 255, 255, 0),
+                            yellow 90%
+            );
             width: 100%;
             height: 4em;
         }

--- a/intranet/static/css/events.scss
+++ b/intranet/static/css/events.scss
@@ -1,11 +1,14 @@
 @import "colors";
+
 .events {
     min-width: 290px; // for 320x480 screens
     max-width: 1000px;
     margin-bottom: 100px;
+
     h2 {
         padding-left: 10px;
         line-height: 38px;
+
         &.category {
             font-size: 18px;
             font-weight: normal;
@@ -29,58 +32,71 @@
     padding: 6px 10px;
     margin-bottom: 6px;
     overflow-x: auto;
-    behavior: url("/static/js/PIE/PIE.htc");
+    behavior: url("/static/js/vendor/PIE/PIE.htc");
+
     h3 {
         cursor: pointer;
+
         > a.event-link {
             cursor: pointer;
             color: $grey !important;
         }
+
         &:hover .event-icon-wrapper .event-toggle,
         .event-icon-wrapper .event-toggle:hover,
         .event-icon-wrapper:hover .event-toggle:hover {
             color: rgb(32, 66, 224);
         }
+
         .event-icon-wrapper:hover .event-toggle {
             color: $grey;
         }
     }
+
     &-metadata {
         color: rgb(144, 144, 144);
         font-size: 12px;
         line-height: 12px;
         margin-bottom: 5px;
     }
+
     &-icon {
         cursor: pointer;
+
         &-wrapper {
             float: right;
             display: none;
+
             .event:hover & {
                 display: block;
             }
+
             > a {
                 color: $grey;
                 text-decoration: none !important;
                 padding-left: 2px;
+
                 &:hover {
                     color: rgb(32, 66, 224);
                 }
             }
         }
     }
+
     @media (max-width: 710px) {
         .bottom-row {
             margin-bottom: 23px;
+
             .attend-status {
                 left: 0;
                 bottom: -27px;
             }
         }
     }
+
     &-approve-table {
         color: grey;
-        margin-bottom: 4px
+        margin-bottom: 4px;
     }
 }
 
@@ -98,15 +114,18 @@
     left: 270px;
     max-width: 280px;
     white-space: nowrap;
+
     .bottom-row.show-attend & {
         width: 280px;
     }
+
     position: absolute;
     left: 270px;
 }
 
 .signup-status {
     color: gray;
+
     > a.button {
         margin-top: -2px;
         position: absolute;
@@ -120,13 +139,13 @@ a.button {
         margin-top: -3px;
         float: right;
     }
+
     &.no-attend-button {
         color: red;
         margin-top: -3px;
         float: right;
     }
 }
-
 
 /*
  * on announcement page, switch to separate rows more quickly
@@ -135,6 +154,7 @@ a.button {
 @media (max-width: 1060px) {
     .announcements.primary-content .announcement .event .bottom-row {
         margin-bottom: 23px;
+
         .attend-status {
             left: 0;
             bottom: -23px;

--- a/intranet/static/css/files.scss
+++ b/intranet/static/css/files.scss
@@ -1,6 +1,8 @@
 @import "colors";
+
 table.directory-list {
     width: 100%;
+
     a {
         &,
         &:link,
@@ -9,35 +11,44 @@ table.directory-list {
         &:active {
             color: $grey;
         }
+
         &.delete:hover {
             color: rgb(220, 0, 0);
             text-decoration: none;
         }
+
         &.zip {
             padding-right: 5px;
+
             &:hover {
                 color: rgb(168, 168, 0);
                 text-decoration: none;
             }
         }
     }
+
     tr {
         border-bottom: 1px solid rgba(0, 0, 0, .2);
+
         &:hover {
             background-color: rgb(220, 220, 220);
         }
+
         &:last-child {
             border-bottom: 0;
         }
     }
+
     td {
         &.item {
             padding: 3px 5px;
             width: 50%;
+
             i.fa {
                 width: 13px;
             }
         }
+
         &.file-options {
             text-align: right;
             padding-right: 10px;
@@ -58,6 +69,7 @@ table.directory-list {
     margin-right: 6px;
     overflow-x: auto;
     width: 250px;
+
     a {
         display: block;
         font-size: 22px;
@@ -65,15 +77,18 @@ table.directory-list {
         text-align: center;
         text-decoration: none
     }
+
     i.fa {
         display: block;
         font-size: 46px;
         clear: both;
         text-align: center;
     }
+
     span {
         text-align: center;
     }
+
     a:hover span {
         text-decoration: underline;
     }
@@ -89,6 +104,7 @@ table.directory-list {
 #additional-upload-option {
     padding-left: 5px;
     display: none;
+
     &.visible {
         display: inline;
     }
@@ -105,12 +121,15 @@ table.directory-list {
     z-index: 1043; // search bar is 1042
     text-align: center;
     border: 10px dashed #666;
+
     div {
         margin-top: 100px;
     }
+
     h3 {
         font-size: 2em;
     }
+
     * {
         pointer-events: none;
     }
@@ -125,6 +144,7 @@ table.directory-list {
         &-information {
             font-size: 0.8em;
         }
+
         &-options {
             font-size: 1.2em;
         }

--- a/intranet/static/css/groups.scss
+++ b/intranet/static/css/groups.scss
@@ -8,12 +8,14 @@
     &-header {
         height: 38px;
         margin-bottom: 4px;
+
         h2 {
             line-height: 38px;
             float: left;
             display: inline;
         }
     }
+
     &-icon-wrapper {
         float: right;
     }

--- a/intranet/static/css/hoco_ribbon.scss
+++ b/intranet/static/css/hoco_ribbon.scss
@@ -1,275 +1,276 @@
 @import "https://fonts.googleapis.com/css?family=Oswald:400,700";
 
 .ribbon * {
-  font-family: 'Oswald', sans-serif;
-	letter-spacing: 1px;
+    font-family: 'Oswald', sans-serif;
+    letter-spacing: 1px;
 }
 
 .ribbon * {
-  box-sizing: border-box;  
+    box-sizing: border-box;
 }
 
 .ribbon {
-		position: relative;
-		top: 0;
-		left: 0;
-		margin: 0 auto;
-		right: 0;
-		overflow: hidden;
-		@media screen and (max-width: 640px) {
-			zoom: 0.6;
-		}
-		@media screen and (min-width: 640px) and (max-width: 868px) {
-			zoom: 0.7;
-		}
-		@media screen and (min-width: 868px) and (max-width: 1368px) {
-			zoom: 0.8;
-		}
-		@media screen and (min-width: 1368px) {
-			zoom: 1.0;
-		}
+    position: relative;
+    top: 0;
+    left: 0;
+    margin: 0 auto;
+    right: 0;
+    overflow: hidden;
+    @media screen and (max-width: 640px) {
+        zoom: 0.6;
+    }
+    @media screen and (min-width: 640px) and (max-width: 868px) {
+        zoom: 0.7;
+    }
+    @media screen and (min-width: 868px) and (max-width: 1368px) {
+        zoom: 0.8;
+    }
+    @media screen and (min-width: 1368px) {
+        zoom: 1.0;
+    }
 
-		[class*="ribbon-"] {
-			margin: 74px auto 0;
-			transform-origin: 50% 50%;
-			transform: rotate(-8.5deg);
-			position: relative;
-			z-index: 4;
-			width: 287px;
-			height: 56px;
-			
-			.inner {
-				background: #003468;
-				color: #fff;
-				text-transform: uppercase;
-				text-align: center;
-				display: block;
-				width: 0;
-				height: 100%;
-				padding: 11px 0;
-				font-size: 1.5em;
-				text-shadow: 3px 3px 1px #001b47;
-				position: relative;
-				z-index: 2;
-				transform: skewX(-9deg);
-				transition: width .12s ease-in-out;
-			}
-			
-			&:before {
-				content: '';
-				transform-origin: 0 0;
-				transform: rotate(-17.25deg) skewX(-9deg) translateX(158px);
-				display: block;
-			    width: 0;
-			    height: 100%;
-				position: absolute;
-				top: 0;
-				left: 4px;
-				background: #001b47;
-				z-index: -1;
-				transition: all .12s ease-in-out .7s;
-			}
-		}
+    [class*="ribbon-"] {
+        margin: 74px auto 0;
+        transform-origin: 50% 50%;
+        transform: rotate(-8.5deg);
+        position: relative;
+        z-index: 4;
+        width: 287px;
+        height: 56px;
 
-		.ribbon-1 {
-			.inner {
-				letter-spacing: 19px;
-				font-weight: 700;
-			}
-		}
+        .inner {
+            background: #003468;
+            color: #fff;
+            text-transform: uppercase;
+            text-align: center;
+            display: block;
+            width: 0;
+            height: 100%;
+            padding: 11px 0;
+            font-size: 1.5em;
+            text-shadow: 3px 3px 1px #001b47;
+            position: relative;
+            z-index: 2;
+            transform: skewX(-9deg);
+            transition: width .12s ease-in-out;
+        }
 
-		&.active .inner {
-			width: 100%;
-		}
+        &:before {
+            content: '';
+            transform-origin: 0 0;
+            transform: rotate(-17.25deg) skewX(-9deg) translateX(158px);
+            display: block;
+            width: 0;
+            height: 100%;
+            position: absolute;
+            top: 0;
+            left: 4px;
+            background: #001b47;
+            z-index: -1;
+            transition: all .12s ease-in-out .7s;
+        }
+    }
 
-		&.active [class*="ribbon-"]:before,
-		&.active [class*="ribbon-"]:after {
-		}
+    .ribbon-1 {
+        .inner {
+            letter-spacing: 19px;
+            font-weight: 700;
+        }
+    }
 
-		&.active .ribbon-1 {
-			.inner {
-				transition-delay: .82s;
-			}
+    &.active .inner {
+        width: 100%;
+    }
 
-			&:before {
-				width: 158px;
-				transform: rotate(-17.25deg) skewX(-9deg) translateX(0);
-			}
-		}
-		
-		.ribbon-2 {
-			z-index: 3;
-			font-size: 45px;
-			width: 451px;
-			height: 137px;
-			margin-top: 22px;
+    &.active [class*="ribbon-"]:before,
+    &.active [class*="ribbon-"]:after {
+    }
 
-			.inner {
-				padding: 19px 0;
+    &.active .ribbon-1 {
+        .inner {
+            transition-delay: .82s;
+        }
 
-				&:before,
-				&:after {
-					content: '';
-					position: absolute;
-					top: 14px;
-					left: 14px;
-					right: 14px;
-					bottom: 14px;
-					background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAeYAAAALCAYAAACqPi4nAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyhpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMDE0IDc5LjE1Njc5NywgMjAxNC8wOC8yMC0wOTo1MzowMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTQgKE1hY2ludG9zaCkiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6NjEyM0FFRTU0NUUzMTFFNTlDMjdDMEJDMDFCNjlGNDkiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6NjEyM0FFRTY0NUUzMTFFNTlDMjdDMEJDMDFCNjlGNDkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpEOUZEM0I5NDQ1QkQxMUU1OUMyN0MwQkMwMUI2OUY0OSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2MTIzQUVFNDQ1RTMxMUU1OUMyN0MwQkMwMUI2OUY0OSIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pm3y348AAAIOSURBVHja7JvhboIwEMfbOZgyQF9h2cPtrfZ8+7APU0RQt7FrciQ3QqHodFT+v+RCc9ikHtX/tUe1GjFVVc3okij/0GRL5ScrT8edkt15OG4zv2cejvuRLPBw3BFZ6OG452y+8UC28HDcAc/xa/FN9k72RvaqSfzMH/EL2RPZMwcyFRMh4YkcKwAAAGC6GAHNyHZke7I1Wcm2Zp+5t+F2Trbltku/TGv9pQeuYGuxTjmjSISAS99CCHwt6l2+JfeNOaMN8PwBAAAMkSgWxIKF7oOvRYdQ5tx26kei+XmNL6JHG+Gqaop1yAIe8hZD7VuJbYc2X73ltuJ7kfAtMZcBAOAqWFeJ3N62CGXp2o9E83grgdJTnymUAEixluIfcVIQdPjq+knM91PhS/hztW+O3yUAYMSi2be6PHn7lkTzgBBDmMeaBEixbtbwkx6frVTQ5sNzBeB22DiuLvu2b8u2fiSae4QYwgwunwDcK3sN31bXt5UKusoHEaINJk524urSafuWRLNEiCHMAAxNAmQNv6+u3ywV9JUPZKlghmiDgeS2VaJyfznIJrBGNAuEGECYwZQTAHNGOVXudX1ZFnApH6RiBwFcnp0QynNWl60CS6KZI8QAwgzA7SQBlzgCGCp/jgUWLUJ5zuryl8CSaG4xywCAMAMw1iTgr44AmutBnfdykBHNDE8FgP/lR4ABABGzGigi55YSAAAAAElFTkSuQmCC') center bottom no-repeat;
-					background-size: 100%;
-					opacity: 0;
-					transition: opacity .3s ease-in-out 1.86s;
-				}
+        &:before {
+            width: 158px;
+            transform: rotate(-17.25deg) skewX(-9deg) translateX(0);
+        }
+    }
 
-				&:before {
-					transform-origin: 50% 50%;
-					transform: rotate(180deg);
-				}
-			}
-			
-			&:before {
-				width: 0;
-				left: 11px;
-				transform: rotate(-10.25deg) skewX(-9deg) translateX(451px);
-				height: 47px;
-				transition-delay: .94s;
-			}
-		}
+    .ribbon-2 {
+        z-index: 3;
+        font-size: 45px;
+        width: 451px;
+        height: 137px;
+        margin-top: 22px;
 
-		&.active .ribbon-2 {
-			.inner {
-				transition-delay: 1.06s;
+        .inner {
+            padding: 19px 0;
 
-				&:before,
-				&:after {
-					opacity: 1;
-				}
-			}
+            &:before,
+            &:after {
+                content: '';
+                position: absolute;
+                top: 14px;
+                left: 14px;
+                right: 14px;
+                bottom: 14px;
+                background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAeYAAAALCAYAAACqPi4nAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyhpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMDE0IDc5LjE1Njc5NywgMjAxNC8wOC8yMC0wOTo1MzowMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTQgKE1hY2ludG9zaCkiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6NjEyM0FFRTU0NUUzMTFFNTlDMjdDMEJDMDFCNjlGNDkiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6NjEyM0FFRTY0NUUzMTFFNTlDMjdDMEJDMDFCNjlGNDkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpEOUZEM0I5NDQ1QkQxMUU1OUMyN0MwQkMwMUI2OUY0OSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo2MTIzQUVFNDQ1RTMxMUU1OUMyN0MwQkMwMUI2OUY0OSIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pm3y348AAAIOSURBVHja7JvhboIwEMfbOZgyQF9h2cPtrfZ8+7APU0RQt7FrciQ3QqHodFT+v+RCc9ikHtX/tUe1GjFVVc3okij/0GRL5ScrT8edkt15OG4zv2cejvuRLPBw3BFZ6OG452y+8UC28HDcAc/xa/FN9k72RvaqSfzMH/EL2RPZMwcyFRMh4YkcKwAAAGC6GAHNyHZke7I1Wcm2Zp+5t+F2Trbltku/TGv9pQeuYGuxTjmjSISAS99CCHwt6l2+JfeNOaMN8PwBAAAMkSgWxIKF7oOvRYdQ5tx26kei+XmNL6JHG+Gqaop1yAIe8hZD7VuJbYc2X73ltuJ7kfAtMZcBAOAqWFeJ3N62CGXp2o9E83grgdJTnymUAEixluIfcVIQdPjq+knM91PhS/hztW+O3yUAYMSi2be6PHn7lkTzgBBDmMeaBEixbtbwkx6frVTQ5sNzBeB22DiuLvu2b8u2fiSae4QYwgwunwDcK3sN31bXt5UKusoHEaINJk524urSafuWRLNEiCHMAAxNAmQNv6+u3ywV9JUPZKlghmiDgeS2VaJyfznIJrBGNAuEGECYwZQTAHNGOVXudX1ZFnApH6RiBwFcnp0QynNWl60CS6KZI8QAwgzA7SQBlzgCGCp/jgUWLUJ5zuryl8CSaG4xywCAMAMw1iTgr44AmutBnfdykBHNDE8FgP/lR4ABABGzGigi55YSAAAAAElFTkSuQmCC') center bottom no-repeat;
+                background-size: 100%;
+                opacity: 0;
+                transition: opacity .3s ease-in-out 1.86s;
+            }
 
-			&:before {
-				width: 376px;
-				transform: rotate(-10.25deg) skewX(-9deg) translateX(0);
-			}
-		}
-		
-		.ribbon-3 {
-			z-index: 2;
-			font-size: 9px;
-			width: 326px;
-			height: 55px;
-			margin-top: 24px;
-			
-			.inner {
-				color: #e8a713;
-				padding: 19px 0;
-			}
-      .inner a {
-				color: #e8a713;
-				padding: 19px 0;
-			}
-			 
-			&:before {
-			    width: 0;
-			    height: 47px;
-			    left: 11px;
-			    transform: rotate(-10.25deg) skewX(-9deg) translateX(387px);
-			    transition-delay: 1.18s;
-			}
-			
-			&:after {
-				content: '';
-				transform-origin: 100% 100%;
-				transform: rotate(-15.3deg) skewX(9deg) translateX(72px);
-				display: block;
-				width: 0;
-				height: 45px;
-				position: absolute;
-				bottom: 0;
-				right: 4px;
-				background: #001b47;
-				z-index: -1;
-				transition-delay: 1.42s;
-			}
-		}
+            &:before {
+                transform-origin: 50% 50%;
+                transform: rotate(180deg);
+            }
+        }
 
-		&.active .ribbon-3 {
-			.inner {
-				transition-delay: 1.3s;
-			}
+        &:before {
+            width: 0;
+            left: 11px;
+            transform: rotate(-10.25deg) skewX(-9deg) translateX(451px);
+            height: 47px;
+            transition-delay: .94s;
+        }
+    }
 
-			&:before {
-				width: 387px;
-				transform: rotate(-10.25deg) skewX(-9deg) translateX(0);
-			}
+    &.active .ribbon-2 {
+        .inner {
+            transition-delay: 1.06s;
 
-			&:after {
-				width: 56px;
-				transform: rotate(-15.3deg) skewX(9deg) translateX(0);
-			}
-		}
-		
-		.ball {
-			width: 190px;
-			height: 190px;
-			background: #e8a713;
-			border-radius: 95px;
-			padding: 85px 20px 0;
-			text-align: center;
-			color: #001b47;
-			border: 10px solid #001b47;
-			margin: -87px auto 0;
-			position: relative;
-			left: 18px;
-			z-index: 1;
-			transform-origin: 50% 50%;
-			transform: rotate(-8.5deg);
+            &:before,
+            &:after {
+                opacity: 1;
+            }
+        }
 
-			.ball-text {
-				font-size: 12px;
-			    line-height: 1.2;
-			    text-align: right;
-			    display: block;
-			    width: 119px;
-			
-				strong {
-				    font-size: 39px;
-				    font-style: italic;
-				    display: block;
-				    margin: 0 auto;
-				}
-			}
+        &:before {
+            width: 376px;
+            transform: rotate(-10.25deg) skewX(-9deg) translateX(0);
+        }
+    }
 
-		}
+    .ribbon-3 {
+        z-index: 2;
+        font-size: 9px;
+        width: 326px;
+        height: 55px;
+        margin-top: 24px;
 
-		.fadeLeft {
-			opacity: 0;
-			transform: translateX(-100%);
-			transition: all .3s ease-in-out 1.56s;
-			display: block;
-		}
-		
-		.fadeRight {
-			opacity: 0;
-			transform: translateX(100%);
-			transition: all .3s ease-in-out 1.56s;
-			display: block;
-		}
+        .inner {
+            color: #e8a713;
+            padding: 19px 0;
+        }
 
-		.fadeIn {
-			opacity: 0;
-			transition: all .3s ease-in-out 1.42s;
-			display: block;
-		}
+        .inner a {
+            color: #e8a713;
+            padding: 19px 0;
+        }
 
-		&.active {
-			.fadeLeft,
-			.fadeRight {
-				opacity: 1;
-				transform: translateX(0);
-			}
+        &:before {
+            width: 0;
+            height: 47px;
+            left: 11px;
+            transform: rotate(-10.25deg) skewX(-9deg) translateX(387px);
+            transition-delay: 1.18s;
+        }
 
-			.fadeIn {
-				opacity: 1;
-			}
-		}
-	}
+        &:after {
+            content: '';
+            transform-origin: 100% 100%;
+            transform: rotate(-15.3deg) skewX(9deg) translateX(72px);
+            display: block;
+            width: 0;
+            height: 45px;
+            position: absolute;
+            bottom: 0;
+            right: 4px;
+            background: #001b47;
+            z-index: -1;
+            transition-delay: 1.42s;
+        }
+    }
+
+    &.active .ribbon-3 {
+        .inner {
+            transition-delay: 1.3s;
+        }
+
+        &:before {
+            width: 387px;
+            transform: rotate(-10.25deg) skewX(-9deg) translateX(0);
+        }
+
+        &:after {
+            width: 56px;
+            transform: rotate(-15.3deg) skewX(9deg) translateX(0);
+        }
+    }
+
+    .ball {
+        width: 190px;
+        height: 190px;
+        background: #e8a713;
+        border-radius: 95px;
+        padding: 85px 20px 0;
+        text-align: center;
+        color: #001b47;
+        border: 10px solid #001b47;
+        margin: -87px auto 0;
+        position: relative;
+        left: 18px;
+        z-index: 1;
+        transform-origin: 50% 50%;
+        transform: rotate(-8.5deg);
+
+        .ball-text {
+            font-size: 12px;
+            line-height: 1.2;
+            text-align: right;
+            display: block;
+            width: 119px;
+
+            strong {
+                font-size: 39px;
+                font-style: italic;
+                display: block;
+                margin: 0 auto;
+            }
+        }
+
+    }
+
+    .fadeLeft {
+        opacity: 0;
+        transform: translateX(-100%);
+        transition: all .3s ease-in-out 1.56s;
+        display: block;
+    }
+
+    .fadeRight {
+        opacity: 0;
+        transform: translateX(100%);
+        transition: all .3s ease-in-out 1.56s;
+        display: block;
+    }
+
+    .fadeIn {
+        opacity: 0;
+        transition: all .3s ease-in-out 1.42s;
+        display: block;
+    }
+
+    &.active {
+        .fadeLeft,
+        .fadeRight {
+            opacity: 1;
+            transform: translateX(0);
+        }
+
+        .fadeIn {
+            opacity: 1;
+        }
+    }
+}

--- a/intranet/static/css/hoco_scores.scss
+++ b/intranet/static/css/hoco_scores.scss
@@ -9,8 +9,7 @@
         position: relative;
         background-color: #545454;
         color: white;
-        padding: 15px;
-        padding-bottom: 20px;
+        padding: 15px 15px 20px;
         margin: 5px;
         width: 100px;
         height: 80px;
@@ -19,11 +18,13 @@
         .class {
             font-size: 1.5em;
         }
+
         .score {
             font-size: 2em;
         }
     }
 }
+
 @media screen and (max-width: 640px) {
     .center-wrapper {
         margin-top: 40px;
@@ -33,6 +34,7 @@
         zoom: 0.7;
     }
 }
+
 .corner-ribbon {
     width: 95px;
     background: #e43;
@@ -49,9 +51,11 @@
     &.gold {
         background-color: #C98910;
     }
+
     &.silver {
         background-color: #A8A8A8;
     }
+
     &.bronze {
         background-color: #965A38;
     }

--- a/intranet/static/css/login.scss
+++ b/intranet/static/css/login.scss
@@ -1,5 +1,6 @@
 @import "colors";
-height {
+
+html {
     height: 100%;
 }
 
@@ -59,6 +60,7 @@ input {
     &[type=password] {
         width: 192px;
     }
+
     &[type=submit] {
         width: 200px;
         margin-top: 6px;
@@ -94,10 +96,12 @@ h2 {
     margin-top: 11px;
     font-size: 16px;
     margin-left: -100px;
+
     .center & {
         margin-left: 0;
         padding-bottom: 25px;
     }
+
     h2 {
         max-width: 300px;
         white-space: normal;
@@ -112,6 +116,7 @@ h2 {
         display: inline-block;
         color: $grey;
     }
+
     &:hover i {
         text-decoration: none;
         color: rgb(32, 66, 224);
@@ -122,6 +127,7 @@ h2 {
     &-left {
         text-align: left;
     }
+
     &-right {
         text-align: right;
     }
@@ -132,6 +138,7 @@ h2 {
     bottom: 0;
     left: 4px;
     z-index: 1;
+
     img {
         width: 100px;
     }
@@ -144,10 +151,12 @@ h2 {
     margin-left: -20%;
     width: 40%;
     text-align: center;
+
     a {
         color: black;
         text-decoration: none;
     }
+
     span {
         font-size: 20px;
         font-weight: 200;
@@ -163,7 +172,7 @@ h2 {
     }
 }
 
-.schedule> iframe {
+.schedule > iframe {
     position: absolute;
     left: 50%;
     margin-left: -154px;
@@ -178,6 +187,7 @@ a.schedule {
     &-left {
         float: left;
     }
+
     &-right {
         float: right;
     }
@@ -191,19 +201,24 @@ a.schedule {
     min-width: 160px;
     cursor: pointer;
     text-align: right;
+
     i {
         margin-right: 4px;
     }
+
     #revision,
     .git-github {
         display: none;
     }
+
     &:hover {
         color: rgba(0, 72, 171, .8);
+
         #revision,
         .git-github {
             display: inline-block;
         }
+
         #git-oss,
         .git-flask {
             display: none;
@@ -246,6 +261,7 @@ a.schedule {
     width: 90px;
     margin: auto;
     cursor: pointer;
+
     .no-svg & {
         background-image: url("/static/img/logos/Login-Logo@2x.png");
     }
@@ -254,9 +270,11 @@ a.schedule {
 .sidebar {
     display: none;
     padding: 5px;
+
     .events-outer {
-        margin: 0px auto;
+        margin: 0 auto;
     }
+
     &.has-events {
         @media (min-width: 800px) {
             display: block;
@@ -270,14 +288,17 @@ a.schedule {
         background-color: #f2f2f4;
         overflow-y: auto;
     }
+
     &-trigger {
         display: none;
         cursor: pointer;
+
         &.has-events {
             @media (max-width: 800px) {
                 display: block;
             }
         }
+
         font-size: 30px;
         z-index: 99;
         position: fixed;
@@ -290,17 +311,19 @@ a.schedule {
         background: -moz-linear-gradient(top, #eaeaea 0%, #dadada 100%);
         background: -webkit-linear-gradient(top, #eaeaea 0%, #dadada 100%);
         background: linear-gradient(to bottom, #eaeaea 0%, #dadada 100%);
-        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#eaeaea', endColorstr='#dadada', GradientType=0);
+        filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#eaeaea', endColorstr='#dadada', GradientType=0);
         border: 1px solid #aaa;
         border-radius: 3px;
         padding: 0;
         margin: 0;
     }
+
     h1 {
         width: auto;
         height: auto;
-        line-height: auto;
+        line-height: initial;
     }
+
     h2 {
         margin-top: 5px;
     }

--- a/intranet/static/css/lostfound.scss
+++ b/intranet/static/css/lostfound.scss
@@ -1,11 +1,14 @@
 @import "colors";
+
 .items {
     min-width: 290px; // for 320x480 screens
     max-width: 1000px;
     margin-bottom: 100px;
+
     h2 {
         padding-left: 10px;
         line-height: 38px;
+
         &.category {
             font-size: 18px;
             font-weight: normal;
@@ -33,8 +36,9 @@ h4 {
     padding: 6px 10px;
     margin-bottom: 6px;
     overflow-x: auto;
-    behavior: url("/static/js/PIE/PIE.htc");
-    h3> a.item-link {
+    behavior: url("/static/js/vendor/PIE/PIE.htc");
+
+    h3 > a.item-link {
         cursor: pointer;
         color: $grey !important;
     }
@@ -42,6 +46,7 @@ h4 {
 
 .items-icon-wrapper {
     float: right;
+
     .item:hover & {
         display: block;
     }
@@ -57,10 +62,12 @@ h4 {
 .item-icon-wrapper {
     float: right;
     display: none;
+
     > a {
         color: $grey;
         text-decoration: none !important;
         padding-left: 2px;
+
         &:hover {
             color: rgb(32, 66, 224);
         }
@@ -74,6 +81,7 @@ h4 {
 .item-comment {
     position: relative;
     padding: 3px 5px;
+
     &-icons {
         position: absolute;
         right: 5px;
@@ -89,6 +97,7 @@ h4 {
     height: 35px;
     line-height: 35px;
     padding: 5px 0 5px 3px;
+
     .button {
         float: right;
         margin-top: -1px
@@ -110,6 +119,7 @@ h4 {
             padding-right: 0;
         }
     }
+
     .lost-items {
         padding-right: 20px;
     }

--- a/intranet/static/css/mobile.scss
+++ b/intranet/static/css/mobile.scss
@@ -9,10 +9,12 @@
         left: 50%;
         width: 438px;
         margin-left: -219px;
+
         li {
             float: left;
             min-width: 73px;
         }
+
         @media (max-width: 438px) {
             left: 0;
             margin-left: 0;

--- a/intranet/static/css/oauth.scss
+++ b/intranet/static/css/oauth.scss
@@ -41,6 +41,7 @@ input[type="text"], textarea {
     box-sizing: border-box;
     width: 100%;
 }
+
 input[readonly], textarea[readonly] {
     background-color: #ddd;
 }

--- a/intranet/static/css/page_base.scss
+++ b/intranet/static/css/page_base.scss
@@ -1,4 +1,5 @@
 @import "colors";
+
 b {
     font-weight: bold;
 }
@@ -43,6 +44,7 @@ h1 {
         -webkit-user-select: none;
         user-select: none;
     }
+
     .logo {
         background-image: url("/static/img/logos/Header-Logo.svg");
         background-size: auto 25px;
@@ -53,11 +55,13 @@ h1 {
         margin-left: 7px;
         float: left;
         z-index: 1043;
+
         .no-svg & {
             background-image: url("/static/img/logos/Header-Logo@2x.png");
             background-size: 30px 30px;
         }
     }
+
     .search {
         position: absolute;
         display: inline-block;
@@ -69,8 +73,9 @@ h1 {
         -moz-border-radius: 3px;
         border-radius: 3px;
         line-height: 20px;
-        behavior: url("/static/js/PIE/PIE.htc");
+        behavior: url("/static/js/vendor/PIE/PIE.htc");
         z-index: 1042;
+
         input[type="text"] {
             -moz-appearance: none;
             background-color: transparent;
@@ -87,13 +92,15 @@ h1 {
             box-shadow: none;
             float: left;
             z-index: 1042;
+
             &:focus {
                 outline: none;
             }
         }
     }
+
     .search-button {
-        font-family: "FontAwesome";
+        font-family: "FontAwesome", sans-serif;
         font-size: 13px;
         padding: 0 8px;
         float: right;
@@ -106,6 +113,7 @@ h1 {
         height: 24px;
         color: white;
         background: rgba(255, 255, 255, .1);
+
         &:hover,
         &:active,
         &:focus {
@@ -113,11 +121,13 @@ h1 {
             background: rgba(255, 255, 255, .3);
         }
     }
+
     .badged-item {
         display: inline-block;
         position: relative;
         padding: 0 10px;
         line-height: normal;
+
         .absence-icon {
             position: relative;
             display: inline-block;
@@ -127,11 +137,13 @@ h1 {
             text-align: center;
             width: 16px;
         }
+
         .dropdown-menu .absence-notification-icon {
             float: left;
             margin: 5px 20px 50px 5px;
         }
     }
+
     .badge-wrapper {
         display: inline-block;
         line-height: normal;
@@ -155,8 +167,8 @@ h1 {
     /* Non-flat UI */
     //text-shadow: 0 1px 0 rgb(173, 2, 11);
     //box-shadow: 0 1px 0 rgb(4, 33, 71);
-    behavior: url("/static/js/PIE/PIE.htc");
-    $colors: ( ('red', rgb(255, 72, 72)), ('darkred', rgb(181, 0, 0)), ('purple', rgb(175, 0, 175)), ('green', rgb(55, 179, 113)), ('yellow', rgb(234, 234, 13)), ('orange', rgb(255, 194, 81)), ('blue', rgb(66, 66, 206)), ('lightblue', rgb(0, 149, 255)));
+    behavior: url("/static/js/vendor/PIE/PIE.htc");
+    $colors: (('red', rgb(255, 72, 72)), ('darkred', rgb(181, 0, 0)), ('purple', rgb(175, 0, 175)), ('green', rgb(55, 179, 113)), ('yellow', rgb(234, 234, 13)), ('orange', rgb(255, 194, 81)), ('blue', rgb(66, 66, 206)), ('lightblue', rgb(0, 149, 255)));
     @each $color in $colors {
         $name: nth($color, 1);
         &.#{$name} {
@@ -168,15 +180,15 @@ h1 {
                 background: none;
                 @if $name=='yellow' {
                     color: black;
-                }
-                @else {
+                } @else {
                     color: nth($color, 1);
                 }
                 border: 1px solid nth($color,
-                1);
+                        1);
             }
         }
     }
+
     &.cancelled-badge {
         font-size: 15px;
         padding: 4px;
@@ -189,6 +201,7 @@ h1 {
     position: relative;
     padding: 0 10px 0 0;
     line-height: normal;
+
     .fa-user {
         margin-right: 1px;
         font-size: 17px;
@@ -216,23 +229,29 @@ h1 {
     list-style: none;
     z-index: 999;
     min-width: 140px;
+
     li {
         white-space: nowrap;
     }
+
     a {
         color: $grey;
         display: block;
+
         &:hover {
             text-decoration: none;
             color: rgb(150, 150, 150);
         }
+
         &.feedback {
             color: green;
+
             &:hover {
                 color: rgb(0, 200, 0);
             }
         }
     }
+
     /*
     i {
         font-size: 16px;
@@ -269,6 +288,7 @@ ul.dropdown-menu.absence-notification {
     height: 65px;
     margin-top: 20px;
     background-color: yellow;
+
     .arrow {
         border-bottom-color: yellow;
         right: 30px;
@@ -320,6 +340,7 @@ ul.dropdown-menu.absence-notification {
 .header .dropdown-menu a {
     line-height: 2em;
     padding: 0 10px;
+
     > i.fa-user {
         margin-right: 0;
     }
@@ -344,7 +365,8 @@ ul.dropdown-menu.absence-notification {
     float: left;
     padding: 1px 0;
     margin-bottom: 16px;
-    behavior: url("/static/js/PIE/PIE.htc");
+    behavior: url("/static/js/vendor/PIE/PIE.htc");
+
     a {
         display: block;
         padding: 9px 0;
@@ -353,17 +375,20 @@ ul.dropdown-menu.absence-notification {
         left: 0;
         width: 100%;
         cursor: pointer;
+
         &,
         &:active,
         &:visited {
             text-decoration: none;
             color: rgb(169, 169, 169);
         }
+
         &:hover {
             text-decoration: none;
             color: $grey;
         }
     }
+
     li {
         border: 1px solid rgb(220, 220, 220);
         //border: rgb(216, 216, 216);
@@ -371,15 +396,19 @@ ul.dropdown-menu.absence-notification {
         position: relative;
         height: 64px;
         list-style: none;
+
         &:first-child {
             margin-top: -2px;
         }
+
         &:last-child {
             margin-bottom: -2px;
         }
     }
+
     .selected {
         background-color: rgb(252, 252, 252);
+
         a {
             color: $grey;
         }
@@ -397,7 +426,6 @@ a i {
     display: block;
     width: 28px;
     height: 28px;
-    background-image: url("/static/img/icons.png");
     background-image: url("/static/img/icons.svg");
     background-size: 308px 84px; // retinafy w/ this
     margin-left: auto;
@@ -408,6 +436,7 @@ a i {
     display: block;
     min-width: 28px;
     text-align: center;
+
     ul.nav li a:hover & {
         color: rgb(0, 85, 164);
     }
@@ -419,9 +448,11 @@ a i {
     right: 20px;
     color: #f00;
     font-size: 16px;
+
     ul.nav li.selected a & {
         color: #f99;
     }
+
     ul.nav li:not(.selected) a:hover & {
         color: #c00;
     }
@@ -445,9 +476,11 @@ a i {
 
 .dashboard-icon {
     background-position: 0 0;
+
     .nav .selected & {
         background-position: 0 28px;
     }
+
     .nav li:not(.selected) a:hover & {
         background-position: 0 56px;
     }
@@ -455,9 +488,11 @@ a i {
 
 .eighth-icon {
     background-position: -28px 0;
+
     .nav .selected & {
         background-position: -28px 28px;
     }
+
     .nav li:not(.selected) a:hover & {
         background-position: -28px 56px;
     }
@@ -465,9 +500,11 @@ a i {
 
 .events-icon {
     background-position: -56px 0;
+
     .nav .selected & {
         background-position: -56px 28px;
     }
+
     .nav li:not(.selected) a:hover & {
         background-position: -56px 56px;
     }
@@ -475,9 +512,11 @@ a i {
 
 .groups-icon {
     background-position: -84px 0;
+
     .nav .selected & {
         background-position: -84px 28px;
     }
+
     .nav li:not(.selected) a:hover & {
         background-position: -84px 56px;
     }
@@ -485,9 +524,11 @@ a i {
 
 .polls-icon {
     background-position: -112px 0;
+
     .nav .selected & {
         background-position: -112px 28px;
     }
+
     .nav li:not(.selected) a:hover & {
         background-position: -112px 56px;
     }
@@ -495,9 +536,11 @@ a i {
 
 .files-icon {
     background-position: -140px 0;
+
     .nav .selected & {
         background-position: -140px 28px;
     }
+
     .nav li:not(.selected) a:hover & {
         background-position: -140px 56px;
     }
@@ -505,9 +548,11 @@ a i {
 
 .help-icon {
     background-position: -168px 0;
+
     .nav .selected & {
         background-position: -168px 28px;
     }
+
     .nav li:not(.selected) a:hover & {
         background-position: -168px 56px;
     }
@@ -515,9 +560,11 @@ a i {
 
 .print-icon {
     background-position: -196px 0;
+
     .nav .selected & {
         background-position: -196px 28px;
     }
+
     .nav li:not(.selected) a:hover & {
         background-position: -196px 56px;
     }
@@ -525,9 +572,11 @@ a i {
 
 .info-icon {
     background-position: -224px 0;
+
     .nav .selected & {
         background-position: -224px 28px;
     }
+
     .nav li:not(.selected) a:hover & {
         background-position: -224px 56px;
     }
@@ -535,9 +584,11 @@ a i {
 
 .bell-icon {
     background-position: -252px 0;
+
     .nav .selected & {
         background-position: -252px 28px;
     }
+
     .nav li:not(.selected) a:hover & {
         background-position: -252px 56px;
     }
@@ -545,9 +596,11 @@ a i {
 
 .bus-icon {
     background-position: -280px 0;
+
     .nav .selected & {
         background-position: -280px 28px;
     }
+
     .nav li:not(.selected) a:hover & {
         background-position: -280px 56px;
     }
@@ -576,7 +629,7 @@ a i {
     -webkit-border-radius: 3px;
     -moz-border-radius: 3px;
     border-radius: 3px;
-    behavior: url("/static/js/PIE/PIE.htc");
+    behavior: url("/static/js/vendor/PIE/PIE.htc");
 }
 
 .messenger button {
@@ -585,7 +638,7 @@ a i {
 }
 
 ul.messenger.messenger-fixed.messenger-on-top {
-    top: 50px!important;
+    top: 50px !important;
 }
 
 .selectize-control.single .selectize-input,
@@ -601,6 +654,7 @@ ul.messenger.messenger-fixed.messenger-on-top {
         box-shadow: 0 1px 0 rgba(0, 0, 0, .05), inset 0 1px 0 rgba(255, 255, 255, .8);
         // Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#f7f7f4+0,eaeaea+100;Button
     }
+
     &.multi .selectize-input {
         /* Fixes weird space at bottom*/
         overflow: inherit;

--- a/intranet/static/css/polls.form.scss
+++ b/intranet/static/css/polls.form.scss
@@ -1,14 +1,16 @@
 #add_question, #questions .add_choice {
     width: 150px;
 }
+
 #question_wrapper {
     padding-top: 10px;
     padding-bottom: 10px;
 }
-#questions  {
+
+#questions {
     .question {
         position: relative;
-        margin-left: 0px;
+        margin-left: 0;
         padding: 5px;
         margin-top: 5px;
         margin-bottom: 5px;
@@ -19,6 +21,7 @@
             width: 75%;
             float: left;
         }
+
         .max-container {
             width: 25%;
             float: left;
@@ -27,6 +30,7 @@
                 padding-left: 5px;
             }
         }
+
         [contenteditable="true"] {
             padding: 6px 3px;
             margin: 2px 0;
@@ -43,7 +47,7 @@
             box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075);
             vertical-align: middle;
             font-family: "Open Sans", "Helvetica Neue", sans-serif;
-            behavior: url(/static/js/PIE/PIE.htc);
+            behavior: url(/static/js/vendor/PIE/PIE.htc);
 
             &:focus {
                 outline: none;
@@ -51,17 +55,21 @@
             }
         }
     }
+
     .actions {
         position: absolute;
         top: 3px;
         right: 5px;
+
         .fa {
             cursor: pointer;
         }
+
         .fa:hover {
             color: #2042e0;
         }
     }
+
     .choice {
         position: relative;
         padding: 5px;
@@ -91,29 +99,36 @@ div.cke_chrome {
 .polls {
     table {
         width: 600px;
+
         th {
             min-width: 120px;
             vertical-align: top;
             padding-top: 10px;
         }
     }
+
     input, button {
         width: 100%;
         width: calc(100% - 8px);
     }
+
     .selectize-control {
         width: 100%;
     }
+
     .helptext {
         padding-left: 7px;
         display: inline-block;
     }
+
     .exp-buttons {
         padding-left: 7px;
     }
+
     th label {
         display: inline-block;
     }
+
     @media (max-width: 855px) {
         table {
             width: 342px !important;

--- a/intranet/static/css/polls.scss
+++ b/intranet/static/css/polls.scss
@@ -1,12 +1,15 @@
 @import "colors";
+
 .polls {
     min-width: 290px;
     /* for 320x480 screens */
     max-width: 1000px;
     margin-bottom: 100px;
+
     h2 {
         padding-left: 10px;
         line-height: 38px;
+
         &.category {
             font-size: 18px;
             font-weight: normal;
@@ -30,24 +33,30 @@
     padding: 6px 10px;
     margin-bottom: 6px;
     overflow-x: auto;
-    behavior: url("/static/js/PIE/PIE.htc");
-    h3> a.poll-link {
+    behavior: url("/static/js/vendor/PIE/PIE.htc");
+
+    h3 > a.poll-link {
         cursor: pointer;
         color: $grey !important;
     }
+
     .not-voted {
         color: #F57C00;
     }
+
     .voted {
         color: #388E3C;
     }
+
     .poll-content {
         b, strong {
             font-weight: bold;
         }
+
         i, em {
             font-style: italic;
         }
+
         ol {
             list-style-type: decimal;
             list-style-position: outside;
@@ -58,6 +67,7 @@
 
 .polls-icon-wrapper {
     float: right;
+
     .poll:hover & {
         display: block;
     }
@@ -72,10 +82,12 @@
 
 .poll-icon-wrapper {
     float: right;
+
     > a {
         color: $grey;
         text-decoration: none !important;
         padding-left: 2px;
+
         &:hover {
             color: rgb(32, 66, 224);
         }
@@ -96,6 +108,7 @@
     left: 270px;
     max-width: 280px;
     white-space: nowrap;
+
     .bottom-row.show-attend & {
         width: 280px;
     }
@@ -103,6 +116,7 @@
 
 .signup-status {
     color: gray;
+
     > a.button {
         margin-top: -2px;
         position: absolute;
@@ -121,6 +135,7 @@ a.button {
         margin-top: -3px;
         float: right;
     }
+
     &.no-attend-button {
         color: red;
         margin-top: -3px;
@@ -131,6 +146,7 @@ a.button {
 @media (max-width: 710px) {
     .poll .bottom-row {
         margin-bottom: 23px;
+
         .attend-status {
             left: 0;
             bottom: -27px;
@@ -146,6 +162,7 @@ a.button {
 @media (max-width: 1060px) {
     .announcements.primary-content .announcement .poll .bottom-row {
         margin-bottom: 23px;
+
         .attend-status {
             left: 0;
             bottom: -23px;
@@ -163,14 +180,14 @@ a.button {
 }
 
 ol.questions {
-    list-style: initial;
-    list-style-type: decimal;
+    list-style: decimal;
     margin-left: 20px;
 }
 
 ul.answers {
     list-style: none;
     margin-left: -20px;
+
     label.clear-vote {
         font-style: italic;
     }
@@ -178,9 +195,11 @@ ul.answers {
 
 .question {
     margin-left: 10px;
+
     .question-writing {
         width: 400px;
         height: 60px;
+
         &.short {
             width: 200px;
             height: 20px;
@@ -191,9 +210,11 @@ ul.answers {
 strong, b {
     font-weight: bold;
 }
+
 em, i {
     font-style: italic;
 }
+
 ol {
     list-style: decimal;
     padding-left: 25px;

--- a/intranet/static/css/preferences.scss
+++ b/intranet/static/css/preferences.scss
@@ -7,11 +7,12 @@ label[for=id_receive_push_notifications] {
 }
 
 table.notification-options {
-  width: 40vw;
-  td {
-    min-width: 20vw;
-    vertical-align: middle;
-  }
+    width: 40vw;
+
+    td {
+        min-width: 20vw;
+        vertical-align: middle;
+    }
 }
 
 table.privacy-options {
@@ -54,7 +55,7 @@ select {
 }
 
 .label {
-    padding: 8px 0px;
+    padding: 8px 0;
     font-weight: bold;
 }
 

--- a/intranet/static/css/profile.scss
+++ b/intranet/static/css/profile.scss
@@ -8,10 +8,12 @@
 
 .preferred-user-picture {
     float: left;
+
     img {
         margin: 0 20px;
         clear: both;
     }
+
     span {
         display: block;
         text-align: center;
@@ -37,10 +39,12 @@
     width: 100%;
     display: none;
     cursor: pointer;
+
     table {
         margin-left: auto;
         margin-right: auto;
     }
+
     td {
         text-align: center;
         margin-left: 9px;
@@ -51,28 +55,35 @@
     h2 {
         font-size: 30px;
     }
+
     h3,
     &-schedule h3 {
         font-size: 18px;
     }
-    table tr> th {
+
+    table tr > th {
         text-align: left;
         font-weight: bold;
         padding: 5px;
     }
+
     &-left {
         float: left;
         min-width: 400px;
     }
+
     &-contact {
         margin-right: 60px;
     }
+
     &-schedule {
         float: left;
     }
+
     &-eighth {
         clear: both;
         padding-top: 20px;
+
         .primary-content.eighth-signup & {
             padding-top: 0;
         }
@@ -89,7 +100,7 @@
     }
 }
 
-table.user-info-contact tr> * {
+table.user-info-contact tr > * {
     padding-bottom: 8px;
 }
 
@@ -97,6 +108,7 @@ table.user-info-contact tr> * {
     .user-pictures {
         margin-left: auto;
         margin-right: auto;
+
         td {
             display: block;
         }

--- a/intranet/static/css/responsive.core.scss
+++ b/intranet/static/css/responsive.core.scss
@@ -26,6 +26,7 @@ body.disable-scroll {
         width: 100%;
         height: auto;
         margin-top: 30px;
+
         .arrow {
             right: 148px;
         }
@@ -40,28 +41,32 @@ body.disable-scroll {
     .header {
         position: fixed;
         z-index: 1042;
-        .left> form.search {
+
+        .left > form.search {
             position: absolute;
             visibility: hidden;
             left: 17.5%;
             opacity: 0;
+
             body.mobile-nav-show & {
                 opacity: 1;
                 visibility: visible;
                 z-index: 1050;
             }
         }
-        &.has-badge .left> form.search {
+
+        &.has-badge .left > form.search {
             //width: 50%;
             //left: 20%;
         }
     }
-    .left> a.intranet-title {
+    .left > a.intranet-title {
         position: absolute;
         left: 50%;
         width: 170px;
         margin-left: -85px;
         z-index: 1045;
+
         body.mobile-nav-show & {
             opacity: 0;
             z-index: 1042;
@@ -71,7 +76,7 @@ body.disable-scroll {
     .absence-count-label {
         display: none;
     }
-    .right> li.notifications {
+    .right > li.notifications {
         display: none;
     }
     /* absence notification */
@@ -88,6 +93,7 @@ body.disable-scroll {
             height: 40px;
             cursor: pointer;
         }
+
         &-icon {
             display: block;
             position: absolute;
@@ -97,6 +103,7 @@ body.disable-scroll {
             width: 30px;
             text-align: center;
             cursor: pointer;
+
             > i {
                 font-size: 20px;
                 display: inline-block;
@@ -105,8 +112,8 @@ body.disable-scroll {
             }
         }
     }
-    .no-touch .left .dropdown-taparea:hover> .dropdown-icon,
-    .disable-scroll .dropdown-taparea> .dropdown-icon {
+    .no-touch .left .dropdown-taparea:hover > .dropdown-icon,
+    .disable-scroll .dropdown-taparea > .dropdown-icon {
         background-color: rgba(0, 0, 0, .2);
         border-radius: 5px;
     }
@@ -130,6 +137,7 @@ body.disable-scroll {
         transition-duration: 0.5s;
         */
         z-index: 1032;
+
         > li {
             padding: 0;
             height: 58px;
@@ -137,20 +145,25 @@ body.disable-scroll {
             border-left: none;
             border-color: rgb(90, 90, 90);
             text-align: left;
+
             .no-touch &:not(.selected):hover {
                 background-color: white;
             }
+
             > a {
                 padding: 20px 0;
                 margin: 0;
                 height: 18px;
+
                 .nav-alert-container {
                     display: inline-block;
                     float: left;
+
                     i.fa-exclamation-circle {
                         right: -2px;
                     }
                 }
+
                 i {
                     display: inline-block;
                     float: left;
@@ -162,7 +175,7 @@ body.disable-scroll {
             }
         }
     }
-    div.main> div.primary-content {
+    div.main > div.primary-content {
         padding-left: 0;
         margin-left: 0;
     }

--- a/intranet/static/css/responsive.scss
+++ b/intranet/static/css/responsive.scss
@@ -31,6 +31,7 @@
             width: 100%;
             width: calc(100% - 16px);
             margin-bottom: 10px;
+
             .widget {
                 position: relative;
                 left: 16px;
@@ -45,6 +46,7 @@
 @media (max-width: 550px) {
     .main div.widgets {
         width: 100%;
+
         .widget {
             position: static;
         }
@@ -64,6 +66,7 @@
     right: 120px;
     color: gray;
     z-index: -1;
+
     .arrow {
         &-left {
             position: absolute;
@@ -72,6 +75,7 @@
             font-size: 30px;
             color: gray;
         }
+
         &-right {
             position: absolute;
             top: -20px;
@@ -91,15 +95,19 @@
         div#activity-detail {
             width: 250px;
         }
+
         .search-wrapper {
             margin-right: 271px;
         }
+
         div#activity-list {
             right: 270px;
+
             li span.activity-sponsors {
                 margin-right: 0;
             }
         }
+
         h5.stuck {
             margin-right: 270px;
         }
@@ -108,6 +116,7 @@
         .middle .desktop-info {
             display: none;
         }
+
         h5.all-header .clear-button {
             margin-right: 20px;
         }
@@ -125,6 +134,7 @@
     z-index: 1001;
     background-color: rgba(169, 169, 169, .3);
     cursor: pointer;
+
     > i {
         position: absolute;
         top: 50%;
@@ -157,18 +167,22 @@
         div#activity-list {
             right: 0;
         }
+
         h5.stuck,
         .search-wrapper {
             margin-right: 0;
         }
+
         .backbtn.visible {
             display: block;
             opacity: 1;
         }
+
         &.visible div#activity-detail {
             margin-right: 100%;
             width: 85%;
         }
+
         div#activity-list li span.activity-sponsors {
             margin-right: 0;
         }
@@ -178,14 +192,17 @@
             right: -100%;
             z-index: 1002;
         }
+
         .middle {
             height: 20px;
+
             h2,
             h4 {
                 display: inline;
                 padding-right: 5px;
             }
         }
+
         #activity-list h5 .clear-button {
             margin-right: 0;
         }
@@ -194,6 +211,7 @@
     .block-title .block-comments {
         display: inline-block;
         clear: left;
+
         > span {
             display: none;
         }
@@ -208,21 +226,26 @@
             .block-title {
                 display: table-cell;
                 margin: 10px 6px;
+
                 h2 {
                     font-size: 16px;
                 }
             }
+
             .switch {
                 display: table-cell;
                 vertical-align: middle;
                 cursor: pointer;
+
                 i {
                     font-size: 25px;
                     padding-right: 2px;
+
                     &.down {
                         opacity: 1;
                         display: inline;
                     }
+
                     &.up {
                         opacity: 0;
                         display: none;
@@ -230,27 +253,33 @@
                 }
             }
         }
+
         &.viewing {
             margin-top: -120px;
+
             .middle .switch i {
                 &.down {
                     opacity: 0;
                     display: none;
                 }
+
                 &.up {
                     opacity: 1;
                     display: inline;
                 }
             }
         }
+
         #activity-list {
             /* increase padding on activity list */
             li {
                 padding: 3px;
+
                 &.search-hide {
                     padding: 0;
                 }
             }
+
             .activity-ids {
                 display: none;
             }
@@ -272,6 +301,7 @@
         -ms-transition: all 0.2s ease;
         -o-transition: all 0.2s ease;
     }
+
     @media (max-width: 430px) {
         .middle .switch {
             //position: absolute;
@@ -292,6 +322,7 @@
             height: auto;
             padding-left: 0;
         }
+
         tr &:last-of-type:not(:first-of-type) {
             padding-left: 0;
         }

--- a/intranet/static/css/schedule.scss
+++ b/intranet/static/css/schedule.scss
@@ -8,12 +8,14 @@
             padding-right: 14px;
             white-space: nowrap;
         }
+
         td {
             text-align: left;
             width: 100px;
             vertical-align: middle;
             white-space: nowrap;
         }
+
         /*
         &.current th {
             &:before {
@@ -55,18 +57,22 @@ body {
     table-layout: fixed;
     width: 100%;
     min-width: 1100px;
+
     td {
         text-align: center;
         width: 19%;
         min-width: 175px;
+
         h2 {
             font-weight: normal;
         }
+
         &.today {
             h2 {
                 font-weight: bold;
             }
         }
+
         &.chevron {
             width: 2.5%;
         }
@@ -88,10 +94,12 @@ body {
         color: blue;
         //color: rgb(0, 72, 171)?
     }
+
     &.day-type-red {
         color: red;
         //color: rgb(171, 0, 72)?
     }
+
     &.day-type-anchor {
         color: green;
         //color: rgb(72, 171, 0)?
@@ -104,9 +112,11 @@ a.day-name.day-type-other {
 
 tr.schedule-block.current {
     font-weight: bold;
+
     .week-table & {
         font-weight: normal;
     }
+
     .today & {
         font-weight: bold;
     }
@@ -116,11 +126,13 @@ tr.schedule-block.current {
     text-align: center;
     vertical-align: center;
     width: 100%;
+
     & .month-name {
         font-size: 25px;
         font-weight: bold;
         padding: 5%;
     }
+
     & .fa {
         color: black;
     }

--- a/intranet/static/css/schedule.widget.scss
+++ b/intranet/static/css/schedule.widget.scss
@@ -1,6 +1,8 @@
 @import 'colors';
+
 .widget-content.schedule {
     width: 100%;
+
     .eighth-block,
     .block-header,
     .block-signup,
@@ -20,11 +22,12 @@
 
 .schedule-widget {
     font-size: 13px;
+
     .widget-title h2 {
         width: 100%;
-        overflow-x: ellipsis;
         overflow: hidden;
     }
+
     .schedule h2 {
         margin: 0;
         font-size: 14px;
@@ -33,6 +36,7 @@
         display: inline-block;
         vertical-align: top;
     }
+
     .bellschedule-table {
         margin-left: auto;
         display: inline-block;
@@ -40,6 +44,7 @@
         margin-top: 5px;
         margin-bottom: 5px;
         float: right;
+
         .day-name-cell {
             text-align: center;
         }
@@ -54,21 +59,25 @@
         display: inline-block;
         color: $grey;
     }
+
     &:hover i {
         text-decoration: none;
         color: rgb(32, 66, 224);
     }
+
     .fa-chevron-left,
     .fa-chevron-right {
         text-align: left;
         cursor: pointer;
     }
+
     &.schedule {
         &-left {
             float: left;
             width: 10px;
             cursor: pointer;
         }
+
         &-right {
             float: right;
             width: 10px;
@@ -87,6 +96,7 @@
     line-height: 22px;
     width: calc(100% - 20px);
     float: left;
+
     a.button {
         margin-top: 1px;
     }

--- a/intranet/static/css/signage.base.scss
+++ b/intranet/static/css/signage.base.scss
@@ -7,7 +7,7 @@ body.signage {
 
     background-color: #f2f2f4;
     overflow: hidden;
-    
+
     ::-webkit-scrollbar {
         display: none;
     }
@@ -60,10 +60,12 @@ section.signage-section {
 
         text-align: center;
     }
+
     img.tjlogo {
         width: 60%;
         max-width: 200px;
     }
+
     .name {
         color: black;
         margin: 50px 0;
@@ -71,10 +73,12 @@ section.signage-section {
         font-size: 36px;
         width: 100%;
     }
+
     .time {
         font-size: 36px;
         font-weight: bold;
     }
+
     .schedule {
         margin-left: 0;
         margin-top: 0;
@@ -125,8 +129,8 @@ section.signage-section {
         display: block;
 
         * {
-           // otherwise, clicking on buttons sometimes registers as a click on the icon.
-           pointer-events: none;
+            // otherwise, clicking on buttons sometimes registers as a click on the icon.
+            pointer-events: none;
         }
     }
 
@@ -174,7 +178,8 @@ section.signage-section {
             padding: 0 20px;
         }
     }
-    section.signage-section iframe.signage-iframe  {
+
+    section.signage-section iframe.signage-iframe {
         width: 100%;
         height: calc(95vh - 20px);
     }

--- a/intranet/static/css/signage.touch.landscape.scss
+++ b/intranet/static/css/signage.touch.landscape.scss
@@ -4,8 +4,7 @@ ul.nav {
 
 .nav-icon, .nav li i.fa.fa-fix {
     float: left;
-    margin: -6px 22px;
-    margin-right: -20px;
+    margin: 22px -20px 22px 22px;
 }
 
 section {
@@ -16,9 +15,11 @@ section {
     left: 0;
     width: 100%;
     margin-left: 0;
+
     .center {
         height: 50%;
     }
+
     .tjlogo {
         height: 100px;
         width: 100px;
@@ -27,14 +28,15 @@ section {
         margin: -50px;
         top: 50%;
     }
+
     .time {
         position: absolute;
         top: 50%;
-        margin: 75px 0;
         left: 25%;
         width: 100px;
-        margin-left: -50px;
+        margin: 75px 0 75px -50px;
     }
+
     .schedule-outer {
         position: absolute;
         top: 50%;

--- a/intranet/static/css/theme.blue.scss
+++ b/intranet/static/css/theme.blue.scss
@@ -1,10 +1,12 @@
 @import 'colors';
+
 $color1: #0048ab;
 $color2: rgb(1, 94, 222);
 $color3: rgb(242, 242, 244);
 $color4: rgb(136, 148, 160);
 $color5: rgb(60, 105, 182);
 $color6: rgb(0, 85, 164);
+
 .header {
     background-color: $color1;
     //background: -webkit-linear-gradient($color1, $color2);
@@ -21,6 +23,7 @@ $color6: rgb(0, 85, 164);
 .widget-title {
     border-bottom-color: $color1;
     font-weight: bold;
+
     a.ui-link {
         color: $color1;
         text-decoration: underline;
@@ -35,21 +38,25 @@ $color6: rgb(0, 85, 164);
 
 ul.nav {
     background-color: white;
-    border: 1px solid $color1;
-    border-color: $color4;
+    border: 1px solid $color4;
+
     li.selected {
         background-color: $color5;
+
         a {
             color: white;
         }
     }
+
     li:not(.selected) a:hover i {
         color: $color6;
     }
+
     a:hover {
         color: $color2;
     }
-    .main &> li {
+
+    .main & > li {
         //border-color: $color1;
         border-color: $color4;
     }
@@ -66,9 +73,11 @@ ul.nav {
 
 body.login-page input {
     border: 1px solid fade_out($color1, 0.7);
+
     &[type=submit] {
         border: 1px solid fade_out($color1, 0.7);
         color: $color1;
+
         &.load-spinner {
             border-color: transparent;
             background: transparent;

--- a/intranet/static/css/themes.scss
+++ b/intranet/static/css/themes.scss
@@ -1,6 +1,8 @@
 @import 'colors';
-$patterns: ( ('weave', "pixel_weave"), ('boxes', "pw_pattern"), ('transparency', "ps_neutral"));
-$colors: ( ('grey', $grey), ('blue', rgb(0, 0, 200)), ('light-blue', rgb(0, 100, 160)), ('red', rgb(193, 23, 23)), ('green', rgb(20, 115, 20)), ('violet', rgb(51, 51, 175)), ('purple', rgb(120, 0, 120)));
+
+$patterns: (('weave', "pixel_weave"), ('boxes', "pw_pattern"), ('transparency', "ps_neutral"));
+$colors: (('grey', $grey), ('blue', rgb(0, 0, 200)), ('light-blue', rgb(0, 100, 160)), ('red', rgb(193, 23, 23)), ('green', rgb(20, 115, 20)), ('violet', rgb(51, 51, 175)), ('purple', rgb(120, 0, 120)));
+
 body.theme {
     @each $pattern in $patterns {
         $name: nth($pattern, 1);

--- a/intranet/static/css/welcome.scss
+++ b/intranet/static/css/welcome.scss
@@ -9,10 +9,10 @@ body {
 
 #welcome-container {
     position: absolute;
-    left: 0px;
-    top: 0px;
-    bottom: 0px;
-    right: 0px;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    right: 0;
     z-index: 9999;
     background-color: rgba(128, 128, 128, 0.5);
     overflow-y: auto;
@@ -47,7 +47,7 @@ body {
 
 #ion-welcome h2 {
     font-size: 40px;
-    font-family: Roboto;
+    font-family: Roboto, sans-serif;
     text-align: center;
 }
 
@@ -78,21 +78,21 @@ body {
 }
 
 @-webkit-keyframes animBg {
-   0% {
-     background-position-x: 0px;
-   }
-   100% {
-     background-position-x: 500px;
-   }
+    0% {
+        background-position-x: 0;
+    }
+    100% {
+        background-position-x: 500px;
+    }
 }
 
 @keyframes animBg {
-   0% {
-     background-position-x: 0px;
-   }
-   100% {
-     background-position-x: 500px;
-   }
+    0% {
+        background-position-x: 0;
+    }
+    100% {
+        background-position-x: 500px;
+    }
 }
 
 .ion-welcome-icons {


### PR DESCRIPTION
# Description
- Reformat all SCSS code.
- Remove redundant styles, such as declaring `padding-top: 0;` and then saying `padding: 0;` right under it.
- Fix broken pointers to files, such as the broken calls to the PIE library.

# Related Issues
#466 - We've already transitioned to SCSS, close this issue.