### PR TITLE
Celery logging fixes

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -208,6 +208,7 @@ intranet/apps/eighth/exceptions.py
 intranet/apps/eighth/models.py
 intranet/apps/eighth/notifications.py
 intranet/apps/eighth/serializers.py
+intranet/apps/eighth/tasks.py
 intranet/apps/eighth/tests.py
 intranet/apps/eighth/urls.py
 intranet/apps/eighth/utils.py

--- a/docs/sourcedoc/intranet.apps.eighth.rst
+++ b/docs/sourcedoc/intranet.apps.eighth.rst
@@ -61,6 +61,14 @@ intranet.apps.eighth.serializers module
    :undoc-members:
    :show-inheritance:
 
+intranet.apps.eighth.tasks module
+---------------------------------
+
+.. automodule:: intranet.apps.eighth.tasks
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 intranet.apps.eighth.tests module
 ---------------------------------
 

--- a/intranet/apps/eighth/notifications.py
+++ b/intranet/apps/eighth/notifications.py
@@ -1,15 +1,10 @@
 import logging
-from typing import Collection
 
-from celery import shared_task
 from django.urls import reverse
-from django.utils import timezone
-from django.contrib.auth import get_user_model
 
-from .models import EighthActivity, EighthRoom, EighthScheduledActivity, EighthSignup
+from .models import EighthScheduledActivity, EighthSignup
 from ..notifications.emails import email_send
 from ..notifications.tasks import email_send_task
-from ...utils.helpers import join_nicely
 
 logger = logging.getLogger(__name__)
 
@@ -87,79 +82,6 @@ def activity_cancelled_email(sched_act: EighthScheduledActivity):
 
     email_send_task.delay("eighth/emails/activity_cancelled.txt", "eighth/emails/activity_cancelled.html", data,
                           "Activity Cancelled on {}".format(date_str), emails, bcc=True)
-
-
-@shared_task
-def room_changed_single_email(sched_act: EighthScheduledActivity, old_rooms: Collection[EighthRoom],  # pylint: disable=unsubscriptable-object
-                              new_rooms: Collection[EighthRoom]):  # pylint: disable=unsubscriptable-object
-    """Notifies all the users signed up for the given EighthScheduledActivity that it is changing rooms.
-
-    Args:
-        sched_act: The activity that has changed rooms.
-        old_rooms: The list of rooms that the activity used to be in.
-        new_rooms: The new list of rooms that the activity is in.
-
-    """
-    date_str = sched_act.block.date.strftime("%A, %B %-d")
-
-    emails = [signup.user.notification_email for signup in sched_act.eighthsignup_set.filter(user__receive_eighth_emails=True).distinct()]
-
-    base_url = "https://ion.tjhsst.edu"
-
-    data = {
-        "sched_act": sched_act,
-        "date_str": date_str,
-        "base_url": base_url,
-        "num_old_rooms": len(old_rooms),
-        "num_new_rooms": len(new_rooms),
-        "old_rooms_str": join_nicely(room.formatted_name for room in old_rooms),
-        "new_rooms_str": join_nicely(room.formatted_name for room in new_rooms),
-    }
-
-    logger.debug("Scheduled activity %d changed from rooms %s to %s; emailing %d of %d signed up users", sched_act.id, data["old_rooms_str"],
-                 data["new_rooms_str"], len(emails), sched_act.eighthsignup_set.count())
-
-    email_send("eighth/emails/room_changed_single.txt", "eighth/emails/room_changed_single.html", data,
-               "Room change for {} on {}".format(sched_act.activity.name, date_str), emails, bcc=True)
-
-
-@shared_task
-def room_changed_activity_email(act: EighthActivity, old_rooms: Collection[EighthRoom],  # pylint: disable=unsubscriptable-object
-                                new_rooms: Collection[EighthRoom]):  # pylint: disable=unsubscriptable-object
-    """Notifies all the users signed up for the given EighthActivity on the blocks for which the room
-    list is not overriden that it is changing rooms.
-
-    Args:
-        act: The activity that has changed rooms.
-        old_rooms: The list of rooms that the activity used to be in.
-        new_rooms: The new list of rooms that the activity is in.
-
-    """
-    all_sched_acts = act.eighthscheduledactivity_set.filter(block__date__gte=timezone.localdate())
-    sched_acts = all_sched_acts.filter(rooms=None)
-    users = get_user_model().objects.filter(receive_eighth_emails=True, eighthsignup__scheduled_activity__activity=act,
-                                            eighthsignup__scheduled_activity__block__date__gte=timezone.localdate()).distinct()
-
-    base_url = "https://ion.tjhsst.edu"
-
-    data = {
-        "act": act,
-        "base_url": base_url,
-        "num_old_rooms": len(old_rooms),
-        "num_new_rooms": len(new_rooms),
-        "old_rooms_str": join_nicely(room.formatted_name for room in old_rooms),
-        "new_rooms_str": join_nicely(room.formatted_name for room in new_rooms),
-    }
-
-    logger.debug("Activity %d changed from rooms %s to %s; emailing %d signed up users", act.id, data["old_rooms_str"], data["new_rooms_str"],
-                 len(users))
-
-    for user in users:
-        data["date_strs"] = ["{}, {} block".format(sa.block.date.strftime("%A, %B %-d"), sa.block.block_letter)
-                             for sa in sched_acts.filter(eighthsignup_set__user=user)]
-
-        email_send("eighth/emails/room_changed_activity.txt", "eighth/emails/room_changed_activity.html", data,
-                   "Room changes for {}".format(act.name), [user.notification_email], bcc=True)
 
 
 def absence_email(signup, use_celery=True):

