### PR TITLE
Upgrade to Django Channels 2

### DIFF
--- a/Ion.egg-info/requires.txt
+++ b/Ion.egg-info/requires.txt
@@ -1,6 +1,4 @@
 argon2-cffi==19.1.0
-asgi-redis==1.4.3
-asgiref==1.1.2
 autobahn==19.6.2
 Babel==2.6.0
 bcrypt==3.1.7
@@ -8,7 +6,8 @@ beautifulsoup4==4.7.1
 bleach==3.1.0
 celery==4.3.0
 certifi==2019.06.16
-channels==1.1.8
+channels==2.2.0
+channels-redis==2.4.0
 contextlib2==0.5.5
 cryptography==2.7
 decorator==4.3.0

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -1,6 +1,4 @@
 argon2-cffi==19.1.0
-asgi-redis==1.4.3
-asgiref==1.1.2
 autobahn==19.6.2
 Babel==2.6.0
 bcrypt==3.1.7
@@ -8,7 +6,8 @@ beautifulsoup4==4.7.1
 bleach==3.1.0
 celery==4.3.0
 certifi==2019.06.16
-channels==1.1.8
+channels==2.2.0
+channels-redis==2.4.0
 contextlib2==0.5.5
 cryptography==2.7
 decorator==4.3.0

--- a/fabfile.py
+++ b/fabfile.py
@@ -92,7 +92,6 @@ def restart_production_gunicorn(skip=False):
 
     if skip or confirm("Are you sure you want to restart the production " "Gunicorn instance?"):
         clean_production_pyc()
-        local("supervisorctl restart ion_worker:*")
         local("supervisorctl restart ion")
 
 

--- a/intranet/apps/bus/consumers.py
+++ b/intranet/apps/bus/consumers.py
@@ -1,72 +1,59 @@
-from channels.generic.websockets import JsonWebsocketConsumer
-from channels.handler import AsgiRequest
+from channels.generic.websocket import JsonWebsocketConsumer
+from channels.http import AsgiRequest
 from django.conf import settings
 
 from .models import Route
 
 
-def check_internal_ip(request):
-    """ request is an AsgiRequest """
-    remote_addr = (request.META["HTTP_X_FORWARDED_FOR"] if "HTTP_X_FORWARDED_FOR" in request.META else request.META.get("REMOTE_ADDR", ""))
-    return remote_addr in settings.INTERNAL_IPS
-
-
 class BusConsumer(JsonWebsocketConsumer):
-    http_user = True
+    groups = ["bus"]
 
-    def connection_groups(self, **kwargs):  # pylint: disable=unused-argument
-        """
-        Called to return the list of groups to automatically add/remove
-        this connection to/from.
-        """
-        return ["bus"]
+    def connect(self):
+        user = self.scope["user"]
+        data = self._serialize(user=user)
+        self.accept()
+        self.send_json(data)
 
-    def connect(self, message, **kwargs):
-        print("connected")
-        print(message.user)
-        if not (message.user.is_authenticated or check_internal_ip(AsgiRequest(message))):
+    def receive(self, text_data=None, bytes_data=None):
+        if text_data:
+            content = self.decode_json(text_data)
+        else:
+            self.send({"error": "Invalid data."})
             self.close()
-            return
-        data = self._serialize(user=message.user)
-        self.send(data)
 
-    def receive(self, content, **kwargs):
-        print("received message")
-        if not self.message.user.is_authenticated():
-            self.send({'error': 'You are not logged in.'})
-        if self.message.user.has_admin_permission('bus'):
+        if self.scope["user"].has_admin_permission("bus"):
             try:
-                route = Route.objects.get(id=content['id'])
-                route.status = content['status']
-                if route.status == 'a':
-                    route.space = content['space']
+                route = Route.objects.get(id=content["id"])
+                route.status = content["status"]
+                if route.status == "a":
+                    route.space = content["space"]
                 else:
-                    route.space = ''
+                    route.space = ""
                 route.save()
                 data = self._serialize()
-                self.group_send('bus', data)
+                self.send_json(data)
             except Exception as e:
                 # TODO: Add logging
                 print(e)
-                self.send({'error': 'An error occurred.'})
+                self.send({"error": "An error occurred."})
         else:
-            self.send({'error': 'User does not have permissions.'})
+            self.send({"error": "User does not have permissions."})
 
     def _serialize(self, user=None):
