### PR TITLE
Allow the user to set a null bus route on the preferences page

### DIFF
--- a/intranet/apps/preferences/forms.py
+++ b/intranet/apps/preferences/forms.py
@@ -17,7 +17,7 @@ class BusRouteForm(forms.Form):
         routes = Route.objects.all()
         for route in routes:
             self.BUS_ROUTE_CHOICES += [(route.route_name, route.route_name)]
-        self.fields['bus_route'] = forms.ChoiceField(choices=self.BUS_ROUTE_CHOICES, widget=forms.Select)
+        self.fields['bus_route'] = forms.ChoiceField(choices=self.BUS_ROUTE_CHOICES, widget=forms.Select, required=False)
 
 
 class PreferredPictureForm(forms.Form):

--- a/intranet/apps/preferences/tests.py
+++ b/intranet/apps/preferences/tests.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.urls import reverse
 
 from ..users.models import User
+from ..bus.models import Route
 from ...test.ion_test import IonTestCase
 
 
@@ -10,6 +11,7 @@ class PreferencesTest(IonTestCase):
 
     def setUp(self):
         User.objects.get_or_create(username="awilliam", id="99999", graduation_year=settings.SENIOR_GRADUATION_YEAR + 1)
+        Route.objects.get_or_create(route_name="AB-123", space="", bus_number="")
 
     def test_get_preferences(self):
         self.login()
@@ -44,7 +46,8 @@ class PreferencesTest(IonTestCase):
             'pf-0-user': ['99999'],
             'wf-0-user': ['99999'],
             'pf-MAX_NUM_FORMS': ['1000'],
-            'show_pictures': ['on']
+            'show_pictures': ['on'],
+            'bus_route': ['AB-123'],
         }
         response = self.client.post(reverse('preferences'), settings_dict)
         self.assertEqual(response.status_code, 302)
@@ -88,7 +91,8 @@ class PreferencesTest(IonTestCase):
             'ef-0-DELETE': ['on'],
             'pf-0-user': ['99999'],
             'ef-1-user': ['99999'],
-            'show_pictures': ['on']
+            'show_pictures': ['on'],
+            'bus_route': [''],
         }
         with self.assertLogs("intranet.apps.preferences.views", "DEBUG") as logger:
             response = self.client.post(reverse('preferences'), pref_dict)
@@ -96,4 +100,6 @@ class PreferencesTest(IonTestCase):
             "DEBUG:intranet.apps.preferences.views:Unable to set field phones with value []"
             ": Can not set User attribute 'phones' -- not in user attribute list."
         ])
+        for line in logger.output:
+            self.assertFalse("Error processing Bus Route Form" in line)
         self.assertEqual(response.status_code, 302)

--- a/intranet/apps/preferences/views.py
+++ b/intranet/apps/preferences/views.py
@@ -228,15 +228,22 @@ def save_bus_route(request, user):
                 else:
                     logger.debug("{}: new: {} from: {}".format(field, fields[field], bus_route[field] if field in bus_route else None))
                     try:
-                        route = Route.objects.get(route_name=fields[field])
+                        if fields[field]:
+                            route = Route.objects.get(route_name=fields[field])
+                        else:
+                            route = None
                         setattr(user, field, route)
                         user.save()
                     except Exception as e:
                         # TODO: replace with better error handling
                         logger.error("Error processing Bus Route Form: {}".format(e))
                     try:
-                        messages.success(request, "Set field {} to {}".format(field, fields[field]
-                                                                              if not isinstance(fields[field], list) else ", ".join(fields[field])))
+                        if fields[field]:
+                            messages.success(request, "Set field {} to {}".format(field, fields[field]
+                                                                                  if not isinstance(fields[field], list)
+                                                                                  else ", ".join(fields[field])))
+                        else:
+                            messages.success(request, "Cleared field {}".format(field))
                     except TypeError:
                         pass
     return bus_route_form


### PR DESCRIPTION
Makes it possible to save the preferences page without setting a bus route if the user hasn't done that yet. Also actually add some tests for the bus route form.