### PR TITLE
Fix alignment of schedule under day type name in calendar view

### DIFF
--- a/intranet/static/css/schedule.scss
+++ b/intranet/static/css/schedule.scss
@@ -58,10 +58,13 @@ body {
     width: 100%;
     min-width: 1100px;
 
+    th {
+        width: 50%;
+    }
+
     td {
         text-align: center;
         width: 19%;
-        min-width: 175px;
 
         h2 {
             font-weight: normal;


### PR DESCRIPTION
Currently becomes misaligned when the screen gets too wide.