### PR TITLE
Set type attribute on poll short answer inputs

### DIFF
--- a/intranet/templates/polls/vote.html
+++ b/intranet/templates/polls/vote.html
@@ -130,7 +130,8 @@
                                       placeholder="Answer here..."
                             >{% if q.current_vote %}{{ q.current_vote.answer|escape }}{% endif %}</textarea>
                         {% elif q.type == "SRE" %}
-                            <input id="question-{{ q.num }}-writing"
+                            <input type="text"
+                                      id="question-{{ q.num }}-writing"
                                       name="question-{{ q.num }}"
                                       class="question-writing short"
                                       placeholder="Answer here..."


### PR DESCRIPTION
For some reason, the "type" attribute is not set for "Short answer" inputs. This means that the custom styles for text inputs are not applied, which slightly changes the way they are displayed.