### PR TITLE
Email and profile fixes/improvements

### DIFF
--- a/intranet/apps/announcements/notifications.py
+++ b/intranet/apps/announcements/notifications.py
@@ -87,11 +87,7 @@ def announcement_approved_email(request, obj, req):
     """ Email to teachers who approved. """
     teachers = req.teachers_approved.all()
 
-    teacher_emails = []
-    for u in teachers:
-        em = u.tj_email
-        if em:
-            teacher_emails.append(em)
+    teacher_emails = [u.tj_email for u in teachers]
 
     base_url = request.build_absolute_uri(reverse("index"))
     url = request.build_absolute_uri(reverse("view_announcement", args=[obj.id]))
@@ -102,14 +98,11 @@ def announcement_approved_email(request, obj, req):
         messages.success(request, "Sent teacher approved email to {} users".format(len(teacher_emails)))
     """ Email to submitter. """
     submitter = req.user
-    submitter_email = submitter.tj_email
-    if submitter_email:
-        submitter_emails = [submitter_email]
-        data = {"announcement": obj, "request": req, "info_link": url, "base_url": base_url, "role": "submitted"}
-        email_send(
-            "announcements/emails/announcement_approved.txt", "announcements/emails/announcement_approved.html", data, subject, submitter_emails
-        )
-        messages.success(request, "Sent teacher approved email to {} users".format(len(submitter_emails)))
+    data = {"announcement": obj, "request": req, "info_link": url, "base_url": base_url, "role": "submitted"}
+    email_send(
+        "announcements/emails/announcement_approved.txt", "announcements/emails/announcement_approved.html", data, subject, [submitter.tj_email]
+    )
+    messages.success(request, "Sent teacher approved email to announcement request submitter")
 
 
 def announcement_posted_email(request, obj, send_all=False):

--- a/intranet/apps/eighth/models.py
+++ b/intranet/apps/eighth/models.py
@@ -879,7 +879,8 @@ class EighthScheduledActivity(AbstractBaseEighthModel):
     def notify_waitlist(self, waitlists, activity):
         data = {"activity": activity}
         for waitlist in waitlists:
-            email_send("eighth/emails/waitlist.txt", "eighth/emails/waitlist.html", data, "Open Spot Notification", [waitlist.user.primary_email])
+            email_send("eighth/emails/waitlist.txt", "eighth/emails/waitlist.html", data, "Open Spot Notification",
+                       [waitlist.user.primary_email_address])
 
     @transaction.atomic
     def add_user(self, user, request=None, force=False, no_after_deadline=False, add_to_waitlist=False):
@@ -950,7 +951,7 @@ class EighthScheduledActivity(AbstractBaseEighthModel):
                     )
                 ):
                     # pylint: enable=too-many-boolean-expressions
-                    if user.primary_email:
+                    if user.primary_email_address:
                         if EighthWaitlist.objects.filter(user_id=user.id, block_id=self.block.id).exists():
                             EighthWaitlist.objects.filter(user_id=user.id, block_id=self.block.id).delete()
                         waitlist = EighthWaitlist.objects.create(user=user, block=self.block, scheduled_activity=sched_act)

--- a/intranet/apps/eighth/views/admin/attendance.py
+++ b/intranet/apps/eighth/views/admin/attendance.py
@@ -178,7 +178,7 @@ def delinquent_students_view(request):
             counselor = delinquent["user"].counselor
             row.append(counselor.last_name if counselor else "")
             row.append(delinquent["user"].tj_email)
-            row.append(delinquent["user"].emails.first() if delinquent["user"].emails and delinquent["user"].emails.count() > 0 else "")
+            row.append(delinquent["user"].non_tj_email or "")
             writer.writerow(row)
 
         return response
@@ -204,7 +204,7 @@ def no_signups_roster(request, block_id):
         response = http.HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = 'attachment; filename="no_signups_roster.csv"'
         writer = csv.writer(response)
-        writer.writerow(["Block ID", "Block Date", "Last Name", "First Name", "Student ID", "Grade", "Counselor", "TJ Email", "Other Email"])
+        writer.writerow(["Block ID", "Block Date", "Last Name", "First Name", "Student ID", "Grade", "Counselor", "TJ Email", "Personal Email"])
 
         for user in unsigned:
             row = []
@@ -217,7 +217,7 @@ def no_signups_roster(request, block_id):
             counselor = user.counselor
             row.append(counselor.last_name if counselor else "")
             row.append(user.tj_email)
-            row.append(user.non_tj_email)
+            row.append(user.non_tj_email or "")
             writer.writerow(row)
 
         return response

--- a/intranet/apps/eighth/views/admin/attendance.py
+++ b/intranet/apps/eighth/views/admin/attendance.py
@@ -177,7 +177,7 @@ def delinquent_students_view(request):
             row.append(delinquent["user"].grade.number)
             counselor = delinquent["user"].counselor
             row.append(counselor.last_name if counselor else "")
