### PR TITLE
Add "Reset password" and account documentation links

### DIFF
--- a/intranet/static/css/login.scss
+++ b/intranet/static/css/login.scss
@@ -91,6 +91,14 @@ h2 {
     padding-bottom: 10px;
     margin-bottom: 5px;
     border-bottom: 1px solid rgba(0, 0, 0, .1);
+
+    .reset-password-container {
+        margin-top: 5px;
+    }
+
+    .account-docs-link-container {
+        margin-top: 3px;
+    }
 }
 
 .schedule {

--- a/intranet/templates/auth/login.html
+++ b/intranet/templates/auth/login.html
@@ -95,6 +95,14 @@
                     {% endfor %}
                     <input type="submit" value="Login">
                     <div class='spinner-container'></div>
+                    <div class="reset-password-container">
+                        <a href="https://resetter.tjhsst.edu">Reset password</a>
+                    </div>
+                    {% if auth_form.errors %}
+                        <div class="account-docs-link-container">
+                            <a href="{% url 'docs_accounts' %}">CSL Account Documentation</a>
+                        </div>
+                    {% endif %}
                 </form>
             </div>
             <div class="schedule-outer{% if sports_events|length > 0 or school_events|length > 0 %} has-events{% endif %}">
@@ -129,6 +137,7 @@
             <a href="{% url 'about' %}">About/Credits</a> &nbsp; - &nbsp;
             <a href="https://www.tjhsst.edu">TJHSST</a> &nbsp; - &nbsp;
             <a href="https://webmail.tjhsst.edu">Webmail</a> &nbsp; - &nbsp;
+            <a href="{% url 'docs_accounts' %}">CSL Account Documentation</a>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
## Proposed changes
- Add "Reset password" link under login button
- Add "CSL Account Documentation" link in footer
- Add "CSL Account Documentation" link under the "Reset password" link when authentication fails

## Brief description of rationale
We currently have no links to the account documentation, and no links to the resetter site except from the account documentation. This PR makes those links very prominent.