### PR TITLE
Use Celery to send emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,17 @@ env:
     # CODACY_PROJECT_TOKEN
   - secure: KmWCQvt6IJh5VAAVuIongjTyLSnsc2QlEOQgmSCAigFjo+qwkeatisho05vCD9nhnqRtEOKFnnPwr/es4uKNUMAVKEqs2N0a2ytBL0jVr4obTTUdUQiaGUxOST5HdaiZY9urDECtwBgXogGImTTG6XdFzi9ah3mmmw5lfMIu+3Y=
 before_install:
+- sudo apt update
 - nvm use 11
 install:
+- sudo apt install -y rabbitmq-server
 - npm install sass
 - pip install -U pip setuptools
 - pip install -U -r requirements.txt
 - pip install -U coveralls flake8 pylint pylint-django codacy-coverage
 before_script:
 - cp intranet/settings/travis_secret.py intranet/settings/secret.py
+- sudo systemctl start rabbitmq-server
 - psql -U postgres -c 'create database ion'
 script:
 - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then flake8 --max-line-length 150 --exclude=*/migrations/* .; fi

--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -121,6 +121,7 @@ docs/sourcedoc/intranet.utils.rst
 docs/sourcedoc/modules.rst
 intranet/__init__.py
 intranet/asgi.py
+intranet/celery.py
 intranet/routing.py
 intranet/urls.py
 intranet/wsgi.py
@@ -1818,3 +1819,4 @@ scripts/export_fixtures.sh
 scripts/import_fixtures.sh
 scripts/make_dark_pattern_images.py
 scripts/push_docs.sh
+scripts/restart_celery.sh

--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -439,6 +439,7 @@ intranet/apps/nomination/migrations/__init__.py
 intranet/apps/notifications/__init__.py
 intranet/apps/notifications/emails.py
 intranet/apps/notifications/models.py
+intranet/apps/notifications/tasks.py
 intranet/apps/notifications/urls.py
 intranet/apps/notifications/views.py
 intranet/apps/notifications/migrations/0001_initial.py

--- a/Ion.egg-info/requires.txt
+++ b/Ion.egg-info/requires.txt
@@ -6,6 +6,7 @@ Babel==2.6.0
 bcrypt==3.1.7
 beautifulsoup4==4.7.1
 bleach==3.1.0
+celery==4.3.0
 certifi==2019.06.16
 channels==1.1.8
 contextlib2==0.5.5

--- a/config/provision_vagrant.sh
+++ b/config/provision_vagrant.sh
@@ -90,6 +90,9 @@ echo | ./install_server.sh
 cd ../..
 rm -rf redis-stable redis-stable.tar.gz
 
+# RabbitMQ
+apt-get -y install rabbitmq-server
+
 # Ion
 master_pwd='swordfish'
 master_pwd_hash='pbkdf2_sha256$15000$GrqEVqNcFQmM$V55xZbQkVANeKb9BPaAV3vENYVd6yadJ5fjsbWnFpo0='

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -6,6 +6,7 @@ Babel==2.6.0
 bcrypt==3.1.7
 beautifulsoup4==4.7.1
 bleach==3.1.0
+celery==4.3.0
 certifi==2019.06.16
 channels==1.1.8
 contextlib2==0.5.5

--- a/docs/sourcedoc/intranet.apps.notifications.rst
+++ b/docs/sourcedoc/intranet.apps.notifications.rst
@@ -20,6 +20,14 @@ intranet.apps.notifications.models module
    :undoc-members:
    :show-inheritance:
 
+intranet.apps.notifications.tasks module
+----------------------------------------
+
+.. automodule:: intranet.apps.notifications.tasks
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 intranet.apps.notifications.urls module
 ---------------------------------------
 

--- a/docs/sourcedoc/intranet.rst
+++ b/docs/sourcedoc/intranet.rst
@@ -23,6 +23,14 @@ intranet.asgi module
    :undoc-members:
    :show-inheritance:
 
+intranet.celery module
+----------------------
+
+.. automodule:: intranet.celery
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 intranet.routing module
 -----------------------
 

--- a/intranet/__init__.py
+++ b/intranet/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ('celery_app',)

--- a/intranet/apps/eighth/models.py
+++ b/intranet/apps/eighth/models.py
@@ -16,7 +16,7 @@ from sentry_sdk import add_breadcrumb, capture_exception
 from simple_history.models import HistoricalRecords
 
 from . import exceptions as eighth_exceptions
-from ..notifications.emails import email_send
+from ..notifications.tasks import email_send_task
 from ...utils.date import is_current_year, get_date_range_this_year
 from ...utils.deletion import set_historical_user
 
@@ -951,8 +951,8 @@ class EighthScheduledActivity(AbstractBaseEighthModel):
 
         """
         for waitlist in waitlists:
-            email_send("eighth/emails/waitlist.txt", "eighth/emails/waitlist.html", {"activity": waitlist.scheduled_activity},
-                       "Open Spot Notification", [waitlist.user.primary_email_address])
+            email_send_task.delay("eighth/emails/waitlist.txt", "eighth/emails/waitlist.html", {"activity": waitlist.scheduled_activity},
+                                  "Open Spot Notification", [waitlist.user.primary_email_address])
 
     @transaction.atomic
     def add_user(self, user, request=None, force=False, no_after_deadline=False, add_to_waitlist=False):

--- a/intranet/apps/eighth/tests.py
+++ b/intranet/apps/eighth/tests.py
@@ -253,21 +253,21 @@ class EighthTest(EighthAbstractTest):
         room1 = self.add_room(name="room1", capacity=1)
         act1.rooms.add(room1)
 
-        msg = signup_status_email(user1, [block1, block2])
+        msg = signup_status_email(user1, [block1, block2], use_celery=False)
         self.assertIn("Jan. 1, 2015 (B): No activity selected", msg.body)
         self.assertIn("Jan. 1, 2015 (A): No activity selected", msg.body)
 
         sa1 = EighthScheduledActivity.objects.get_or_create(block=block1, activity=act1)[0]
         sa1.add_user(user1)
 
-        msg = signup_status_email(user1, [block1, block2])
+        msg = signup_status_email(user1, [block1, block2], use_celery=False)
         self.assertIn("Jan. 1, 2015 (B): No activity selected", msg.body)
         self.assertNotIn("Jan. 1, 2015 (A): No activity selected", msg.body)
 
         sa2 = EighthScheduledActivity.objects.get_or_create(block=block2, activity=act1)[0]
         sa2.add_user(user1)
 
-        msg = signup_status_email(user1, [block1, block2])
+        msg = signup_status_email(user1, [block1, block2], use_celery=False)
         self.assertNotIn("Jan. 1, 2015 (B): No activity selected", msg.body)
         self.assertNotIn("Jan. 1, 2015 (A): No activity selected", msg.body)
 
@@ -284,7 +284,7 @@ class EighthTest(EighthAbstractTest):
         sa1.attendance_taken = True
         es1 = EighthSignup.objects.get_or_create(user=user1, was_absent=True, scheduled_activity=sa1)[0]
 
-        msg = absence_email(es1)
+        msg = absence_email(es1, use_celery=False)
         self.assertIn("Jan. 1, 2015 (A)", msg.body)
 
     def test_take_attendance_zero(self):

--- a/intranet/apps/eighth/views/admin/maintenance.py
+++ b/intranet/apps/eighth/views/admin/maintenance.py
@@ -20,7 +20,7 @@ from ....auth.decorators import eighth_admin_required, reauthentication_required
 
 from ....users.models import Address, Course, Section
 
-from ....notifications.emails import email_send
+from ....notifications.tasks import email_send_task
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +138,7 @@ class ImportThread(threading.Thread):
         content.seek(0)
 
         data = {"log": content.read(), "failure": failure, "help_email": settings.FEEDBACK_EMAIL, "date": start_time.strftime("%I:%M:%S %p %m/%d/%Y")}
-        email_send(
+        email_send_task.delay(
             "eighth/emails/import_notify.txt",
             "eighth/emails/import_notify.html",
             data,

--- a/intranet/apps/events/notifications.py
+++ b/intranet/apps/events/notifications.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.urls import reverse
 
-from ..notifications.emails import email_send
+from ..notifications.tasks import email_send_task
 
 
 def event_approval_request(request, event):
@@ -11,4 +11,4 @@ def event_approval_request(request, event):
     base_url = request.build_absolute_uri(reverse("index"))
     data = {"event": event, "info_link": request.build_absolute_uri(reverse("event", args=[event.id])), "base_url": base_url}
 
-    email_send("events/emails/admin_approve.txt", "events/emails/admin_approve.html", data, subject, emails)
+    email_send_task.delay("events/emails/admin_approve.txt", "events/emails/admin_approve.html", data, subject, emails)

--- a/intranet/apps/feedback/views.py
+++ b/intranet/apps/feedback/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import render
 
 from .forms import FeedbackForm
 from .models import Feedback
-from ..notifications.emails import email_send
+from ..notifications.tasks import email_send_task
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,8 @@ def send_feedback_email(request, data):
     data["remote_ip"] = (request.META["HTTP_X_FORWARDED_FOR"] if "HTTP_X_FORWARDED_FOR" in request.META else request.META.get("REMOTE_ADDR", ""))
     data["user_agent"] = request.META.get("HTTP_USER_AGENT")
     headers = {"Reply-To": "{}; {}".format(email, settings.FEEDBACK_EMAIL)}
-    email_send("feedback/email.txt", "feedback/email.html", data, "Feedback from {}".format(request.user), [settings.FEEDBACK_EMAIL], headers)
+    email_send_task.delay("feedback/email.txt", "feedback/email.html", data, "Feedback from {}".format(request.user), [settings.FEEDBACK_EMAIL],
+                          headers)
 
 
 @login_required

--- a/intranet/apps/notifications/tasks.py
+++ b/intranet/apps/notifications/tasks.py
@@ -1,0 +1,6 @@
+from celery import shared_task
+
+from . import emails
+
+
+email_send_task = shared_task(emails.email_send)

--- a/intranet/celery.py
+++ b/intranet/celery.py
@@ -1,0 +1,9 @@
+import os
+
+from celery import Celery
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "intranet.settings")
+
+app = Celery("intranet")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -727,6 +727,9 @@ SIMILAR_THRESHOLD = 5
 # Substrings of user agents to not log in the Ion access logs
 NONLOGGABLE_USER_AGENT_SUBSTRINGS = ["Prometheus", "GoogleBot", "UptimeRobot"]
 
+CELERY_ACCEPT_CONTENT = ["json", "pickle"]
+CELERY_TASK_SERIALIZER = "pickle"
+
 # Shows a warning message with yellow background on the login page
 # LOGIN_WARNING = "This is a message to display on the login page."
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ Babel==2.6.0
 bcrypt==3.1.7
 beautifulsoup4==4.7.1
 bleach==3.1.0
+celery==4.3.0
 certifi==2019.06.16
 channels==1.1.8
 contextlib2==0.5.5

--- a/scripts/restart_celery.sh
+++ b/scripts/restart_celery.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+cd "$(dirname -- "$(readlink -f -- "$0")")/.."
+
+logdir=/var/log/ion/celery
+if [ $USER == root ]; then
+    piddir=/run/ion
+else
+    piddir=/run/user/$(id -u)/ion
+fi
+
+mkdir -p "$piddir"
+mkdir -p "$logdir"
+
+celery multi restart worker1 -A intranet -l info --pidfile="$piddir/celery-%n.pid" --logfile="$logdir/celery-%n.log" -c 16
+


### PR DESCRIPTION
Fixes #604. Makes #156, #709, and #710 possible.

Note that as it is currently set up, this will require `rabbitmq-server` to be installed on both development and production environments, and `scripts/restart_celery.sh` will need to be run 1) before starting the server and 2) any time a file used by Celery is modified (though for development environments, this isn't strictly necessary unless using features that have been offloaded to Celery).