### PR TITLE
Fix the build during July

### DIFF
--- a/intranet/utils/date.py
+++ b/intranet/utils/date.py
@@ -1,4 +1,5 @@
 import datetime
+import calendar
 
 from django.conf import settings
 from django.utils import timezone
@@ -14,9 +15,9 @@ def get_date_range_this_year(now=None):
     if now is None:
         now = datetime.datetime.now().date()
     if now.month <= settings.YEAR_TURNOVER_MONTH:
-        date_start = datetime.datetime(now.year - 1, settings.YEAR_TURNOVER_MONTH + 1, 1)
-        date_end = datetime.datetime(now.year, settings.YEAR_TURNOVER_MONTH, 1)
+        date_start = datetime.datetime(now.year - 1, settings.YEAR_TURNOVER_MONTH + 1, 1, 0, 0, 0)
+        date_end = datetime.datetime(now.year, settings.YEAR_TURNOVER_MONTH, calendar.monthrange(now.year, settings.YEAR_TURNOVER_MONTH)[1], 23, 59, 59)
     else:
-        date_start = datetime.datetime(now.year, settings.YEAR_TURNOVER_MONTH + 1, 1)
-        date_end = datetime.datetime(now.year + 1, settings.YEAR_TURNOVER_MONTH, 1)
+        date_start = datetime.datetime(now.year, settings.YEAR_TURNOVER_MONTH + 1, 1, 0, 0, 0)
+        date_end = datetime.datetime(now.year + 1, settings.YEAR_TURNOVER_MONTH, 1, 0, 0, 0)
     return timezone.make_aware(date_start), timezone.make_aware(date_end)


### PR DESCRIPTION
Also took this opportunity to set explicit 00:00:00 times for the `datetime.datetime`s return by `get_date_range_this_year()`.

Note: @theo-o originally tracked down the bug to this function.