### PR TITLE
perf(eighth): improve SQL queries for

### DIFF
--- a/intranet/apps/eighth/views/admin/general.py
+++ b/intranet/apps/eighth/views/admin/general.py
@@ -6,6 +6,7 @@ from cacheops import invalidate_all
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
+from django.db.models import Count
 from django.shortcuts import redirect, render
 
 from ...forms.admin import general as general_forms
@@ -28,7 +29,7 @@ def eighth_admin_dashboard_view(request, **kwargs):
     else:
         blocks_next_date = blocks_after_start_date[0].date
         blocks_next = EighthBlock.objects.filter(date=blocks_next_date)
-    groups = Group.objects.prefetch_related("user_set", "groupproperties").order_by("name")
+    groups = Group.objects.prefetch_related("groupproperties").annotate(user_count=Count("user")).order_by("name")
     rooms = EighthRoom.objects.all()
     sponsors = EighthSponsor.objects.select_related("user").order_by("last_name", "first_name")
 

--- a/intranet/templates/eighth/admin/dashboard.html
+++ b/intranet/templates/eighth/admin/dashboard.html
@@ -81,7 +81,7 @@
             <select id="group-select" placeholder="Select or search for a group">
                 <option value="">Select or search for a group</option>
                 {% for group in groups %}
-                    <option value="{{ group.id }}">{{ group.name }}{% if group.properties.student_visible %} (Student-visible){% endif %} -- {{ group.user_set.count }} members</option>
+                    <option value="{{ group.id }}">{{ group.name }}{% if group.properties.student_visible %} (Student-visible){% endif %} -- {{ group.user_count }} members</option>
                 {% endfor %}
             </select>
             {% endcached_as %}


### PR DESCRIPTION
eighth_dashboard by more than 60% for loading # of users per Group by annotating the user_set count instead of full prefetchs.

(Based on timings from sqldebugshell)
```
>>> before=25.49+1.98
>>> after=8.36+1.6
>>> 1-(after/before)
0.6374226428831453
```