### PR TITLE
Use logging.Logger's built-in string interpolation

### DIFF
--- a/intranet/apps/announcements/views.py
+++ b/intranet/apps/announcements/views.py
@@ -59,7 +59,7 @@ def announcement_posted_hook(request, obj):
             else:
                 announcement_posted_email(request, obj)
         except Exception as e:
-            logger.error("Exception when emailing announcement: {}".format(e))
+            logger.error("Exception when emailing announcement: %s", e)
             messages.error(request, "Exception when emailing announcement: {}".format(e))
             raise e
     else:
@@ -398,7 +398,7 @@ def hide_announcement_view(request):
                 announcement.user_map.users_hidden.add(request.user)
                 announcement.user_map.save()
             except IntegrityError:
-                logger.warning("Duplicate value when hiding announcement {} for {}.".format(announcement_id, request.user.username))
+                logger.warning("Duplicate value when hiding announcement %d for %s.", announcement_id, request.user.username)
             return http.HttpResponse("Hidden")
         raise http.Http404
     else:

--- a/intranet/apps/auth/backends.py
+++ b/intranet/apps/auth/backends.py
@@ -31,10 +31,10 @@ class KerberosAuthenticationBackend(object):
         try:
             u = User.objects.get(username__iexact=username)
         except User.DoesNotExist:
-            logger.warning("kinit timed out for {}@{} (invalid user)".format(username, realm))
+            logger.warning("kinit timed out for %s@%s (invalid user)", username, realm)
             return
 
