### PR TITLE
Upgrade Vagrant to bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 language: python
 python:
-- '3.5'
+#- '3.5'
 - '3.6'
 - '3.7'
 node_js:

--- a/Ion.egg-info/PKG-INFO
+++ b/Ion.egg-info/PKG-INFO
@@ -30,7 +30,7 @@ Description: **********
         
         **What does the TJ Intranet do?** Ion allows students, teachers, and staff at TJHSST to access student information, manage activity signups for TJ's Eighth Period program, and view information on news and events. `Read more about how Ion is used at Thomas Jefferson <https://ion.tjhsst.edu/about>`_.
         
-        **Ion now requires Python 3.5+** Python 3.5 is currently used in both production and testing environments.
+        **Ion now requires Python 3.6+** Python 3.6 is currently used in both production and testing environments.
         
         **How can I create a testing environment?** Read the section on `Setting up Vagrant <https://tjcsl.github.io/ion/setup/vagrant.html>`_ in the documentation.
         

--- a/Ion.egg-info/PKG-INFO
+++ b/Ion.egg-info/PKG-INFO
@@ -48,7 +48,6 @@ Platform: UNKNOWN
 Classifier: Development Status :: 5 - Production/Stable
 Classifier: License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)
 Classifier: Operating System :: POSIX :: Linux
-Classifier: Programming Language :: Python :: 3.5
 Classifier: Programming Language :: Python :: 3.6
 Classifier: Programming Language :: Python :: 3.7
 Classifier: Framework :: Django :: 1.11

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Documentation (in RestructuredText format) is available inside the "docs" folder
 
 **What does the TJ Intranet do?** Ion allows students, teachers, and staff at TJHSST to access student information, manage activity signups for TJ's Eighth Period program, and view information on news and events. `Read more about how Ion is used at Thomas Jefferson <https://ion.tjhsst.edu/about>`_.
 
-**Ion now requires Python 3.5+** Python 3.5 is currently used in both production and testing environments.
+**Ion now requires Python 3.6+** Python 3.6 is currently used in both production and testing environments.
 
 **How can I create a testing environment?** Read the section on `Setting up Vagrant <https://tjcsl.github.io/ion/setup/vagrant.html>`_ in the documentation.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ end
 
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
   config.vm.boot_timeout = 1000
   if devconfig["use_vpn"]
       config.vm.network "public_network", bridge: devconfig["network_interface"]
@@ -76,13 +76,13 @@ Vagrant.configure("2") do |config|
   end
 
   config.bindfs.default_options = {
-    force_user:   'ubuntu',
-    force_group:  'ubuntu',
+    force_user:   'vagrant',
+    force_group:  'vagrant',
     perms:        'u=rwX:g=rD:o=rD'
   }
-  config.bindfs.bind_folder "/vagrant", "/home/ubuntu/intranet",
-      force_user: 'ubuntu',
-      force_group: 'ubuntu'
+  config.bindfs.bind_folder "/vagrant", "/home/vagrant/intranet",
+      force_user: 'vagrant',
+      force_group: 'vagrant'
 
   config.vm.provision "file",
     source: "~/.ssh/#{devconfig['ssh_key']}",
@@ -94,7 +94,5 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", path: "config/provision_vagrant.sh"
 
-  if ARGV[0] == "ssh"
-      config.ssh.username = "ubuntu"
-  end
+  config.ssh.username = "vagrant"
 end

--- a/config/ion_env_setup.sh
+++ b/config/ion_env_setup.sh
@@ -12,7 +12,7 @@ export PATH=$PATH:/usr/lib/postgresql/9.5/bin
 function devconfig() {
     python3 -c "
 import json
-with open('/home/ubuntu/intranet/config/devconfig.json', 'r') as f:
+with open('/home/vagrant/intranet/config/devconfig.json', 'r') as f:
 	print(json.load(f)['$1'])"
 }
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Framework :: Django :: 1.11",


### PR DESCRIPTION
Drops Python 3.5 support.
To test,
```bash
vagrant destroy
vagrant up && vagrant reload
```

Fixes #675 