### PR TITLE
Remove fastclick

### DIFF
--- a/intranet/templates/page_base.html
+++ b/intranet/templates/page_base.html
@@ -40,9 +40,6 @@
                 nope: "{% static 'js/vendor/PIE/PIE.js' %}"
             });
 
-            {% block modernizr %}
-            {% endblock %}
-
             $(function() {
                 $("body").removeClass("notransition");
             });

--- a/intranet/templates/page_base.html
+++ b/intranet/templates/page_base.html
@@ -40,16 +40,6 @@
                 nope: "{% static 'js/vendor/PIE/PIE.js' %}"
             });
 
-            Modernizr.load({
-                test: Modernizr.touch,
-                yep: "//cdnjs.cloudflare.com/ajax/libs/fastclick/1.0.2/fastclick.min.js",
-                complete: function() {
-                    if (Modernizr.touch) {
-                        FastClick.attach(document.body);
-                    }
-                }
-            });
-
             {% block modernizr %}
             {% endblock %}
 


### PR DESCRIPTION
Per https://developers.google.com/web/updates/2013/12/300ms-tap-delay-gone-away and https://stackoverflow.com/questions/42250283/is-fastclick-js-still-needed, unless people are running old mobile browsers, fastclick is no longer needed.

Fixes #353