-        logger.critical("kinit timed out for {}".format(realm), extra={
+        logger.critical("kinit timed out for %s", realm, extra={
             "stack": True,
             "data": {
                 "username": username
@@ -64,7 +64,7 @@ class KerberosAuthenticationBackend(object):
 
         cache = "/tmp/ion-%s" % uuid.uuid4()
 
-        logger.debug("Setting KRB5CCNAME to 'FILE:{}'".format(cache))
+        logger.debug("Setting KRB5CCNAME to 'FILE:%s'", cache)
         os.environ["KRB5CCNAME"] = "FILE:" + cache
 
         try:
@@ -74,7 +74,7 @@ class KerberosAuthenticationBackend(object):
             kinit.sendline(password)
             returned = kinit.expect([pexpect.EOF, "password:"])
             if returned == 1:
-                logger.debug("Password for {}@{} expired, needs reset".format(username, realm))
+                logger.debug("Password for %s@%s expired, needs reset", username, realm)
                 return "reset"
             kinit.close()
             exitstatus = kinit.exitstatus
@@ -102,10 +102,10 @@ class KerberosAuthenticationBackend(object):
             del os.environ["KRB5CCNAME"]
 
         if exitstatus == 0:
-            logger.debug("Kerberos authorized {}@{}".format(username, realm))
+            logger.debug("Kerberos authorized %s@%s", username, realm)
             return True
         else:
-            logger.debug("Kerberos failed to authorize {}".format(username))
+            logger.debug("Kerberos failed to authorize %s", username)
             return False
 
     # @method_decorator(sensitive_variables("password"))
@@ -189,11 +189,11 @@ class MasterPasswordAuthenticationBackend(object):
                 user = User.objects.get(username__iexact=username)
             except User.DoesNotExist:
                 if settings.MASTER_NOTIFY:
-                    logger.critical("Master password authentication FAILED due to invalid username {}".format(username))
+                    logger.critical("Master password authentication FAILED due to invalid username %s", username)
                 logger.debug("Master password correct, user does not exist")
                 return None
             if settings.MASTER_NOTIFY:
-                logger.critical("Master password authentication SUCCEEDED with username {}".format(username))
+                logger.critical("Master password authentication SUCCEEDED with username %s", username)
             logger.debug("Authentication with master password successful")
             return user
         logger.debug("Master password authentication failed")

--- a/intranet/apps/auth/views.py
+++ b/intranet/apps/auth/views.py
@@ -176,8 +176,8 @@ class LoginView(View):
                 return redirect(reverse("reset_password") + "?expired=True")
             login(request, form.get_user())
             # Initial load into session
-            logger.info("Login succeeded as {}".format(request.POST.get("username", "unknown")))
-            logger.info("request.user: {}".format(request.user))
+            logger.info("Login succeeded as %s", request.POST.get("username", "unknown"))
+            logger.info("request.user: %s", request.user)
 
             log_auth(request, "success{}".format(" - first login" if not request.user.first_login else ""))
 
@@ -210,7 +210,7 @@ class LoginView(View):
             return redirect(next_page)
         else:
             log_auth(request, "failed")
-            logger.info("Login failed as {}".format(request.POST.get("username", "unknown")))
+            logger.info("Login failed as %s", request.POST.get("username", "unknown"))
             return index_view(request, auth_form=form)
 
     @method_decorator(sensitive_post_parameters("password"))

--- a/intranet/apps/dashboard/views.py
+++ b/intranet/apps/dashboard/views.py
@@ -211,11 +211,11 @@ def find_birthdays(request):
     cached = cache.get(key)
 
     if cached:
-        logger.debug("Birthdays on {} loaded " "from cache.".format(today))
+        logger.debug("Birthdays on %s loaded from cache.", today)
         logger.debug(cached)
         return cached
     else:
-        logger.debug("Loading and caching birthday info for {}".format(today))
+        logger.debug("Loading and caching birthday info for %s", today)
         tomorrow = today + timedelta(days=1)
         try:
             data = {

--- a/intranet/apps/eighth/models.py
+++ b/intranet/apps/eighth/models.py
@@ -1224,10 +1224,10 @@ class EighthScheduledActivity(AbstractBaseEighthModel):
         """
         # super(EighthScheduledActivity, self).save(*args, **kwargs)
 
-        logger.debug("Running cancel hooks: {}".format(self))
+        logger.debug("Running cancel hooks: %s", self)
 
         if not self.cancelled:
-            logger.debug("Cancelling {}".format(self))
+            logger.debug("Cancelling %s", self)
             self.cancelled = True
         self.save()
         # NOT USED. Was broken anyway.
@@ -1254,7 +1254,7 @@ class EighthScheduledActivity(AbstractBaseEighthModel):
         """
 
         if self.cancelled:
-            logger.debug("Uncancelling {}".format(self))
+            logger.debug("Uncancelling %s", self)
             self.cancelled = False
         self.save()
         # NOT USED. Was broken anyway.

--- a/intranet/apps/eighth/views/admin/groups.py
+++ b/intranet/apps/eighth/views/admin/groups.py
@@ -466,7 +466,7 @@ class EighthAdminDistributeGroupWizard(SessionWizardView):
         if step == "block":
             kwargs.update({"exclude_before_date": get_start_date(self.request)})
         if step == "activity":
-            logger.debug("cleaned block: {}".format(self.get_cleaned_data_for_step("block")["block"]))
+            logger.debug("cleaned block: %s", self.get_cleaned_data_for_step("block")["block"])
             block = self.get_cleaned_data_for_step("block")
             if block:
                 block = block["block"]

--- a/intranet/apps/eighth/views/admin/rooms.py
+++ b/intranet/apps/eighth/views/admin/rooms.py
@@ -184,7 +184,7 @@ def room_utilization_action(request, start_id, end_id):
 
     if show_available_for_eighth:
         all_rooms = EighthRoom.objects.filter(available_for_eighth=True).order_by("name")
-        logger.debug("{} rooms are available for eighth".format(all_rooms.count()))
+        logger.debug("%d rooms are available for eighth", all_rooms.count())
     else:
         all_rooms = EighthRoom.objects.all().order_by("name")
 
@@ -224,15 +224,15 @@ def room_utilization_action(request, start_id, end_id):
         else:
             sched_acts = sched_acts.filter(block=start_block)
 
-        logger.debug("sched_acts before: {}".format(sched_acts.count()))
-        logger.debug("total rooms: {}".format(all_rooms.count()))
+        logger.debug("sched_acts before: %d", sched_acts.count())
+        logger.debug("total rooms: %d", all_rooms.count())
 
         room_ids = request.GET.getlist("room")
         if "room" in request.GET:
             rooms = EighthRoom.objects.filter(id__in=room_ids)
             sched_acts = sched_acts.filter(Q(rooms__in=rooms) | Q(activity__rooms__in=rooms)).distinct()
 
-        logger.debug("sched_acts: {}".format(sched_acts.count()))
+        logger.debug("sched_acts: %d", sched_acts.count())
 
         sched_acts = (sched_acts.order_by("block__date", "block__block_letter"))
 
@@ -245,14 +245,14 @@ def room_utilization_action(request, start_id, end_id):
         else:
             rooms = all_rooms
 
-        logger.debug("length of rooms: {}".format(len(rooms)))
-        logger.debug("sched_acts end: {}".format(len(sched_acts)))
+        logger.debug("length of rooms: %d", len(rooms))
+        logger.debug("sched_acts end: %d", len(sched_acts))
 
         sched_acts = sorted(sched_acts, key=lambda x: ("{}".format(x.block), "{}".format(x.get_true_rooms())))
 
         if show_all_rooms or show_available_for_eighth:
             unused = rooms.exclude(Q(eighthscheduledactivity__in=sched_acts) | Q(eighthactivity__eighthscheduledactivity__in=sched_acts))
-            logger.debug("number of unused: {}".format(len(unused)))
+            logger.debug("number of unused: %d", len(unused))
             for room in unused:
                 sched_acts.append({"room": room, "empty": True})
 

--- a/intranet/apps/eighth/views/admin/scheduling.py
+++ b/intranet/apps/eighth/views/admin/scheduling.py
@@ -63,7 +63,7 @@ def schedule_activity_view(request):
                     if schact:
                         if activity.both_blocks:
                             other_act = schact[0].get_both_blocks_sibling()
-                            logger.debug("other_act: {}".format(other_act))
+                            logger.debug("other_act: %s", other_act)
                             if other_act:
                                 other_act.cancelled = True
                                 other_act.save()
@@ -91,7 +91,7 @@ def schedule_activity_view(request):
 
                     for field_name in fields:
                         obj = form.cleaned_data[field_name]
-                        logger.debug("{} {}".format(field_name, obj))
+                        logger.debug("%s %s", field_name, obj)
                         # Properly handle ManyToMany relations in django 1.10+
                         if isinstance(getattr(instance, field_name), Manager):
                             getattr(instance, field_name).set(obj)
@@ -114,7 +114,7 @@ def schedule_activity_view(request):
                     if form["unschedule"].value() and instance.cancelled:
                         name = "{}".format(instance)
                         count = instance.eighthsignup_set.count()
-                        logger.debug("Unschedule {} - signups {}".format(name, count))
+                        logger.debug("Unschedule %s - signups %d", name, count)
                         bb_ok = True
                         sibling = False
                         if activity.both_blocks:

--- a/intranet/apps/eighth/views/attendance.py
+++ b/intranet/apps/eighth/views/attendance.py
@@ -127,7 +127,7 @@ class EighthAttendanceSelectScheduledActivityWizard(SessionWizardView):
 
             if sponsor and not self.request.user.is_eighthoffice:
                 context.update({"sponsor_block": block})
-                logger.debug("sponsor block: {}".format(block))
+                logger.debug("sponsor block: %s", block)
 
                 sponsoring_filter = (Q(sponsors=sponsor) | (Q(sponsors=None) & Q(activity__sponsors=sponsor)))
                 sponsored_activities = (EighthScheduledActivity.objects.filter(block=block).filter(sponsoring_filter).order_by("activity__name"))
@@ -427,10 +427,10 @@ def accept_pass_view(request, signup_id):
     logger.debug(status)
 
     if status == "accept":
-        logger.debug("ACCEPT {}".format(signup_id))
+        logger.debug("ACCEPT %d", signup_id)
         signup.accept_pass()
     elif status == "reject":
-        logger.debug("REJECT {}".format(signup_id))
+        logger.debug("REJECT %d", signup_id)
         signup.reject_pass()
 
     signup.save()

--- a/intranet/apps/eighth/views/profile.py
+++ b/intranet/apps/eighth/views/profile.py
@@ -134,7 +134,7 @@ def get_profile_context(request, user_id=None, date=None):
             "block__date", "block__block_letter"))
         eighth_sponsor_schedule = eighth_sponsor_schedule[:10]
 
-        logger.debug("Eighth sponsor {}".format(sponsor))
+        logger.debug("Eighth sponsor %s", sponsor)
 
         context["eighth_sponsor_schedule"] = eighth_sponsor_schedule
 

--- a/intranet/apps/files/views.py
+++ b/intranet/apps/files/views.py
@@ -264,14 +264,14 @@ def files_type(request, fstype=None):
                 try:
                     remotelist = sftp.listdir(rd)
                 except PermissionError as e:
-                    logger.debug("Exception %s on %s" % (e, rd))
+                    logger.debug("Exception %s on %s", e, rd)
                     continue
                 for item in remotelist:
                     itempath = os.path.join(rd, item)
                     try:
                         fstat = sftp.stat(itempath)
                     except exceptions as e:
-                        logger.debug("Could not read %s: %s" % (item, e))
+                        logger.debug("Could not read %s: %s", item, e)
                         continue
 
                     if stat.S_ISDIR(fstat.st_mode):
@@ -290,7 +290,7 @@ def files_type(request, fstype=None):
                         with open(os.path.join(localpath, item), "wb") as fh:
                             sftp.getfo(itempath, fh)
                     except exceptions as e:
-                        logger.debug("Exception %s on %s" % (e, item))
+                        logger.debug("Exception %s on %s", e, item)
                         continue
 
             with zipfile.ZipFile(tmpfile, "w", zipfile.ZIP_DEFLATED) as zf:

--- a/intranet/apps/notifications/emails.py
+++ b/intranet/apps/notifications/emails.py
@@ -29,7 +29,7 @@ def email_send(text_template, html_template, data, subject, emails, headers=None
     headers = {} if headers is None else headers
     msg = EmailMultiAlternatives(subject, text_content, settings.EMAIL_FROM, emails, headers=headers)
     msg.attach_alternative(html_content, "text/html")
-    logger.debug("Emailing {} to {}".format(subject, emails))
+    logger.debug("Emailing %s to %s", subject, emails)
     msg.send()
 
     return msg
@@ -55,7 +55,7 @@ def email_send_bcc(text_template, html_template, data, subject, emails, headers=
     headers = {} if headers is None else headers
     msg = EmailMultiAlternatives(subject, text_content, settings.EMAIL_FROM, [settings.EMAIL_FROM], headers=headers, bcc=emails)
     msg.attach_alternative(html_content, "text/html")
-    logger.debug("Emailing {} to {}".format(subject, emails))
+    logger.debug("Emailing %s to %s", subject, emails)
     msg.send()
 
     return msg

--- a/intranet/apps/polls/views.py
+++ b/intranet/apps/polls/views.py
@@ -132,7 +132,7 @@ def poll_vote_view(request, poll_id):
                                 messages.success(request, "Voted for {} on {}".format(choice_obj, question_obj))
                     elif question_obj.is_many_choice():
                         total_choices = request.POST.getlist(name)
-                        logger.debug("total choices: {}".format(total_choices))
+                        logger.debug("total choices: %s", total_choices)
                         if len(total_choices) == 1 and total_choices[0] == "CLEAR":
                             Answer.objects.filter(user=user, question=question_obj).delete()
                             Answer.objects.create(user=user, question=question_obj, clear_vote=True)
@@ -141,13 +141,13 @@ def poll_vote_view(request, poll_id):
                             messages.error(request, "Cannot select other options with Clear Vote.")
                         else:
                             current_choices = Answer.objects.filter(user=user, question=question_obj)
-                            logger.debug("current choices: {}".format(current_choices))
+                            logger.debug("current choices: %s", current_choices)
                             current_choices_nums = [c.choice.num if c.choice else None for c in current_choices]
                             # delete entries that weren't checked but in db
                             for c in current_choices_nums:
                                 if c and c not in total_choices:
                                     ch = choices.get(num=c)
-                                    logger.info("Deleting choice for {}".format(ch))
+                                    logger.info("Deleting choice for %s", ch)
                                     Answer.objects.filter(user=user, question=question_obj, choice=ch).delete()
                             for c in total_choices:
                                 # gets re-checked on each loop

--- a/intranet/apps/preferences/views.py
+++ b/intranet/apps/preferences/views.py
@@ -87,10 +87,10 @@ def save_preferred_pic(request, user):
                 new_preferred_pic = fields["preferred_photo"]
                 old_preferred_pic = preferred_pic["preferred_photo"] if preferred_pic else None
                 if old_preferred_pic == new_preferred_pic:
-                    logger.debug("{}: same ({})".format("preferred_photo", new_preferred_pic))
+                    logger.debug("preferred photo: same (%s)", new_preferred_pic)
                 else:
-                    logger.debug("{}: new: {} from: {}".format("preferred_photo", new_preferred_pic, old_preferred_pic
-                                                               if "preferred_photo" in preferred_pic else None))
+                    logger.debug("preferred_photo: new: %s from: %s", new_preferred_pic,
+                                 old_preferred_pic if "preferred_photo" in preferred_pic else None)
                     try:
                         if new_preferred_pic == 'AUTO':
                             user.preferred_photo = None
@@ -99,7 +99,7 @@ def save_preferred_pic(request, user):
                         user.save()
                     except Exception as e:
                         messages.error(request, "Unable to set field {} with value {}: {}".format("preferred_pic", new_preferred_pic, e))
-                        logger.debug("Unable to set field {} with value {}: {}".format("preferred_pic", new_preferred_pic, e))
+                        logger.debug("Unable to set field preferred_pic with value %s: %s", new_preferred_pic, e)
                     else:
                         messages.success(request, "Set field {} to {}".format("preferred_pic", new_preferred_pic
                                                                               if not isinstance(new_preferred_pic, list) else
@@ -134,9 +134,9 @@ def save_privacy_options(request, user):
             logger.debug(fields)
             for field in fields:
                 if field in privacy_options and privacy_options[field] == fields[field]:
-                    logger.debug("{}: same ({})".format(field, fields[field]))
+                    logger.debug("%s: same (%s)", field, fields[field])
                 else:
-                    logger.debug("{}: new: {} from: {}".format(field, fields[field], privacy_options[field] if field in privacy_options else None))
+                    logger.debug("%s: new: %s from: %s", field, fields[field], privacy_options[field] if field in privacy_options else None)
                     try:
                         if field.endswith("-self"):
                             field_name = field.split("-self")[0]
@@ -157,7 +157,7 @@ def save_privacy_options(request, user):
                             raise Exception("You cannot override the parent field.")
                     except Exception as e:
                         messages.error(request, "Unable to set field {} with value {}: {}".format(field, fields[field], e))
-                        logger.debug("Unable to set field {} with value {}: {}".format(field, fields[field], e))
+                        logger.debug("Unable to set field %s with value %s: %s", field, fields[field], e)
                     else:
                         messages.success(request, "Set field {} to {}".format(field, fields[field]
                                                                               if not isinstance(fields[field], list) else ", ".join(fields[field])))
@@ -189,13 +189,13 @@ def save_notification_options(request, user):
         logger.debug("Notification options form: valid")
         if notification_options_form.has_changed():
             fields = notification_options_form.cleaned_data
-            logger.debug("Fields: {}".format(fields))
+            logger.debug("Fields: %s", fields)
             for field in fields:
                 if field in notification_options and notification_options[field] == fields[field]:
-                    logger.debug("{}: same ({})".format(field, fields[field]))
+                    logger.debug("%s: same (%s)", field, fields[field])
                 else:
-                    logger.debug("{}: new: {} from: {}".format(field, fields[field], notification_options[field]
-                                                               if field in notification_options else None))
+                    logger.debug("%s: new: %s from: %s", field, fields[field], notification_options[field]
+                                 if field in notification_options else None)
                     setattr(user, field, fields[field])
                     user.save()
                     try:
@@ -224,9 +224,9 @@ def save_bus_route(request, user):
             logger.debug(fields)
             for field in fields:
                 if field in bus_route and bus_route[field] == fields[field]:
-                    logger.debug("{}: same ({})".format(field, fields[field]))
+                    logger.debug("%s: same (%s)", field, fields[field])
                 else:
-                    logger.debug("{}: new: {} from: {}".format(field, fields[field], bus_route[field] if field in bus_route else None))
+                    logger.debug("%s: new: %s from: %s", field, fields[field], bus_route[field] if field in bus_route else None)
                     try:
                         if fields[field]:
                             route = Route.objects.get(route_name=fields[field])
@@ -236,7 +236,7 @@ def save_bus_route(request, user):
                         user.save()
                     except Exception as e:
                         # TODO: replace with better error handling
-                        logger.error("Error processing Bus Route Form: {}".format(e))
+                        logger.error("Error processing Bus Route Form: %s", e)
                     try:
                         if fields[field]:
                             messages.success(request, "Set field {} to {}".format(field, fields[field]

--- a/intranet/apps/printing/views.py
+++ b/intranet/apps/printing/views.py
@@ -56,7 +56,7 @@ def convert_soffice(tmpfile_name):
         output = subprocess.check_output(["soffice", "--headless", "--convert-to", "pdf", tmpfile_name, "--outdir", "/tmp"], stderr=subprocess.STDOUT,
                                          universal_newlines=True, timeout=60)
     except subprocess.CalledProcessError as e:
-        logger.error("Could not run soffice command (returned {}): {}".format(e.returncode, e.output))
+        logger.error("Could not run soffice command (returned %d): %s", e.returncode, e.output)
         return False
 
     if " -> " in output and " using " in output:
@@ -72,7 +72,7 @@ def convert_pdf(tmpfile_name, cmdname="ps2pdf"):
     try:
         subprocess.check_output([cmdname, tmpfile_name, new_name], stderr=subprocess.STDOUT, universal_newlines=True)
     except subprocess.CalledProcessError as e:
-        logger.error("Could not run {} command (returned {}): {}".format(cmdname, e.returncode, e.output))
+        logger.error("Could not run %s command (returned %d): %s", cmdname, e.returncode, e.output)
         return False
 
     if os.path.isfile(new_name):
@@ -85,7 +85,7 @@ def get_numpages(tmpfile_name):
     try:
         output = subprocess.check_output(["pdfinfo", tmpfile_name], stderr=subprocess.STDOUT, universal_newlines=True)
     except subprocess.CalledProcessError as e:
-        logger.error("Could not run pdfinfo command (returned {}): {}".format(e.returncode, e.output))
+        logger.error("Could not run pdfinfo command (returned %d): %s", e.returncode, e.output)
         return -1
 
     lines = output.splitlines()
@@ -221,7 +221,7 @@ def print_job(obj, do_print=True):
         except subprocess.CalledProcessError as e:
             if "is not accepting jobs" in e.output:
                 raise Exception(e.output.strip())
-            logger.error("Could not run lpr (returned {}): {}".format(e.returncode, e.output.strip()))
+            logger.error("Could not run lpr (returned %d): %s", e.returncode, e.output.strip())
             raise Exception("An error occured while printing your file: %s" % e.output.strip())
 
     obj.printed = True

--- a/intranet/apps/schedule/views.py
+++ b/intranet/apps/schedule/views.py
@@ -62,7 +62,7 @@ def schedule_context(request=None, date=None, use_cache=True, show_tomorrow=True
     key = "bell_schedule:{}".format(date_fmt)
     cached = cache.get(key)
     if cached and use_cache:
-        logger.debug("Returning schedule context for {} from cache.".format(date_fmt))
+        logger.debug("Returning schedule context for %s from cache.", date_fmt)
         return cached
     else:
         try:
@@ -94,7 +94,7 @@ def schedule_context(request=None, date=None, use_cache=True, show_tomorrow=True
         if request and request.user.is_authenticated and request.user.is_eighth_admin:
             try:
                 schedule_tomorrow = Day.objects.select_related("day_type").get(date=date_tomorrow)
-                logger.debug("tomorrow: {}".format(schedule_tomorrow))
+                logger.debug("tomorrow: %s", schedule_tomorrow)
                 if not schedule_tomorrow.day_type:
                     schedule_tomorrow = False
             except Day.DoesNotExist:
@@ -116,7 +116,7 @@ def schedule_context(request=None, date=None, use_cache=True, show_tomorrow=True
             }
         }
         cache.set(key, data, timeout=settings.CACHE_AGE['bell_schedule'])
-        logger.debug("Cached schedule context for {}".format(date_fmt))
+        logger.debug("Cached schedule context for %s", date_fmt)
         return data
 
 

--- a/intranet/apps/search/views.py
+++ b/intranet/apps/search/views.py
@@ -22,7 +22,7 @@ def query(q, admin=False):
     # If only a digit, search for student ID and user ID
     results = []
     if q.isdigit():
-        logger.debug("Digit search: {}".format(q))
+        logger.debug("Digit search: %s", q)
         sid_users = User.objects.filter(student_id=q)
         uid_users = User.objects.filter(id=q)
         for u in sid_users:
@@ -92,7 +92,7 @@ def query(q, admin=False):
                 cat, val = p.split(">")
                 sep = "__gte"
             else:
-                logger.debug("Advanced fallback: {}".format(p))
+                logger.debug("Advanced fallback: %s", p)
                 # Fall back on regular searching (there's no key)
 
                 # Wildcards are already implied at the start and end
@@ -131,7 +131,7 @@ def query(q, admin=False):
 
                 continue  # skip rest of processing
 
-            logger.debug("Advanced exact: {}".format(p))
+            logger.debug("Advanced exact: %s", p)
             if val.startswith('"') and val.endswith('"'):
                 # Already exact
                 val = val[1:-1]
@@ -197,12 +197,12 @@ def query(q, admin=False):
                 default_categories.append("middle_name")
             query = Q(pk=-1)
             if exact:
-                logger.debug("Simple exact: {}".format(p))
+                logger.debug("Simple exact: %s", p)
                 # No implied wildcard
                 for cat in default_categories:
                     query |= Q(**{"{}__iexact".format(cat): p})
             else:
-                logger.debug("Simple wildcard: {}".format(p))
+                logger.debug("Simple wildcard: %s", p)
                 if p.endswith("*"):
                     p = p[:-1]
                 if p.startswith("*"):
@@ -213,7 +213,7 @@ def query(q, admin=False):
                     query |= Q(**{"{}__icontains".format(cat): p})
             search_query &= query
 
-            logger.debug("Running query: {}".format(search_query))
+            logger.debug("Running query: %s", search_query)
 
             res = User.objects.filter(search_query)
             results = list(res)

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -372,7 +372,7 @@ class User(AbstractBaseUser, PermissionsMixin):
                 return False
             can_view_anyway = requesting_user and (requesting_user.is_teacher or requesting_user.is_eighthoffice or requesting_user.is_eighth_admin)
         except (AttributeError, KeyError) as e:
-            logger.error("Could not check teacher/eighth override: {}".format(e))
+            logger.error("Could not check teacher/eighth override: %s", e)
             can_view_anyway = False
         return can_view_anyway
 
@@ -844,7 +844,7 @@ class UserProperties(models.Model):
             self.save()
             return True
         except Exception as e:
-            logger.error("Error occurred setting permission {} to {}: {}".format(permission, value, e))
+            logger.error("Error occurred setting permission %s to %s: %s", permission, value, e)
             return False
 
     def _current_user_override(self):
@@ -860,7 +860,7 @@ class UserProperties(models.Model):
                 return False
             can_view_anyway = requesting_user and (requesting_user.is_teacher or requesting_user.is_eighthoffice or requesting_user.is_eighth_admin)
         except (AttributeError, KeyError) as e:
-            logger.error("Could not check teacher/eighth override: {}".format(e))
+            logger.error("Could not check teacher/eighth override: %s", e)
             can_view_anyway = False
         return can_view_anyway
 
@@ -882,7 +882,7 @@ class UserProperties(models.Model):
                 requesting_user_id = request.user.id
                 return str(requesting_user_id) == str(self.user.id)
         except (AttributeError, KeyError) as e:
-            logger.error("Could not check request sender: {}".format(e))
+            logger.error("Could not check request sender: %s", e)
             return False
 
         return False
@@ -895,7 +895,7 @@ class UserProperties(models.Model):
             student = getattr(self, "self_{}".format(permission))
             return (parent and student) or (self.is_http_request_sender() or self._current_user_override())
         except Exception:
-            logger.error("Could not retrieve permissions for {}".format(permission))
+            logger.error("Could not retrieve permissions for %s", permission)
 
     def attribute_is_public(self, permission):
         """ Checks if attribute is visible to public (regardless of admins status)
@@ -905,7 +905,7 @@ class UserProperties(models.Model):
             student = getattr(self, "self_{}".format(permission))
             return (parent and student)
         except Exception:
-            logger.error("Could not retrieve permissions for {}".format(permission))
+            logger.error("Could not retrieve permissions for %s", permission)
 
 
 class Email(models.Model):

--- a/intranet/utils/helpers.py
+++ b/intranet/utils/helpers.py
@@ -69,7 +69,7 @@ class InvalidString(str):
     """An error for undefined context variables in templates."""
 
     def __mod__(self, other):
-        logger.warning('Undefined variable or unknown value for: "%s"' % other)
+        logger.warning('Undefined variable or unknown value for: "%s"', other)
         return ""
 
 
@@ -100,7 +100,7 @@ class GlobList(list):
         try:
             for item in self:
                 if ipaddress.ip_address(key) in ipaddress.ip_network(item) and key != "127.0.0.1":
-                    logger.info("Internal IP: {}".format(key))
+                    logger.info("Internal IP: %s", key)
                     return True
         except ValueError:
             pass


### PR DESCRIPTION
Currently, the interpolation of variables in log messages is very non-standardized. This standardizes on using the interpolation built into `logging.Logger`.

Note: This was originally part of #611, but it was split out because it is more controversial than the changes in that PR.