### PR TITLE
Clean up parts of the codebase

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -194,6 +194,7 @@ intranet/apps/bus/models.py
 intranet/apps/bus/tests.py
 intranet/apps/bus/urls.py
 intranet/apps/bus/views.py
+intranet/apps/bus/management/commands/__init__.py
 intranet/apps/bus/management/commands/import_routes.py
 intranet/apps/bus/management/commands/reset_routes.py
 intranet/apps/bus/migrations/0001_initial.py

--- a/intranet/apps/announcements/models.py
+++ b/intranet/apps/announcements/models.py
@@ -119,7 +119,7 @@ class Announcement(models.Model):
     @property
     def user_map(self):
         try:
-            return self._user_map # pylint: disable=E1101; Defined via a related_name in AnnouncementUserMap
+            return self._user_map  # pylint: disable=E1101; Defined via a related_name in AnnouncementUserMap
         except AnnouncementUserMap.DoesNotExist:
             return AnnouncementUserMap.objects.create(announcement=self)
 

--- a/intranet/apps/announcements/models.py
+++ b/intranet/apps/announcements/models.py
@@ -119,7 +119,7 @@ class Announcement(models.Model):
     @property
     def user_map(self):
         try:
-            return self._user_map
+            return self._user_map # pylint: disable=E1101; Defined via a related_name in AnnouncementUserMap
         except AnnouncementUserMap.DoesNotExist:
             return AnnouncementUserMap.objects.create(announcement=self)
 

--- a/intranet/apps/announcements/notifications.py
+++ b/intranet/apps/announcements/notifications.py
@@ -98,7 +98,7 @@ def announcement_approved_email(request, obj, req):
     base_url = request.build_absolute_uri(reverse('index'))
     url = request.build_absolute_uri(reverse('view_announcement', args=[obj.id]))
 
-    if len(teacher_emails) > 0:
+    if teacher_emails:
         data = {"announcement": obj, "request": req, "info_link": url, "base_url": base_url, "role": "approved"}
         email_send("announcements/emails/announcement_approved.txt", "announcements/emails/announcement_approved.html", data, subject, teacher_emails)
         messages.success(request, "Sent teacher approved email to {} users".format(len(teacher_emails)))
@@ -131,7 +131,7 @@ def announcement_posted_email(request, obj, send_all=False):
         emails = []
         users_send = []
         for u in users:
-            if len(send_groups) == 0:
+            if not send_groups:
                 # no groups, public.
                 em = u.emails.first() if u.emails.count() >= 1 else u.tj_email
                 if em:

--- a/intranet/apps/auth/backends.py
+++ b/intranet/apps/auth/backends.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import uuid
+import subprocess
 
 from django.conf import settings
 # from django.utils.decorators import method_decorator
@@ -11,7 +12,6 @@ from django.contrib.auth.hashers import check_password
 # from django.views.decorators.debug import sensitive_variables
 
 import pexpect
-import subprocess
 
 from ..users.models import User
 

--- a/intranet/apps/dashboard/views.py
+++ b/intranet/apps/dashboard/views.py
@@ -51,7 +51,7 @@ def gen_schedule(user, num_blocks=6, surrounding_blocks=None):
     if surrounding_blocks is None:
         surrounding_blocks = EighthBlock.objects.get_upcoming_blocks(num_blocks)
 
-    if len(surrounding_blocks) == 0:
+    if not surrounding_blocks:
         return None, False
 
     # Use select_related to reduce query count

--- a/intranet/apps/dataimport/management/commands/import_sis.py
+++ b/intranet/apps/dataimport/management/commands/import_sis.py
@@ -6,10 +6,11 @@ import json
 import csv
 import re
 import time
-from django.core.management.base import BaseCommand
-from intranet.apps.users.models import User
-
 from typing import Dict, List  # noqa
+
+from django.core.management.base import BaseCommand
+
+from intranet.apps.users.models import User
 
 
 class Command(BaseCommand):

--- a/intranet/apps/dataimport/management/commands/import_sis.py
+++ b/intranet/apps/dataimport/management/commands/import_sis.py
@@ -85,13 +85,13 @@ class Command(BaseCommand):
             else:
                 users = self.load_gen_users()
                 self.stdout.write("Faking teachers...")
-                for i in range(len(users)):
-                    for classid in users[i]["classes"]:
-                        classobj = users[i]["classes"][classid]
+                for user in users:
+                    for classid in user["classes"]:
+                        classobj = user["classes"][classid]
                         classobj["Room"] = "Dome"
                         classobj["TeacherStaffName"] = "Glazer, E."
                         classobj["Teacher"] = "Glazer, Evan"
-                        users[i]["classes"][classid] = classobj
+                        user["classes"][classid] = classobj
 
                 open("users_faked.json", "w").write(json.dumps(users))
         else:
@@ -100,16 +100,14 @@ class Command(BaseCommand):
         if os.path.isfile("users_uids.json"):
             self.stdout.write("Loading user existence/UIDnumbers info...")
             self.uidmap = json.loads(open("users_uids.json", "r").read())