-        print(user)
         all_routes = Route.objects.all()
         data = {}
         route_list = []
         for route in all_routes:
             serialized = {
-                'id': route.id,
-                'bus_number': route.bus_number,
-                'space': route.space,
-                'route_name': route.route_name,
-                'status': route.status,
+                "id": route.id,
+                "bus_number": route.bus_number,
+                "space": route.space,
+                "route_name": route.route_name,
+                "status": route.status,
             }
             route_list.append(serialized)
             if user and user in route.user_set.all():
-                data['userRouteId'] = route.id
-        data['allRoutes'] = route_list
+                data["userRouteId"] = route.id
+
+        data["allRoutes"] = route_list
         return data

--- a/intranet/apps/bus/consumers.py
+++ b/intranet/apps/bus/consumers.py
@@ -12,7 +12,7 @@ class BusConsumer(JsonWebsocketConsumer):
         self.accept()
         self.send_json(data)
 
-    def receive(self, text_data=None, bytes_data=None):
+    def receive(self, text_data=None, bytes_data=None, **kwargs):
         if text_data:
             content = self.decode_json(text_data)
         else:

--- a/intranet/apps/bus/consumers.py
+++ b/intranet/apps/bus/consumers.py
@@ -1,6 +1,4 @@
 from channels.generic.websocket import JsonWebsocketConsumer
-from channels.http import AsgiRequest
-from django.conf import settings
 
 from .models import Route
 

--- a/intranet/asgi.py
+++ b/intranet/asgi.py
@@ -2,7 +2,9 @@
 Sets up application for channels
 """
 import os
-import channels.asgi
+import django
+from channels.routing import get_default_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "intranet.settings")
-channel_layer = channels.asgi.get_channel_layer()
+django.setup()
+application = get_default_application()

--- a/intranet/routing.py
+++ b/intranet/routing.py
@@ -9,4 +9,4 @@ from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 from .apps.bus.consumers import BusConsumer
 
-application = ProtocolTypeRouter({"websocket": AuthMiddlewareStack(URLRouter([url(r"^bus/$", BusConsumer),]))})
+application = ProtocolTypeRouter({"websocket": AuthMiddlewareStack(URLRouter([url(r"^bus/$", BusConsumer)]))})

--- a/intranet/routing.py
+++ b/intranet/routing.py
@@ -2,7 +2,11 @@
 Defines routes for channels
 https://channels.readthedocs.io/en/latest/topics/routing.html
 """
-from channels.routing import route_class
+
+from django.conf.urls import url
+
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
 from .apps.bus.consumers import BusConsumer
 
-channel_routing = [route_class(BusConsumer, path=r"^/bus/")]
+application = ProtocolTypeRouter({"websocket": AuthMiddlewareStack(URLRouter([url(r"^bus/$", BusConsumer),]))})

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -538,7 +538,9 @@ INSTALLED_APPS = [
 ]
 
 # Django Channels Configuration (we use this for websockets)
-CHANNEL_LAYERS = {"default": {"BACKEND": "asgi_redis.RedisChannelLayer", "ROUTING": "intranet.routing.channel_routing"}}
+CHANNEL_LAYERS = {"default": {"BACKEND": "channels_redis.core.RedisChannelLayer", "CONFIG": {"hosts": [("127.0.0.1", 6379)]}}}
+
+ASGI_APPLICATION = "intranet.routing.application"
 
 # Eighth period default block date format
 # Post Django 1.8.7, this can no longer be used in templates.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 argon2-cffi==19.1.0
-asgi-redis==1.4.3
-asgiref==1.1.2
 autobahn==19.6.2
 Babel==2.6.0
 bcrypt==3.1.7
@@ -8,7 +6,8 @@ beautifulsoup4==4.7.1
 bleach==3.1.0
 celery==4.3.0
 certifi==2019.06.16
-channels==1.1.8
+channels==2.2.0
+channels-redis==2.4.0
 contextlib2==0.5.5
 cryptography==2.7
 decorator==4.3.0


### PR DESCRIPTION
Fixes #554 

This upgrades Ion from legacy Channels to the newest backwards-incompatible Django Channels 2.  The functionality for end users remains the same. This is also introduces our first hard requirements for Python 3.6+.

Edit: I have manually tested adding and removing buses as an admin and then viewing those buses as a regular user (all within my development environment).