-            row.append("{}".format(delinquent["user"].tj_email))
+            row.append(delinquent["user"].tj_email)
             row.append(delinquent["user"].emails.first() if delinquent["user"].emails and delinquent["user"].emails.count() > 0 else "")
             writer.writerow(row)
 
@@ -216,7 +216,7 @@ def no_signups_roster(request, block_id):
             row.append(user.grade.number)
             counselor = user.counselor
             row.append(counselor.last_name if counselor else "")
-            row.append("{}".format(user.tj_email))
+            row.append(user.tj_email)
             row.append(user.non_tj_email)
             writer.writerow(row)
 

--- a/intranet/apps/eighth/views/admin/groups.py
+++ b/intranet/apps/eighth/views/admin/groups.py
@@ -99,14 +99,13 @@ def edit_group_view(request, group_id):
     members = []
     for user in page:
         grade = user.grade
-        emails = user.emails
         members.append(
             {
                 "id": user.id,
                 "first_name": user.first_name,
                 "last_name": user.last_name,
                 "student_id": user.student_id,
-                "email": user.tj_email if user.tj_email else emails.first() if emails.count() > 0 else "",
+                "email": user.tj_email,
                 "grade": grade.number if user.grade and not user.grade.number == 13 else "Staff",
             }
         )
@@ -363,8 +362,7 @@ def download_group_csv_view(request, group_id):
         row.append(user.student_id)
         grade = user.grade
         row.append(grade.number if grade else "Staff")
-        emails = user.emails
-        row.append(user.tj_email if user.tj_email else emails.first() if emails.count() > 0 else None)
+        row.append(user.tj_email)
         writer.writerow(row)
 
     return response

--- a/intranet/apps/feedback/views.py
+++ b/intranet/apps/feedback/views.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def send_feedback_email(request, data):
     data["user"] = request.user
-    email = request.user.tj_email if request.user and request.user.tj_email else "unknown-{}@tjhsst.edu".format(request.user)
+    email = request.user.tj_email if request.user.is_authenticated else "unknown-{}@tjhsst.edu".format(request.user)
     data["email"] = email
     data["remote_ip"] = (request.META["HTTP_X_FORWARDED_FOR"] if "HTTP_X_FORWARDED_FOR" in request.META else request.META.get("REMOTE_ADDR", ""))
     data["user_agent"] = request.META.get("HTTP_USER_AGENT")

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -300,7 +300,7 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         for email in self.emails.all():
             if email.address.endswith(("@fcps.edu", "@tjhsst.edu")):
-                return email
+                return email.address
 
         if self.is_teacher:
             domain = "fcps.edu"
@@ -323,10 +323,12 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         """
         tj_email = self.tj_email
-        if self.primary_email and self.primary_email != tj_email:
-            return self.primary_email
 
-        return self.emails.exclude(address__iexact=tj_email).first()
+        if self.primary_email and self.primary_email.address != tj_email:
+            return self.primary_email.address
+
+        email = self.emails.exclude(address__iexact=tj_email).first()
+        return email.address if email else None
 
     @property
     def notification_email(self):
@@ -341,7 +343,11 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         """
 
-        return self.primary_email or self.emails.first() or self.tj_email
+        if self.primary_email:
+            return self.primary_email.address
+
+        email = self.emails.first()
+        return email.address if email and email.address else self.tj_email
 
     @property
     def default_photo(self):

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -288,6 +288,13 @@ class User(AbstractBaseUser, PermissionsMixin):
         return self.short_name
 
     @property
+    def primary_email_address(self):
+        try:
+            return self.primary_email.address if self.primary_email else None
+        except Email.DoesNotExist:
+            return None
+
+    @property
     def tj_email(self):
         """Get (or guess) a user's TJ email.
 
@@ -324,8 +331,8 @@ class User(AbstractBaseUser, PermissionsMixin):
         """
         tj_email = self.tj_email
 
-        if self.primary_email and self.primary_email.address != tj_email:
-            return self.primary_email.address
+        if self.primary_email_address and self.primary_email_address != tj_email:
+            return self.primary_email_address
 
         email = self.emails.exclude(address__iexact=tj_email).first()
         return email.address if email else None
@@ -343,8 +350,8 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         """
 
-        if self.primary_email:
-            return self.primary_email.address
+        if self.primary_email_address:
+            return self.primary_email_address
 
         email = self.emails.first()
         return email.address if email and email.address else self.tj_email

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -472,6 +472,17 @@ class User(AbstractBaseUser, PermissionsMixin):
         return self.properties.attribute_is_visible("show_eighth")
 
     @property
+    def can_view_phone(self):
+        """Checks if a user has the show_telephone permission.
+
+        Returns:
+            Boolean
+
+        """
+
+        return self.properties.attribute_is_visible("show_telephone")
+
+    @property
     def is_eighth_admin(self):
         """Checks if user is an eighth period admin.
 

