### PR TITLE
Prohibit setting fcpsschools.net as an email

### DIFF
--- a/intranet/apps/preferences/forms.py
+++ b/intranet/apps/preferences/forms.py
@@ -10,18 +10,16 @@ logger = logging.getLogger(__name__)
 
 
 class BusRouteForm(forms.Form):
-
     def __init__(self, *args, **kwargs):
         super(BusRouteForm, self).__init__(*args, **kwargs)
         self.BUS_ROUTE_CHOICES = [(None, "Set bus route...")]
         routes = Route.objects.all().order_by("route_name")
         for route in routes:
             self.BUS_ROUTE_CHOICES += [(route.route_name, route.route_name)]
-        self.fields['bus_route'] = forms.ChoiceField(choices=self.BUS_ROUTE_CHOICES, widget=forms.Select, required=False)
+        self.fields["bus_route"] = forms.ChoiceField(choices=self.BUS_ROUTE_CHOICES, widget=forms.Select, required=False)
 
 
 class PreferredPictureForm(forms.Form):
-
     def __init__(self, user, *args, **kwargs):
         super(PreferredPictureForm, self).__init__(*args, **kwargs)
 
@@ -39,7 +37,6 @@ class PreferredPictureForm(forms.Form):
 
 
 class PrivacyOptionsForm(forms.Form):
-
     def __init__(self, user, *args, **kwargs):
         super(PrivacyOptionsForm, self).__init__(*args, **kwargs)
 
@@ -77,11 +74,10 @@ class PrivacyOptionsForm(forms.Form):
         if not user.has_admin_permission("preferences"):
             for name in self.fields:
                 if not name.endswith("-self"):
-                    self.fields[name].widget.attrs['class'] = 'disabled'
+                    self.fields[name].widget.attrs["class"] = "disabled"
 
 
 class NotificationOptionsForm(forms.Form):
-
     def __init__(self, user, *args, **kwargs):
         super(NotificationOptionsForm, self).__init__(*args, **kwargs)
 
@@ -94,47 +90,45 @@ class NotificationOptionsForm(forms.Form):
         if user.emails.all().count() == 0:
             label = "You can set a primary email after adding emails below."
         self.fields["primary_email"] = forms.ModelChoiceField(
-            queryset=Email.objects.filter(user=user), required=False, label=label, disabled=(user.emails.all().count() == 0))
+            queryset=Email.objects.filter(user=user), required=False, label=label, disabled=(user.emails.all().count() == 0)
+        )
 
 
 class DarkModeForm(forms.Form):
     def __init__(self, user, *args, **kwargs):
         super(DarkModeForm, self).__init__(*args, **kwargs)
         self.fields["dark_mode_enabled"] = forms.BooleanField(
-            initial=user.dark_mode_properties.dark_mode_enabled,
-            label="Enable dark mode?",
-            required=False,
+            initial=user.dark_mode_properties.dark_mode_enabled, label="Enable dark mode?", required=False
         )
 
 
 class PhoneForm(forms.ModelForm):
     """Represents a phone number (number + purpose)"""
+
     _number = forms.CharField(max_length=14)
 
     class Meta:
         model = Phone
-        fields = ['purpose', '_number']
+        fields = ["purpose", "_number"]
 
 
 class EmailForm(forms.ModelForm):
-
     def clean_address(self):
         data = self.cleaned_data["address"]
         if "@fcpsschools.net" in data.lower():
-            raise forms.ValidationError("You cannot provide a fcpsschools.net address.",code="invalid")
+            raise forms.ValidationError("You cannot provide a fcpsschools.net address.", code="invalid")
 
         return data
 
     class Meta:
         model = Email
-        fields = ['address']
+        fields = ["address"]
 
 
 class WebsiteForm(forms.ModelForm):
-
     class Meta:
         model = Website
-        fields = ['url']
+        fields = ["url"]
 
 
 PhoneFormset = forms.inlineformset_factory(get_user_model(), Phone, form=PhoneForm, extra=1)

--- a/intranet/apps/preferences/forms.py
+++ b/intranet/apps/preferences/forms.py
@@ -115,7 +115,7 @@ class PhoneForm(forms.ModelForm):
 class EmailForm(forms.ModelForm):
     def clean_address(self):
         data = self.cleaned_data["address"]
-        if "@fcpsschools.net" in data.lower():
+        if data.lower().strip().endswith("@fcpsschools.net"):
             raise forms.ValidationError("You cannot provide a fcpsschools.net address.", code="invalid")
 
         return data

--- a/intranet/apps/preferences/forms.py
+++ b/intranet/apps/preferences/forms.py
@@ -118,6 +118,13 @@ class PhoneForm(forms.ModelForm):
 
 class EmailForm(forms.ModelForm):
 
+    def clean_address(self):
+        data = self.cleaned_data["address"]
+        if "@fcpsschools.net" in data.lower():
+            raise forms.ValidationError("You cannot provide a fcpsschools.net address.",code="invalid")
+
+        return data
+
     class Meta:
         model = Email
         fields = ['address']

--- a/intranet/apps/preferences/tests.py
+++ b/intranet/apps/preferences/tests.py
@@ -128,7 +128,7 @@ class PreferencesFormTest(IonTestCase):
     def test_email_form(self):
         # Indirect test of formset validation
 
-        user = self.login()
+        _ = self.login()
 
         # Test valid address
         form_params = {"address": "test@example.com"}

--- a/intranet/apps/preferences/tests.py
+++ b/intranet/apps/preferences/tests.py
@@ -123,6 +123,7 @@ class PreferencesTest(IonTestCase):
             self.assertEqual(route_name, choices[index][0])
             self.assertEqual(choices[index][1], choices[index][0])
 
+
 class PreferencesFormTest(IonTestCase):
 
     def test_email_form(self):

--- a/intranet/apps/preferences/tests.py
+++ b/intranet/apps/preferences/tests.py
@@ -4,6 +4,7 @@ from django.contrib.auth import get_user_model
 from django.test.client import RequestFactory
 
 from .views import save_bus_route
+from .forms import EmailForm
 from ..bus.models import Route
 from ...test.ion_test import IonTestCase
 
@@ -121,3 +122,21 @@ class PreferencesTest(IonTestCase):
         for index, route_name in enumerate(self.route_names):
             self.assertEqual(route_name, choices[index][0])
             self.assertEqual(choices[index][1], choices[index][0])
+
+class PreferencesFormTest(IonTestCase):
+
+    def test_email_form(self):
+        # Indirect test of formset validation
+
+        user = self.login()
+
+        # Test valid address
+        form_params = {"address": "test@example.com"}
+        form = EmailForm(form_params)
+        self.assertTrue(form.is_valid())
+
+        # Test invalid address
+        form_params = {"address": "test@fcpsschools.net"}
+        form = EmailForm(form_params)
+        self.assertFalse(form.is_valid())
+        self.assertTrue(form.has_error("address", code="invalid"))

--- a/intranet/apps/preferences/views.py
+++ b/intranet/apps/preferences/views.py
@@ -52,6 +52,9 @@ def save_personal_info(request, user):
     if email_formset.is_valid():
         email_formset.save()
     else:
+        for error in email_formset.errors:
+            if isinstance(error.get("address"), list):
+                errors.append(error["address"][0])
         errors.append('Could not set emails.')
     if website_formset.is_valid():
         website_formset.save()


### PR DESCRIPTION
Blocks users from setting an `fcpsschools.net` address via preferences.

Fixes #599 