### PR TITLE
Switch development environments and Travis build from Ruby Sass to Dart Sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ fixtures/README.txt
 .idea/
 
 *fixtures*.tar*
+
+node_modules/
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
 - '3.5'
 - '3.6'
 - '3.7'
-rvm:
-- 2.0
+node_js:
+- "7"
 sudo: false
 cache:
   directories:
@@ -17,11 +17,12 @@ env:
   matrix:
   - PRODUCTION=TRUE
   global:
+  - PATH=$TRAVIS_BUILD_DIR/node_modules/.bin:$PATH
   - secure: fQVrTJV4FyBcRihbrd+MSvWtYHVFLXeX1uTOINZx121k88k1yyH6Qnh2cYpouMfXdTFMc4negTr3ceNqtljVD1za8Q6jWKk0Ht6MWTuDMb/4mynTKn7qufGe0+scJDueofeBymXthEXbRzh1O+1qEmVkxZUwoKCYXIb6Uk2KSeU=
   - secure: BT+ndG5VAs3UxdrF7dTx7MK6SACHG8lf9ABfcAD1FgMi+gccT+R3b6FiQ6AcBn4P+1FqHnoxrOEL4PsxPBAUVLf+wjynOXBMI6Ee+bmUfqLvcP1WwCRK3WhSZpH5lSUr7TCxkGFX7ROOJLnqPScTgQhiWHbCzwV9RcAwHaKj1PM=
   - secure: KmWCQvt6IJh5VAAVuIongjTyLSnsc2QlEOQgmSCAigFjo+qwkeatisho05vCD9nhnqRtEOKFnnPwr/es4uKNUMAVKEqs2N0a2ytBL0jVr4obTTUdUQiaGUxOST5HdaiZY9urDECtwBgXogGImTTG6XdFzi9ah3mmmw5lfMIu+3Y=
 install:
-- gem install sass
+- npm install sass
 - pip install -U pip setuptools
 - pip install -U -r requirements.txt
 - pip install -U coveralls flake8 codacy-coverage

--- a/config/provision_vagrant.sh
+++ b/config/provision_vagrant.sh
@@ -54,9 +54,20 @@ apt-get -y install htop
 apt-get -y install glances
 
 # CSS
-apt-get -y install rubygems || apt-get -y install rubygems-integration
-apt-get -y install ruby-dev
-gem install sass
+if [[ -x "$(which gem)" ]]; then
+    echo
+    echo "Uninstalling deprecated Ruby Sass (and Ruby)"
+    echo
+    gem uninstall sass
+    if dpkg -s rubygems; then
+        apt-get -y remove rubygems
+    else
+        apt-get -y remove rubygems-integration
+    fi
+    apt-get -y remove ruby-dev
+fi
+apt-get -y install npm nodejs-legacy
+npm -g install sass
 
 # PostsgreSQL
 apt-get -y install postgresql


### PR DESCRIPTION
[Ruby Sass is deprecated](https://sass-lang.com/ruby-sass). The new standard implementation is Dart Sass. This PR installs the Node.js-compiled version (Dart can compile to JavaScript).

Dart Sass [is not completely backwards-compatible](https://github.com/sass/dart-sass#behavioral-differences-from-ruby-sass), but it seems that Ruby Sass has deprecated/removed almost all of the features that Dart Sass lacks. In addition, we do not use many of Sass's features, so this switch should not change Ion's behavior. (Testing also shows that Dart Sass compiles all of the `static/css/*.scss` files without complaint.)

The switch will also require changes to the Ion production environment, so this PR should not be merged until a plan for said changes is in place.

Note that if you have a development environment, you will need to re-run `vagrant provision` to apply these changes.