### PR TITLE
build: only run pylint on one python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
 - cp intranet/settings/travis_secret.py intranet/settings/secret.py
 - psql -U postgres -c 'create database ion'
 script:
-- flake8 --max-line-length 150 --exclude=*/migrations/* .
+- if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]];then flake8 --max-line-length 150 --exclude=*/migrations/* . ;fi
 - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]];then pylint --disable=fixme,broad-except,global-statement,attribute-defined-outside-init intranet/; fi
 - coverage run ./setup.py test
 - coverage run -a ./manage.py migrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
 - psql -U postgres -c 'create database ion'
 script:
 - flake8 --max-line-length 150 --exclude=*/migrations/* .
-- pylint --disable=fixme,broad-except,global-statement,attribute-defined-outside-init intranet/
+- if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]];then pylint --disable=fixme,broad-except,global-statement,attribute-defined-outside-init intranet/; fi
 - coverage run ./setup.py test
 - coverage run -a ./manage.py migrate
 - "./manage.py collectstatic --noinput -v 0"


### PR DESCRIPTION
Since the errors from pylint don't differ (at least substantially) from one Python version to another, we should only run pylint once in the test suite.  This would shave off about 3 minutes from the test matrix.