-            for i in range(len(users)):
-                user = users[i]
+            for user in users:
                 tjuser = user["user"]["TJUsername"].lower()
                 user["uidNumber"] = self.uidmap[tjuser]["uidNumber"]
                 user["ldapExists"] = self.uidmap[tjuser]["ldapExists"]
             self.stdout.write("Loaded")
         else:
             self.stdout.write("Check for user existence/generate iodineUidNumbers")
-            for i in range(len(users)):
-                user = users[i]
+            for user in users:
                 tjuser = user["user"]["TJUsername"].lower()
                 try:
                     ionuser = User.objects.get(username__iexact=tjuser)
@@ -127,8 +125,7 @@ class Command(BaseCommand):
             open("users_uids.json", "w").write(json.dumps(self.uidmap))
 
         self.stdout.write("Either add or modify accounts in LDAP")
-        for i in range(len(users)):
-            user = users[i]
+        for user in users:
             if user["ldapExists"]:
                 self.stdout.write("%s MODIFY %s" % (user["user"]["TJUsername"], user["uidNumber"]))
                 self.update_ldap_user(user)
@@ -143,8 +140,8 @@ class Command(BaseCommand):
         else:
             self.stdout.write("Handle schedules")
             self.schedules = {}
-            for i in range(len(users)):
-                classes = users[i]["classes"]
+            for user in users:
+                classes = user["classes"]
                 for sid in classes:
                     if sid not in self.schedules:
                         self.schedules[sid] = classes[sid]

--- a/intranet/apps/dataimport/management/commands/import_sis.py
+++ b/intranet/apps/dataimport/management/commands/import_sis.py
@@ -411,7 +411,7 @@ replace: enrolledclass
         return {"M": "Mr.", "F": "Ms."}[gender]
 
     def format_display_name(self, data):
-        if len(data["user"]["MiddleName"] or "") > 0:
+        if data["user"]["MiddleName"]:
             return "{} {} {}".format(data["user"]["FirstName"], data["user"]["MiddleName"], data["user"]["LastName"])
 
         return "{} {}".format(data["user"]["FirstName"], data["user"]["LastName"])

--- a/intranet/apps/eighth/forms/admin/activities.py
+++ b/intranet/apps/eighth/forms/admin/activities.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 
 import logging
+from typing import List  # noqa
 
 from django import forms
 from django.db.models import Q
 
 from ...models import EighthActivity, EighthScheduledActivity
 from ....users.models import User
-
-from typing import List  # noqa
 
 logger = logging.getLogger(__name__)
 

--- a/intranet/apps/eighth/models.py
+++ b/intranet/apps/eighth/models.py
@@ -749,7 +749,7 @@ class EighthScheduledActivity(AbstractBaseEighthModel):
         overrides."""
 
         sponsors = self.sponsors.all()
-        if len(sponsors) > 0:
+        if sponsors:
             return sponsors
         else:
             return self.activity.sponsors.all()
@@ -774,7 +774,7 @@ class EighthScheduledActivity(AbstractBaseEighthModel):
         overrides."""
 
         rooms = self.rooms.all()
-        if len(rooms) > 0:
+        if rooms:
             return rooms
         else:
             return self.activity.rooms.all()
@@ -1389,7 +1389,7 @@ class EighthSignup(AbstractBaseEighthModel):
         if self.scheduled_activity.activity and self.scheduled_activity.activity.sticky:
             exception.Sticky = True
 
-        if len(exception.messages()) > 0 and not force:
+        if exception.messages() and not force:
             raise exception
         else:
             block = self.scheduled_activity.block

--- a/intranet/apps/eighth/models.py
+++ b/intranet/apps/eighth/models.py
@@ -7,10 +7,10 @@ from django.conf import settings
 from django.contrib.auth.models import Group as DjangoGroup
 from django.core.cache import cache
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
-from simple_history.models import HistoricalRecords
 from django.db import models, transaction
 from django.db.models import Manager, Q, Count
 from django.utils import formats
+from simple_history.models import HistoricalRecords
 
 from . import exceptions as eighth_exceptions
 from ..notifications.emails import email_send

--- a/intranet/apps/eighth/models.py
+++ b/intranet/apps/eighth/models.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=C0302; Allow more than 1000 lines
 import datetime
 import logging
 from itertools import chain

--- a/intranet/apps/eighth/models.py
+++ b/intranet/apps/eighth/models.py
@@ -149,7 +149,7 @@ class EighthRoom(AbstractBaseEighthModel):
 class EighthActivityExcludeDeletedManager(models.Manager):
 
     def get_queryset(self):
-        return (super(EighthActivityExcludeDeletedManager, self).get_queryset().exclude(deleted=True))
+        return super(EighthActivityExcludeDeletedManager, self).get_queryset().exclude(deleted=True)
 
 
 class EighthActivity(AbstractBaseEighthModel):
@@ -546,7 +546,7 @@ class EighthBlock(AbstractBaseEighthModel):
     def signup_time_future(self):
         """Is the signup time in the future?"""
         now = datetime.datetime.now()