--- a/intranet/apps/users/tests.py
+++ b/intranet/apps/users/tests.py
@@ -97,7 +97,7 @@ class UserTest(IonTestCase):
         user = self.login()
         self.assertEqual(user.primary_email, None)
         self.assertFalse(user.emails.exists())
-        self.assertEqual(str(user.tj_email), "{}@tjhsst.edu".format(user.username))
+        self.assertEqual(user.tj_email, "{}@tjhsst.edu".format(user.username))
         self.assertEqual(user.notification_email, user.tj_email)
 
         email = Email.objects.create(user=user, address="test@example.com")

--- a/intranet/apps/users/tests.py
+++ b/intranet/apps/users/tests.py
@@ -101,12 +101,12 @@ class UserTest(IonTestCase):
         self.assertEqual(user.notification_email, user.tj_email)
 
         email = Email.objects.create(user=user, address="test@example.com")
-        self.assertEqual(user.notification_email, email)
+        self.assertEqual(user.notification_email, email.address)
 
         # Set primary email
         user.primary_email = Email.objects.create(user=user, address="test2@example.com")
         user.save()
-        self.assertEqual(user.notification_email, user.primary_email)
+        self.assertEqual(user.notification_email, user.primary_email.address)
 
 
 class ProfileTest(IonTestCase):

--- a/intranet/apps/users/tests.py
+++ b/intranet/apps/users/tests.py
@@ -106,7 +106,7 @@ class UserTest(IonTestCase):
         # Set primary email
         user.primary_email = Email.objects.create(user=user, address="test2@example.com")
         user.save()
-        self.assertEqual(user.notification_email, user.primary_email.address)
+        self.assertEqual(user.notification_email, user.primary_email_address)
 
 
 class ProfileTest(IonTestCase):

--- a/intranet/templates/users/profile.html
+++ b/intranet/templates/users/profile.html
@@ -197,7 +197,7 @@
                                 <td> {{ profile_user.counselor.last_name }} </td>
                             </div>
                         {% endif %}
-                        {% if profile_user.emails %}
+                        {% if profile_user.emails.exists %}
                         {% if request.user.is_teacher and not profile_user.non_tj_email or request.user.is_eighth_admin and not profile_user.non_tj_email %}
                             <!-- Don't duplicate TJ email -->
                         {% else %}

--- a/intranet/templates/users/profile.html
+++ b/intranet/templates/users/profile.html
@@ -220,13 +220,13 @@
                         </tr>
                         {% endif %}
                         {% endif %}
-                        {% if profile_user.webpages %}
+                        {% if profile_user.websites.exists %}
                         <tr>
                             <th>
                                 Web
                             </th>
                             <td>
-                                {% for url in profile_user.webpages %}
+                                {% for url in profile_user.websites.all %}
                                 <a href="{% if "javascript:" in url %}{{ url|cut:"http://"|cut:"https://" }}{% else %}{{ url }}{% endif %}">{{ url|cut:"http://"|cut:"https://" }}</a>
                                 {% if not forloop.last %}<br>{% endif %}
                                 {% endfor %}

--- a/intranet/templates/users/profile.html
+++ b/intranet/templates/users/profile.html
@@ -255,7 +255,8 @@
                         {% endif %}
                         {% endcomment %}
 
-                        {% if profile_user.phones %}
+                        {% if profile_user.phones.exists %}
+                        {% if profile_user.can_view_phone or request.user == profile_user or request.user.is_teacher or request.user.is_eighth_admin %}
                         <tr>
                             <th>
                                 Phone Number{{ profile_user.phones.all|pluralize }}
@@ -272,6 +273,7 @@
                                 {% endfor %}
                             </td>
                         </tr>
+                        {% endif %}
                         {% endif %}
                         {% if profile_user.address %}
                         <tr>


### PR DESCRIPTION
The main changes:
* `User.tj_email` and `User.notification_email` now always return string email addresses.
* `User.non_tj_email` now always returns either a string email address or `None`.
* Profile items (websites, phones, email addresses) are now displayed correctly.

Things that were intentionally not changed:
* Certain parts of the codebase, including parts that this PR modifies, hardcode references to `user.tj_email` that perhaps could (should?) be switched to `user.notification_email` were not. That is because the main goal of this PR is fixing bugs. A later PR can easily switch those to `user.notifcation_email`.
* The waitlist functionality (though it is disabled, this is worth mentioning) currently requires `user.primary_email` to be set. While perhaps that could be switched to `user.notification_email`, I do not think that is a good idea. Many people do not check their TJ email address, so they should be required to explicitly set a primary email address to ensure that they will actually get waitlist-related emails.