### PR TITLE
Respect user's primary email for notifications

### DIFF
--- a/intranet/apps/announcements/notifications.py
+++ b/intranet/apps/announcements/notifications.py
@@ -129,8 +129,9 @@ def announcement_posted_email(request, obj, send_all=False):
         send_groups = obj.groups.all()
         emails = []
         users_send = []
+        is_public = not send_groups.exists()
         for u in users:
-            if not send_groups.exists() or send_groups.intersection(u.groups.all()).exists():
+            if is_public or send_groups.intersection(u.groups.all()).exists():
                 # Either it has no groups (public) or user is a member of a send group
                 em = u.emails.first() if u.emails.exists() else u.tj_email
                 if em:

--- a/intranet/apps/announcements/notifications.py
+++ b/intranet/apps/announcements/notifications.py
@@ -130,21 +130,12 @@ def announcement_posted_email(request, obj, send_all=False):
         emails = []
         users_send = []
         for u in users:
-            if not send_groups:
-                # no groups, public.
-                em = u.emails.first() if u.emails.count() >= 1 else u.tj_email
+            if not send_groups.exists() or send_groups.intersection(u.groups.all()).exists():
+                # Either it has no groups (public) or user is a member of a send group
+                em = u.emails.first() if u.emails.exists() else u.tj_email
                 if em:
                     emails.append(em)
                 users_send.append(u)
-            else:
-                # specific to a group
-                user_groups = u.groups.all()
-                if any(i in send_groups for i in user_groups):
-                    # group intersection exists
-                    em = u.emails.first() if u.emails.count() >= 1 else u.tj_email
-                    if em:
-                        emails.append(em)
-                    users_send.append(u)
 
         logger.debug(users_send)
         logger.debug(emails)

--- a/intranet/apps/announcements/notifications.py
+++ b/intranet/apps/announcements/notifications.py
@@ -133,7 +133,7 @@ def announcement_posted_email(request, obj, send_all=False):
         for u in users:
             if is_public or send_groups.intersection(u.groups.all()).exists():
                 # Either it has no groups (public) or user is a member of a send group
-                em = u.emails.first() if u.emails.exists() else u.tj_email
+                em = u.notification_email
                 if em:
                     emails.append(em)
                 users_send.append(u)

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -309,6 +309,21 @@ class User(AbstractBaseUser, PermissionsMixin):
         return "{}@{}".format(self.username, domain)
 
     @property
+    def notification_email(self):
+        """Returns the notification email.
+
+        If a primary email is set, use it. Otherwise, use the first
+        email on file. If no email addresses exist, use the user's
+        TJ email.
+
+        Returns:
+            A user's notification email address
+
+        """
+
+        return self.primary_email or self.emails.first() or self.tj_email
+
+    @property
     def default_photo(self):
         """Returns default photo (in binary) that should be used
 
@@ -912,6 +927,7 @@ class UserDarkModeProperties(models.Model):
     """
     Contains user properties relating to dark mode
     """
+
     user = models.OneToOneField(settings.AUTH_USER_MODEL, related_name="dark_mode_properties", on_delete=models.CASCADE)
     _dark_mode_unlocked = models.BooleanField(default=False)
     dark_mode_enabled = models.BooleanField(default=False)
@@ -1040,6 +1056,7 @@ class Photo(models.Model):
 
 class Grade:
     """Represents a user's grade."""
+
     names = [elem[1] for elem in GRADE_NUMBERS]
 
     def __init__(self, graduation_year):

--- a/intranet/apps/users/tests.py
+++ b/intranet/apps/users/tests.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from oauth2_provider.models import get_application_model, AccessToken
 from oauth2_provider.settings import oauth2_settings
 
-from .models import PERMISSIONS_NAMES, Address, Course, Section
+from .models import PERMISSIONS_NAMES, Address, Course, Section, Email
 from ..eighth.models import EighthBlock, EighthActivity, EighthScheduledActivity, EighthSignup
 from ..nomination.models import Nomination, NominationPosition
 from ...test.ion_test import IonTestCase
@@ -91,6 +91,22 @@ class CourseTest(IonTestCase):
 class UserTest(IonTestCase):
     def test_get_signage_user(self):
         self.assertEqual(get_user_model().get_signage_user().id, 99999)
+
+    def test_notification_email(self):
+        # Test default user notification email property
+        user = self.login()
+        self.assertEqual(user.primary_email, None)
+        self.assertFalse(user.emails.exists())
+        self.assertEqual(str(user.tj_email), "{}@tjhsst.edu".format(user.username))
+        self.assertEqual(user.notification_email, user.tj_email)
+
+        email = Email.objects.create(user=user, address="test@example.com")
+        self.assertEqual(user.notification_email, email)
+
+        # Set primary email
+        user.primary_email = Email.objects.create(user=user, address="test2@example.com")
+        user.save()
+        self.assertEqual(user.notification_email, user.primary_email)
 
 
 class ProfileTest(IonTestCase):


### PR DESCRIPTION
When sending email notifications, we should first try the user's set primary email address before falling back. This PR also does some refactoring.

Fixes #600 