### PR TITLE
Fix dark mode stylesheet names

### DIFF
--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -275,8 +275,8 @@ LIST_OF_INDEPENDENT_CSS = [
     "dark/events",
     "dark/dashboard",
     "dark/dashboard.widgets",
-    "dark/schedule.widgets",
-    "dark/nav"
+    "dark/schedule.widget",
+    "dark/nav",
     "dark/cke",
     "dark/polls",
     "dark/bus",


### PR DESCRIPTION
I missed a comma when I rebased `dark-mode` against `dev` and resolved the conflicts to make it mergeable.