-        return (now.date() < self.date or (self.date == now.date() and self.signup_time > now.time()))
+        return now.date() < self.date or (self.date == now.date() and self.signup_time > now.time())
 
     def date_in_past(self):
         """Is the block's date in the past?
@@ -555,7 +555,7 @@ class EighthBlock(AbstractBaseEighthModel):
 
         """
         now = datetime.datetime.now()
-        return (now.date() > self.date)
+        return now.date() > self.date
 
     def in_clear_absence_period(self):
         """Is the current date in the block's clear absence period?
@@ -606,7 +606,7 @@ class EighthBlock(AbstractBaseEighthModel):
         """Display the date and block letter (mm/dd B, for example: '9/1 B')
 
         """
-        return ("{} {}".format(self.date.strftime("%m/%d"), self.block_letter))
+        return "{} {}".format(self.date.strftime("%m/%d"), self.block_letter)
 
     @property
     def is_this_year(self):
@@ -869,7 +869,7 @@ class EighthScheduledActivity(AbstractBaseEighthModel):
         # Presign activities can only be signed up for 2 days in advance.
         presign_period = datetime.timedelta(days=2)
 
-        return (now < (activity_date - presign_period))
+        return now < (activity_date - presign_period)
 
     def has_open_passes(self):
         """Return whether there are passes that have not been acknowledged."""
@@ -1292,7 +1292,7 @@ class EighthSignupManager(Manager):
         self.create(user=user, scheduled_activity=scheduled_activity, **kwargs)
 
     def get_absences(self):
-        return (EighthSignup.objects.filter(was_absent=True, scheduled_activity__attendance_taken=True))
+        return EighthSignup.objects.filter(was_absent=True, scheduled_activity__attendance_taken=True)
 
 
 class EighthSignup(AbstractBaseEighthModel):

--- a/intranet/apps/eighth/views/activities.py
+++ b/intranet/apps/eighth/views/activities.py
@@ -224,7 +224,7 @@ def calculate_statistics(activity, start_date=None, all_years=False, year=None, 
     else:
         average_signups = 0
 
-    if len(signups) > 0:
+    if signups:
         average_user_signups = round(total_signups / len(signups), 2)
     else:
         average_user_signups = 0

--- a/intranet/apps/eighth/views/activities.py
+++ b/intranet/apps/eighth/views/activities.py
@@ -4,23 +4,22 @@ import csv
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
+from io import BytesIO
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, render
 from django.http import HttpResponse
 
-from ..models import EighthActivity, EighthBlock, EighthScheduledActivity
-from ..utils import get_start_date
-from ....utils.date import get_date_range_this_year
-from ....utils.serialization import safe_json
-
-from io import BytesIO
-
 from reportlab.lib.pagesizes import letter
 from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 from reportlab.lib.units import inch
 from reportlab.platypus import PageBreak, Paragraph, SimpleDocTemplate, Spacer, Table
+
+from ..models import EighthActivity, EighthBlock, EighthScheduledActivity
+from ..utils import get_start_date
+from ....utils.date import get_date_range_this_year
+from ....utils.serialization import safe_json
 
 logger = logging.getLogger(__name__)
 

--- a/intranet/apps/eighth/views/admin/activities.py
+++ b/intranet/apps/eighth/views/admin/activities.py
@@ -58,7 +58,7 @@ def edit_activity_view(request, activity_id):
                 old_sponsor_ids = old_sponsors.values_list("id", flat=True)
                 new_sponsor_ids = [s.id for s in form.cleaned_data["sponsors"]]
 
-                if set(old_sponsor_ids) != set(new_sponsor_ids) and len(old_sponsor_ids) > 0:
+                if set(old_sponsor_ids) != set(new_sponsor_ids) and old_sponsor_ids:
                     start_date = get_start_date(request)
                     sched_acts_default = EighthScheduledActivity.objects.filter(activity=activity, sponsors=None, block__date__lt=start_date)
 
@@ -106,7 +106,7 @@ def edit_activity_view(request, activity_id):
                 old_room_ids = old_rooms.values_list("id", flat=True)
                 new_room_ids = [r.id for r in form.cleaned_data["rooms"]]
 
-                if set(old_room_ids) != set(new_room_ids) and len(old_room_ids) > 0:
+                if set(old_room_ids) != set(new_room_ids) and old_room_ids:
                     start_date = get_start_date(request)
                     sched_acts_default = EighthScheduledActivity.objects.filter(activity=activity, rooms=None, block__date__lt=start_date)
 

--- a/intranet/apps/eighth/views/admin/attendance.py
+++ b/intranet/apps/eighth/views/admin/attendance.py
@@ -357,7 +357,7 @@ def out_of_building_schedules_view(request, block_id=None):
     if block is not None:
         rooms = EighthRoom.objects.filter(name__icontains="out of building")
 
-        if len(rooms) > 0:
+        if rooms:
             rooms_filter = Q(scheduled_activity__rooms__in=rooms) | (
                 Q(scheduled_activity__rooms=None) & Q(scheduled_activity__activity__rooms__in=rooms))
             signups = (EighthSignup.objects.filter(scheduled_activity__block=block).filter(rooms_filter)

--- a/intranet/apps/eighth/views/admin/blocks.py
+++ b/intranet/apps/eighth/views/admin/blocks.py
@@ -56,13 +56,13 @@ def add_block_view(request):
             logger.debug(letters)
             logger.debug(current_letters)
             for l in letters:
-                if len(l) == 0:
+                if not l:
                     continue
                 if l not in current_letters:
                     EighthBlock.objects.create(date=fmtdate, block_letter=l)
                     messages.success(request, "Successfully added {} Block on {}".format(l, fmtdate))
             for l in current_letters:
-                if len(l) == 0:
+                if not l:
                     continue
                 if l not in letters:
                     EighthBlock.objects.get(date=fmtdate, block_letter=l).delete()

--- a/intranet/apps/eighth/views/admin/blocks.py
+++ b/intranet/apps/eighth/views/admin/blocks.py
@@ -195,7 +195,7 @@ def delete_block_view(request, block_id):
             "admin_page_title": "Delete Block",
             "item_name": str(block),
             "help_text": "Deleting this block will remove all records "
-            "of it related to eighth period."
+                         "of it related to eighth period."
         }
 
         return render(request, "eighth/admin/delete_form.html", context)

--- a/intranet/apps/eighth/views/admin/groups.py
+++ b/intranet/apps/eighth/views/admin/groups.py
@@ -329,7 +329,7 @@ def delete_group_view(request, group_id):
             "admin_page_title": "Delete Group",
             "item_name": str(group),
             "help_text": "Deleting this group will remove all records "
-            "of it related to eighth period."
+                         "of it related to eighth period."
         }
 
         return render(request, "eighth/admin/delete_form.html", context)

--- a/intranet/apps/eighth/views/admin/groups.py
+++ b/intranet/apps/eighth/views/admin/groups.py
@@ -655,7 +655,7 @@ def add_member_to_group_view(request, group_id):
         messages.error(request, "Could not process search query.")
         return redirect(next_url + "?error=n")
     logger.debug(results)
-    if len(results) == 0:
+    if not results:
         return redirect(next_url + "?error=n")
     else:
         users = results

--- a/intranet/apps/eighth/views/admin/maintenance.py
+++ b/intranet/apps/eighth/views/admin/maintenance.py
@@ -149,7 +149,7 @@ def sis_import(request):
         if context["already_importing"]:
             messages.error(request, "An upload is currently in progress!")
             return redirect(reverse("eighth_admin_maintenance_sis_import"))
-        if len(request.FILES) == 0:
+        if not request.FILES:
             messages.error(request, "You need to upload a file!")
             return redirect(reverse("eighth_admin_maintenance_sis_import"))
         data = request.FILES["data"]

--- a/intranet/apps/eighth/views/admin/maintenance.py
+++ b/intranet/apps/eighth/views/admin/maintenance.py
@@ -103,8 +103,8 @@ class ImportThread(threading.Thread):
                 reader = csv.reader(f)
                 headers = next(reader)
                 index_dict = {}
-                for i in range(len(headers)):
-                    index_dict[headers[i].strip()] = i
+                for i, header in enumerate(headers):
+                    index_dict[header.strip()] = i
                 for row in reader:
                     try:
                         u = User.objects.get(student_id=row[index_dict["Student ID"]].strip())

--- a/intranet/apps/eighth/views/admin/rooms.py
+++ b/intranet/apps/eighth/views/admin/rooms.py
@@ -193,7 +193,7 @@ def room_utilization_action(request, start_id, end_id):
     show_opts = ["block", "rooms", "capacity", "signups", "aid", "activity", "comments", "sponsors", "admin_comments"]
     show_opts_defaults = ["block", "rooms", "capacity", "signups", "aid", "activity", "comments", "sponsors"]
     show_opts_hidden = ["admin_comments"]
-    if len(show_vals) == 0:
+    if not show_vals:
         show = {name: True for name in show_opts_defaults}
         show.update({name: False for name in show_opts_hidden})
     else:
@@ -240,7 +240,7 @@ def room_utilization_action(request, start_id, end_id):
             all_sched_acts = sched_acts
             sched_acts = []
             for sched_act in all_sched_acts:
-                if len(set(rooms).intersection(set(sched_act.get_true_rooms()))) > 0:
+                if set(rooms).intersection(set(sched_act.get_true_rooms())):
                     sched_acts.append(sched_act)
         else:
             rooms = all_rooms

--- a/intranet/apps/eighth/views/admin/rooms.py
+++ b/intranet/apps/eighth/views/admin/rooms.py
@@ -76,7 +76,7 @@ def delete_room_view(request, room_id):
             "admin_page_title": "Delete Room",
             "item_name": str(room),
             "help_text": "Deleting this room will remove all records "
-            "of it related to eighth period."
+                         "of it related to eighth period."
         }
 
         return render(request, "eighth/admin/delete_form.html", context)

--- a/intranet/apps/eighth/views/admin/scheduling.py
+++ b/intranet/apps/eighth/views/admin/scheduling.py
@@ -149,7 +149,7 @@ def schedule_activity_view(request):
     activity_id = request.GET.get("activity", None)
     activity = None
 
-    if activity_id is not None and len(activity_id) > 0:
+    if activity_id is not None and activity_id:
         try:
             activity = EighthActivity.undeleted_objects.get(id=activity_id)
         except (EighthActivity.DoesNotExist, ValueError):

--- a/intranet/apps/eighth/views/api.py
+++ b/intranet/apps/eighth/views/api.py
@@ -5,15 +5,16 @@ from datetime import datetime
 
 from django.http import Http404
 
-from intranet.apps.users.models import User
-
 from rest_framework import generics, status, views, permissions
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
+from rest_framework.exceptions import ValidationError
+
+from intranet.apps.users.models import User
+
 from ..models import (EighthActivity, EighthBlock, EighthScheduledActivity, EighthSignup)
 from ..serializers import (EighthActivityDetailSerializer, EighthActivityListSerializer, EighthAddSignupSerializer, EighthBlockDetailSerializer,
                            EighthBlockListSerializer, EighthScheduledActivitySerializer, EighthSignupSerializer, EighthToggleFavoriteSerializer)
-from rest_framework.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
 

--- a/intranet/apps/eighth/views/attendance.py
+++ b/intranet/apps/eighth/views/attendance.py
@@ -150,7 +150,7 @@ class EighthAttendanceSelectScheduledActivityWizard(SessionWizardView):
             return response
 
         if hasattr(self, "default_activity"):
-            activity = self.default_activity
+            activity = self.default_activity # pylint: disable=E1101; We just checked if the attribute exists
         else:
             activity = form_list[1].cleaned_data["activity"]
 

--- a/intranet/apps/eighth/views/attendance.py
+++ b/intranet/apps/eighth/views/attendance.py
@@ -150,7 +150,7 @@ class EighthAttendanceSelectScheduledActivityWizard(SessionWizardView):
             return response
 
         if hasattr(self, "default_activity"):
-            activity = self.default_activity # pylint: disable=E1101; We just checked if the attribute exists
+            activity = self.default_activity  # pylint: disable=E1101; We just checked if the attribute exists
         else:
             activity = form_list[1].cleaned_data["activity"]
 

--- a/intranet/apps/eighth/views/profile.py
+++ b/intranet/apps/eighth/views/profile.py
@@ -97,11 +97,11 @@ def get_profile_context(request, user_id=None, date=None):
     blocks_all = EighthBlock.objects.order_by("date", "block_letter").filter(date__gte=date)
     blocks = blocks_all.filter(date__lt=date_end)
 
-    if len(blocks) == 0:
+    if not blocks:
         blocks = list(blocks_all)[:6]
         skipped_ahead = True
         logger.debug(blocks)
-        if len(blocks) > 0:
+        if blocks:
             date_next = list(blocks)[-1].date + timedelta(days=1)
 
     for block in blocks:

--- a/intranet/apps/eighth/views/signup.py
+++ b/intranet/apps/eighth/views/signup.py
@@ -139,7 +139,7 @@ def eighth_signup_view(request, block_id=None):
                 "locked": b.locked
             }
 
-            if len(schedule) and schedule[-1]["date"] == b.date:
+            if schedule and schedule[-1]["date"] == b.date:
                 schedule[-1]["blocks"].append(info)
             else:
                 day = {}
@@ -225,7 +225,7 @@ def eighth_display_view(request, block_id=None):
             "locked": b.locked
         }
 
-        if len(schedule) and schedule[-1]["date"] == b.date:
+        if schedule and schedule[-1]["date"] == b.date:
             schedule[-1]["blocks"].append(info)
         else:
             day = {}

--- a/intranet/apps/emerg/views.py
+++ b/intranet/apps/emerg/views.py
@@ -32,7 +32,7 @@ def check_emerg():
 
     r = requests.get("{}?{}".format(settings.FCPS_EMERGENCY_PAGE, int(time.time() // 60)), timeout=timeout)
     res = r.text
-    if not res or len(res) < 1:
+    if not res:
         status = False
 
     # Keep this list up to date with whatever wording FCPS decides to use each time...

--- a/intranet/apps/events/forms.py
+++ b/intranet/apps/events/forms.py
@@ -10,7 +10,7 @@ from ..groups.models import Group
 class EventForm(forms.ModelForm):
 
     def __init__(self, all_groups=False, *args, **kwargs):
-        super(forms.ModelForm, self).__init__(*args, **kwargs)
+        super(EventForm, self).__init__(*args, **kwargs)
         if not all_groups:
             self.fields["groups"].queryset = Group.objects.student_visible()
 
@@ -31,7 +31,7 @@ class EventForm(forms.ModelForm):
 class AdminEventForm(forms.ModelForm):
 
     def __init__(self, all_groups=False, *args, **kwargs):
-        super(forms.ModelForm, self).__init__(*args, **kwargs)
+        super(AdminEventForm, self).__init__(*args, **kwargs)
         if not all_groups:
             self.fields["groups"].queryset = Group.objects.student_visible()
         self.fields["scheduled_activity"].widget = forms.NumberInput()

--- a/intranet/apps/events/models.py
+++ b/intranet/apps/events/models.py
@@ -202,7 +202,7 @@ class Event(models.Model):
     @property
     def user_map(self):
         try:
-            return self._user_map # pylint: disable=E1101; Defined via a related_name in EventUserMap
+            return self._user_map  # pylint: disable=E1101; Defined via a related_name in EventUserMap
         except EventUserMap.DoesNotExist:
             return EventUserMap.objects.create(event=self)
 

--- a/intranet/apps/events/models.py
+++ b/intranet/apps/events/models.py
@@ -202,7 +202,7 @@ class Event(models.Model):
     @property
     def user_map(self):
         try:
-            return self._user_map
+            return self._user_map # pylint: disable=E1101; Defined via a related_name in EventUserMap
         except EventUserMap.DoesNotExist:
             return EventUserMap.objects.create(event=self)
 

--- a/intranet/apps/events/models.py
+++ b/intranet/apps/events/models.py
@@ -42,7 +42,7 @@ class EventManager(Manager):
 
         """
 