--- a/intranet/apps/eighth/tasks.py
+++ b/intranet/apps/eighth/tasks.py
@@ -1,0 +1,85 @@
+from typing import Collection
+
+from celery import shared_task
+from celery.utils.log import get_task_logger
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from .models import EighthActivity, EighthRoom, EighthScheduledActivity
+from ..notifications.emails import email_send
+from ...utils.helpers import join_nicely
+
+logger = get_task_logger(__name__)
+
+
+@shared_task
+def room_changed_single_email(sched_act: EighthScheduledActivity, old_rooms: Collection[EighthRoom],  # pylint: disable=unsubscriptable-object
+                              new_rooms: Collection[EighthRoom]):  # pylint: disable=unsubscriptable-object
+    """Notifies all the users signed up for the given EighthScheduledActivity that it is changing rooms.
+
+    Args:
+        sched_act: The activity that has changed rooms.
+        old_rooms: The list of rooms that the activity used to be in.
+        new_rooms: The new list of rooms that the activity is in.
+
+    """
+    date_str = sched_act.block.date.strftime("%A, %B %-d")
+
+    emails = [signup.user.notification_email for signup in sched_act.eighthsignup_set.filter(user__receive_eighth_emails=True).distinct()]
+
+    base_url = "https://ion.tjhsst.edu"
+
+    data = {
+        "sched_act": sched_act,
+        "date_str": date_str,
+        "base_url": base_url,
+        "num_old_rooms": len(old_rooms),
+        "num_new_rooms": len(new_rooms),
+        "old_rooms_str": join_nicely(room.formatted_name for room in old_rooms),
+        "new_rooms_str": join_nicely(room.formatted_name for room in new_rooms),
+    }
+
+    logger.debug("Scheduled activity %d changed from rooms %s to %s; emailing %d of %d signed up users", sched_act.id, data["old_rooms_str"],
+                 data["new_rooms_str"], len(emails), sched_act.eighthsignup_set.count())
+
+    email_send("eighth/emails/room_changed_single.txt", "eighth/emails/room_changed_single.html", data,
+               "Room change for {} on {}".format(sched_act.activity.name, date_str), emails, bcc=True)
+
+
+@shared_task
+def room_changed_activity_email(act: EighthActivity, old_rooms: Collection[EighthRoom],  # pylint: disable=unsubscriptable-object
+                                new_rooms: Collection[EighthRoom]):  # pylint: disable=unsubscriptable-object
+    """Notifies all the users signed up for the given EighthActivity on the blocks for which the room
+    list is not overriden that it is changing rooms.
+
+    Args:
+        act: The activity that has changed rooms.
+        old_rooms: The list of rooms that the activity used to be in.
+        new_rooms: The new list of rooms that the activity is in.
+
+    """
+    all_sched_acts = act.eighthscheduledactivity_set.filter(block__date__gte=timezone.localdate())
+    sched_acts = all_sched_acts.filter(rooms=None)
+    users = get_user_model().objects.filter(receive_eighth_emails=True, eighthsignup__scheduled_activity__activity=act,
+                                            eighthsignup__scheduled_activity__block__date__gte=timezone.localdate()).distinct()
+
+    base_url = "https://ion.tjhsst.edu"
+
+    data = {
+        "act": act,
+        "base_url": base_url,
+        "num_old_rooms": len(old_rooms),
+        "num_new_rooms": len(new_rooms),
+        "old_rooms_str": join_nicely(room.formatted_name for room in old_rooms),
+        "new_rooms_str": join_nicely(room.formatted_name for room in new_rooms),
+    }
+
+    logger.debug("Activity %d changed from rooms %s to %s; emailing %d signed up users", act.id, data["old_rooms_str"], data["new_rooms_str"],
+                 len(users))
+
+    for user in users:
+        data["date_strs"] = ["{}, {} block".format(sa.block.date.strftime("%A, %B %-d"), sa.block.block_letter)
+                             for sa in sched_acts.filter(eighthsignup_set__user=user)]
+
+        email_send("eighth/emails/room_changed_activity.txt", "eighth/emails/room_changed_activity.html", data,
+                   "Room changes for {}".format(act.name), [user.notification_email], bcc=True)

