### PR TITLE
Eighth page tweaks

### DIFF
--- a/intranet/static/css/eighth.profile.scss
+++ b/intranet/static/css/eighth.profile.scss
@@ -98,7 +98,7 @@ table.eighth-table {
 
 section.user {
     &-info-eighth {
-        overflow-x: scroll;
+        overflow-x: auto;
 
         > form {
             min-width: 700px;

--- a/intranet/templates/eighth/activity.html
+++ b/intranet/templates/eighth/activity.html
@@ -185,7 +185,7 @@
             </tr>
         {% empty %}
             <tr>
-            <td colspan="{% if request.user.is_student %}5{% else %}4{% endif %}">
+            <td colspan="{% if request.user.is_student %}6{% else %}5{% endif %}">
                 There were no instances of this activity found within the next two months.
             </td>
             </tr>


### PR DESCRIPTION
These are lumped together simply because neither is big enough to be a separate PR.

The `overflow-x` property was set to `scroll` in 598000f (the blame says it was f74d249, but that commit just changed the formatting). I'm not sure what the rationale was, but I don't think it's necessary.