-        return (Event.objects.filter(approved=True).filter(Q(groups__in=user.groups.all()) | Q(groups__isnull=True) | Q(user=user)))
+        return Event.objects.filter(approved=True).filter(Q(groups__in=user.groups.all()) | Q(groups__isnull=True) | Q(user=user))
 
     def hidden_events(self, user):
         """Get a list of events marked as hidden for a given user (usually request.user).

--- a/intranet/apps/files/models.py
+++ b/intranet/apps/files/models.py
@@ -59,7 +59,7 @@ class Host(models.Model):
     def visible_to(self, user):
         if self.groups_visible.count() == 0:
             return True
-        return (self in Host.objects.visible_to_user(user))
+        return self in Host.objects.visible_to_user(user)
 
     def __str__(self):
         return "{} ({})".format(self.name, self.code)

--- a/intranet/apps/files/views.py
+++ b/intranet/apps/files/views.py
@@ -333,11 +333,11 @@ def files_type(request, fstype=None):
 
     current_dir = normpath(sftp.pwd)  # current directory
     dir_list = current_dir.split("/")
-    if len(dir_list) > 1 and len(dir_list[-1]) == 0:
+    if len(dir_list) > 1 and not dir_list[-1]:
         dir_list.pop()
     parent_dir = "/".join(dir_list[:-1])
 
-    if len(parent_dir) == 0:
+    if not parent_dir:
         parent_dir = "/"
 
     files = sorted(files, key=lambda f: (not f["folder"], f["name"]))

--- a/intranet/apps/files/views.py
+++ b/intranet/apps/files/views.py
@@ -5,10 +5,10 @@ import base64
 import datetime
 import logging
 import os
+from os.path import normpath
 import stat
 import tempfile
 import zipfile
-from os.path import normpath
 from wsgiref.util import FileWrapper
 
 from Crypto import Random

--- a/intranet/apps/nomination/views.py
+++ b/intranet/apps/nomination/views.py
@@ -20,10 +20,10 @@ def vote_for_user(request, username, position):
         if nominated_user.grade.number == request.user.grade.number and request.user.grade.number < 13:
             nominated_position = NominationPosition.objects.get(position_name=position)
             votes_for_position = request.user.nomination_votes.filter(position=nominated_position)
-            if len(votes_for_position.filter(nominee=nominated_user)) > 0:
+            if votes_for_position.filter(nominee=nominated_user):
                 messages.error(request, "You have already voted for this user.")
             else:
-                if len(votes_for_position) > 0:
+                if votes_for_position:
                     for vote in votes_for_position:
                         if (vote.nominee.is_male and nominated_user.is_male) or (vote.nominee.is_female and nominated_user.is_female):
                             vote.delete()

--- a/intranet/apps/parking/tests.py
+++ b/intranet/apps/parking/tests.py
@@ -41,8 +41,7 @@ class ParkingTest(IonTestCase):
             "make": "Lamborghini",
             "model": "Veneno",
             "year": 2018
-        }
-        )
+        })
 
         self.assertEqual(response.status_code, 302)
 
@@ -75,8 +74,7 @@ class ParkingTest(IonTestCase):
             "make": "Lamborghini",
             "model": "Veneno",
             "year": "2018"
-        }
-        )
+        })
 
         # Check that car application is not created
         self.assertEqual(response.status_code, 302)

--- a/intranet/apps/polls/forms.py
+++ b/intranet/apps/polls/forms.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
+from typing import List  # noqa
 
 from django import forms
 
 from .models import Poll
 
 from ...utils.html import safe_html
-
-from typing import List  # noqa
 
 
 class PollForm(forms.ModelForm):

--- a/intranet/apps/polls/forms.py
+++ b/intranet/apps/polls/forms.py
@@ -12,7 +12,7 @@ from typing import List  # noqa
 class PollForm(forms.ModelForm):
 
     def __init__(self, all_groups=False, *args, **kwargs):
-        super(forms.ModelForm, self).__init__(*args, **kwargs)
+        super(PollForm, self).__init__(*args, **kwargs)
         self.fields["description"].widget = forms.Textarea()
 
     def clean_description(self):

--- a/intranet/apps/polls/models.py
+++ b/intranet/apps/polls/models.py
@@ -86,7 +86,7 @@ class Poll(models.Model):
     def get_users_voted(self):
         users = []
         for q in self.question_set.all():
-            if len(users) > 0:
+            if users:
                 users = list(set(q.get_users_voted()) | set(users))
             else:
                 users = list(q.get_users_voted())

--- a/intranet/apps/polls/models.py
+++ b/intranet/apps/polls/models.py
@@ -93,7 +93,7 @@ class Poll(models.Model):
         return users
 
     def has_user_voted(self, user):
-        return (Answer.objects.filter(question__in=self.question_set.all(), user=user).count() == self.question_set.count())
+        return Answer.objects.filter(question__in=self.question_set.all(), user=user).count() == self.question_set.count()
 
     def can_vote(self, user):
         if user.has_admin_permission("polls"):

--- a/intranet/apps/polls/views.py
+++ b/intranet/apps/polls/views.py
@@ -190,7 +190,7 @@ def poll_vote_view(request, poll_id):
             "is_writing": q.is_writing(),
             "max_choices": q.max_choices,
             "current_votes": current_votes,
-            "current_vote": current_votes[0] if len(current_votes) > 0 else None,
+            "current_vote": current_votes[0] if current_votes else None,
             "current_choices": [v.choice for v in current_votes],
             "current_vote_none": (len(current_votes) < 1),
             "current_vote_clear": (len(current_votes) == 1 and current_votes[0].clear_vote)

--- a/intranet/apps/printing/views.py
+++ b/intranet/apps/printing/views.py
@@ -59,7 +59,7 @@ def convert_soffice(tmpfile_name):
         logger.error("Could not run soffice command (returned {}): {}".format(e.returncode, e.output))
         return False
 
-    if " -> " in output and " using " in output:
+    if " -> " in output and " using " in output: # pylint: disable=E1135; Pylint is wrong
         fileout = output.split(" -> ", 2)[1]
         fileout = fileout.split(" using ", 1)[0]
         return fileout

--- a/intranet/apps/printing/views.py
+++ b/intranet/apps/printing/views.py
@@ -59,7 +59,7 @@ def convert_soffice(tmpfile_name):
         logger.error("Could not run soffice command (returned {}): {}".format(e.returncode, e.output))
         return False
 
-    if " -> " in output and " using " in output: # pylint: disable=E1135; Pylint is wrong
+    if " -> " in output and " using " in output:  # pylint: disable=E1135; Pylint is wrong
         fileout = output.split(" -> ", 2)[1]
         fileout = fileout.split(" using ", 1)[0]
         return fileout

--- a/intranet/apps/search/views.py
+++ b/intranet/apps/search/views.py
@@ -106,7 +106,7 @@ def query(q, admin=False):
                     exact = True
                     p = p[1:-1]
 
-                if len(p) == 0:
+                if not p:
                     continue
 
                 default_categories = ["first_name", "last_name", "nickname"]

--- a/intranet/apps/users/api.py
+++ b/intranet/apps/users/api.py
@@ -5,11 +5,11 @@ import os
 
 from django.conf import settings
 
-from intranet.apps.search.views import get_search_results
-
 from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+
+from intranet.apps.search.views import get_search_results
 
 from .models import Grade, User
 from .renderers import JPEGRenderer

--- a/intranet/apps/users/management/commands/generate_fake_data.py
+++ b/intranet/apps/users/management/commands/generate_fake_data.py
@@ -1,7 +1,8 @@
 import datetime
 
-from faker import Faker
 from django.conf import settings
+
+from faker import Faker
 
 from ...models import User
 fake = Faker()

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -2,8 +2,8 @@
 
 import logging
 from datetime import datetime
-from dateutil.relativedelta import relativedelta
 from base64 import b64encode
+from dateutil.relativedelta import relativedelta
 
 from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser, PermissionsMixin, UserManager as DjangoUserManager

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -68,7 +68,7 @@ class UserManager(DjangoUserManager):
                 query['last_name'] = sn
             results = User.objects.filter(**query)
 
-            if len(results) == 0:
+            if not results:
                 # Try their first name as a nickname
                 del query['first_name']
                 query['nickname'] = given_name
@@ -353,7 +353,7 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         for field in self.properties._meta.get_fields():
             split_field = field.name.split('_', 1)
-            if len(split_field) <= 0 or split_field[0] not in ['self', 'parent']:
+            if not split_field or split_field[0] not in ['self', 'parent']:
                 continue
             permissions_dict[split_field[0]][split_field[1]] = getattr(self.properties, field.name)
 

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+# pylint: disable=C0302; Allow more than 1000 lines
 import logging
 from datetime import datetime
 from base64 import b64encode

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -903,7 +903,7 @@ class UserProperties(models.Model):
         try:
             parent = getattr(self, "parent_{}".format(permission))
             student = getattr(self, "self_{}".format(permission))
-            return (parent and student)
+            return parent and student
         except Exception:
             logger.error("Could not retrieve permissions for {}".format(permission))
 

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -821,7 +821,7 @@ class UserProperties(models.Model):
         if name == "birthday":
             if self.attribute_is_visible("show_birthday"):
                 self._birthday = value
-        super(UserProperties, self).__setattr__(name, value)
+        super(UserProperties, self).__setattr__(name, value) # pylint: disable=E1101; Pylint is wrong
 
     def __str__(self):
         return self.user.__str__()
@@ -934,7 +934,7 @@ class Phone(models.Model):
                 self._number = value
                 self.save()
         else:
-            super(Phone, self).__setattr__(name, value)
+            super(Phone, self).__setattr__(name, value) # pylint: disable=E1101; Pylint is wrong
 
     def __getattr__(self, name):
         if name == "number":
@@ -998,7 +998,7 @@ class Photo(models.Model):
                 self._binary = value
                 self.save()
         else:
-            super(Photo, self).__setattr__(name, value)
+            super(Photo, self).__setattr__(name, value) # pylint: disable=E1101; Pylint is wrong
 
     def __getattr__(self, name):
         if name == "binary":

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -821,7 +821,7 @@ class UserProperties(models.Model):
         if name == "birthday":
             if self.attribute_is_visible("show_birthday"):
                 self._birthday = value
-        super(UserProperties, self).__setattr__(name, value) # pylint: disable=E1101; Pylint is wrong
+        super(UserProperties, self).__setattr__(name, value)  # pylint: disable=E1101; Pylint is wrong
 
     def __str__(self):
         return self.user.__str__()
@@ -934,7 +934,7 @@ class Phone(models.Model):
                 self._number = value
                 self.save()
         else:
-            super(Phone, self).__setattr__(name, value) # pylint: disable=E1101; Pylint is wrong
+            super(Phone, self).__setattr__(name, value)  # pylint: disable=E1101; Pylint is wrong
 
     def __getattr__(self, name):
         if name == "number":
@@ -998,7 +998,7 @@ class Photo(models.Model):
                 self._binary = value
                 self.save()
         else:
-            super(Photo, self).__setattr__(name, value) # pylint: disable=E1101; Pylint is wrong
+            super(Photo, self).__setattr__(name, value)  # pylint: disable=E1101; Pylint is wrong
 
     def __getattr__(self, name):
         if name == "binary":

--- a/intranet/middleware/profiler.py
+++ b/intranet/middleware/profiler.py
@@ -16,10 +16,10 @@ from typing import Any, Set, Dict  # noqa
 
 import cProfile
 
+import pstats
+
 from django.conf import settings
 from django.db import connections
-
-import pstats
 
 # FIXME change log base to something appropriate for the particular installation
 PROFILE_LOG_BASE = '/var/tmp/django'

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -10,7 +10,8 @@ if sys.version_info < (3, 3):
     # dependency on ipaddress module
     raise Exception("Python 3.3 or higher is required.")
 
-from ..utils import helpers  # noqa
+# noqa
+from ..utils import helpers  # pylint: disable=C0413
 """ !! In production, add a file called secret.py to the settings package that
 defines AUTHUSER_PASSWORD, SECRET_KEY, SECRET_DATABASE_URL. !!
 

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -10,8 +10,7 @@ if sys.version_info < (3, 3):
     # dependency on ipaddress module
     raise Exception("Python 3.3 or higher is required.")
 