--- a/intranet/apps/eighth/views/admin/activities.py
+++ b/intranet/apps/eighth/views/admin/activities.py
@@ -12,7 +12,7 @@ from django.shortcuts import redirect, render
 from ...forms.admin.activities import ActivityForm, QuickActivityForm
 from ...models import EighthActivity, EighthRoom, EighthScheduledActivity, EighthSponsor, EighthWaitlist
 from ...utils import get_start_date
-from ...notifications import room_changed_activity_email
+from ...tasks import room_changed_activity_email
 from ....auth.decorators import eighth_admin_required
 from ....groups.models import Group
 

--- a/intranet/apps/eighth/views/admin/scheduling.py
+++ b/intranet/apps/eighth/views/admin/scheduling.py
@@ -17,7 +17,7 @@ from ...forms.admin.blocks import BlockSelectionForm
 from ...forms.admin.scheduling import ScheduledActivityForm
 from ...models import EighthActivity, EighthBlock, EighthRoom, EighthScheduledActivity, EighthSponsor, EighthSignup
 from ...utils import get_start_date
-from ...notifications import room_changed_single_email
+from ...tasks import room_changed_single_email
 from ....auth.decorators import eighth_admin_required
 from .....utils.serialization import safe_json
 

--- a/intranet/apps/notifications/emails.py
+++ b/intranet/apps/notifications/emails.py
@@ -1,3 +1,4 @@
+from typing import Collection, Mapping
 import logging
 
 from django.conf import settings
@@ -7,17 +8,27 @@ from django.template.loader import get_template
 logger = logging.getLogger(__name__)
 
 
-def email_send(text_template, html_template, data, subject, emails, headers=None, bcc=False):
+def email_send(text_template: str, html_template: str, data: Mapping[str, object], subject: str,
+               emails: Collection[str], headers: Mapping[str, str] = None, bcc: bool = False, *,  # pylint: disable=unsubscriptable-object
+               custom_logger: logging.Logger = None) -> EmailMultiAlternatives:
     """Send an HTML/Plaintext email with the following fields.
+    If we are not in production and settings.FORCE_EMAIL_SEND is not set, does not actually send the email
 
-    text_template: URL to a Django template for the text email's contents
-    html_template: URL to a Django tempalte for the HTML email's contents
-    data: The context to pass to the templates
-    subject: The subject of the email
-    emails: The addresses to send the email to
-    headers: A dict of additional headers to send to the message
+    Args:
+        text_template: URL to a Django template for the text email's contents
+        html_template: URL to a Django tempalte for the HTML email's contents
+        data: The context to pass to the templates
+        subject: The subject of the email
+        emails: The addresses to send the email to
+        headers: A dict of additional headers to send to the message
+        custom_logger: An optional logger to use instead of the Django logger
+
+    Returns:
+        The email object that was created (and sent if we're in production or settings.FORCE_EMAIL_SEND is set)
 
     """
+
+    logger = (custom_logger if custom_logger is not None else globals()["logger"])  # pylint: disable=redefined-outer-name
 
     text = get_template(text_template)
     html = get_template(html_template)

--- a/intranet/apps/notifications/tasks.py
+++ b/intranet/apps/notifications/tasks.py
@@ -1,6 +1,17 @@
+import functools
+
 from celery import shared_task
+from celery.utils.log import get_task_logger
 
 from . import emails
 
+logger = get_task_logger(__name__)
 
-email_send_task = shared_task(emails.email_send)
+
+@shared_task
+@functools.wraps(emails.email_send)
+def email_send_task(*args, **kwargs):
+    if "custom_logger" not in kwargs:
+        kwargs["custom_logger"] = logger
+
+    return emails.email_send(*args, **kwargs)

--- a/intranet/celery.py
+++ b/intranet/celery.py
@@ -1,9 +1,19 @@
 import os
+import logging
 
 from celery import Celery
+from celery.signals import after_setup_logger, after_setup_task_logger
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "intranet.settings")
 
 app = Celery("intranet")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()
+
+
+@after_setup_logger.connect
+@after_setup_task_logger.connect
+def setup_logger(logger, **kwargs):  # pylint: disable=unused-argument
+    from django.conf import settings
+
+    logger.level = getattr(logging, settings.LOG_LEVEL)


### PR DESCRIPTION
The behavior described in #731 was expected and it's impossible to get messages logged from Celery to show up in Django logs, but this PR 1) makes our Celery tasks use Celery's logging system properly and 2) makes the Celery loggers respect `settings.LOG_LEVEL`.

So I guess this closes #731.