### PR TITLE
fix(notifications): refuse to send emails in

### DIFF
--- a/intranet/apps/notifications/emails.py
+++ b/intranet/apps/notifications/emails.py
@@ -31,6 +31,11 @@ def email_send(text_template, html_template, data, subject, emails, headers=None
         msg = EmailMultiAlternatives(subject, text_content, settings.EMAIL_FROM, emails, headers=headers)
     msg.attach_alternative(html_content, "text/html")
     logger.debug("Emailing %s to %s", subject, emails)
-    msg.send()
+
+    # We only want to actually send emails if we are in production or explicitly force sending.
+    if settings.PRODUCTION or settings.FORCE_EMAIL_SEND:
+        msg.send()
+    else:
+        logger.debug("Refusing to email in non-production environments. To force email sending, enable settings.FORCE_EMAIL_SEND.")
 
     return msg

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -74,6 +74,9 @@ DEBUG = os.getenv("DEBUG", str(not PRODUCTION).upper()) == "TRUE"
 EMAIL_ANNOUNCEMENTS = PRODUCTION
 SEND_ANNOUNCEMENT_APPROVAL = PRODUCTION
 
+# Whether to force sending emails, even if we aren't in production.
+FORCE_EMAIL_SEND = False
+
 # Don't require https for testing.
 SESSION_COOKIE_SECURE = PRODUCTION
 CSRF_COOKIE_SECURE = PRODUCTION


### PR DESCRIPTION
development. If necessary, developers can explicitly force sending the
email.

In most cases, developers only need to check that the correct email was
created which `msg` can do.