-# noqa
-from ..utils import helpers  # pylint: disable=C0413
+from ..utils import helpers  # pylint: disable=C0413 # noqa
 """ !! In production, add a file called secret.py to the settings package that
 defines AUTHUSER_PASSWORD, SECRET_KEY, SECRET_DATABASE_URL. !!
 

--- a/intranet/utils/date.py
+++ b/intranet/utils/date.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+import datetime
+
 from django.conf import settings
 from django.utils import timezone
-
-import datetime
 
 
 def is_current_year(date):

--- a/intranet/utils/helpers.py
+++ b/intranet/utils/helpers.py
@@ -4,9 +4,9 @@ import logging
 import subprocess
 from urllib import parse
 
-from django.conf import settings
-
 from typing import Set # noqa
+
+from django.conf import settings
 
 logger = logging.getLogger('intranet.settings')
 

--- a/scripts/export_iodine_fixtures.py
+++ b/scripts/export_iodine_fixtures.py
@@ -18,11 +18,11 @@ import os.path
 import re
 import sys
 
-import MySQLdb as mdb
-
 import ldap3
 
 import pexpect
+
+import MySQLdb as mdb
 
 # Run this on iodine.tjhsst.edu
 start_date = "2015-09-01"


### PR DESCRIPTION
This will be the first of several PRs with the goal of cleaning up Ion to the point that Pylint does not complain excessively and the build process can be extended to run Pylint as well as flake8.

The changes made in this PR were made based on the output of `pylint --reports=n -f colorized --ignore-patterns='.*/migrations/.*' intranet` (you will need to run this in a development environment, and you'll need to `pip install pylint pylint-django` first). Be warned that this command takes several minutes to run and prints several screenfuls of errors and warnings. This PR may look like it does a lot, but it barely scratches the surface towards reducing that.

It is very likely that I made a few mistakes in this process. One has already been caught by @theo-o (the fix was squashed into the commit that added the bug and force-pushed). This PR should not be merged for several days at the least to allow time to audit the code.