### PR TITLE
Block use of ION in announcements and events

### DIFF
--- a/intranet/static/js/announcement.form.js
+++ b/intranet/static/js/announcement.form.js
@@ -24,6 +24,13 @@ $(function() {
             }
         }
 
+        if($("#id_title").val().match(/\bION\b/) || editor.getData().match(/\bION\b/)) {
+            // People frequently write "ION" instead of the correct spelling, "Ion." See https://github.com/tjcsl/ion/issues/805
+            Messenger().error('We have detected the use of "ION" in all caps in your announcement. Please correct it to use "Ion", <a href="/docs/terminology" style="color:#7F7FFF">the official name</a>.');
+            e.preventDefault();
+            return;
+        }
+
         var button = $("button#submit_announcement");
         button.prop("disabled", true);
         button.append(" <i class=\"fa fa-spinner fa-spin\" aria-hidden=\"true\"></i>");

--- a/intranet/templates/announcements/approve.html
+++ b/intranet/templates/announcements/approve.html
@@ -77,7 +77,7 @@
         Announcement Approval
     </h2>
 
-    <form action="" method="post">
+    <form action="" method="post" id="announcement_form">
     <table>
     <tr>
         <td colspan="2">
@@ -154,7 +154,7 @@
     {% if not req.posted %}
     <table>
     <tr><td>
-        <input type="submit" name="approve" value="{% if admin_approve %}Post{% else %}Approve{% endif %} Announcement">
+        <button type="submit" name="approve" id="submit_announcement">{% if admin_approve %}Post{% else %}Approve{% endif %} Announcement</button>
         </td>
         <td>
         <input type="submit" name="reject" value="Reject Announcement" onclick="return confirm('This will hide, but not delete, the request.')">

--- a/intranet/templates/announcements/request.html
+++ b/intranet/templates/announcements/request.html
@@ -146,11 +146,11 @@
     <br>
     We reserve the right to edit requests at our discretion (e.g. to correct formatting or spelling errors). Please make sure your post complies with the guidelines.
     <br><br>
-    <form action="" method="post">
+    <form action="" method="post" id="announcement_form">
         <table>
             {% csrf_token %}
             {{ form.as_table }}
-            <tr><td><input type="submit"></td></tr>
+            <tr><td><button type="submit" id="submit_announcement">Submit</button></td></tr>
         </table>
     </form>
 </div>

--- a/intranet/templates/events/add_modify.html
+++ b/intranet/templates/events/add_modify.html
@@ -30,6 +30,20 @@
                 placeholder: "Links",
                 create: true
             })
+
+            // name of <textarea> is description
+            var editor = CKEDITOR.replace("id_description", {
+                width: "600px"
+            });
+
+            $("form#event_form").bind("submit", function(e) {
+                if($("#id_title").val().match(/\bION\b/) || editor.getData().match(/\bION\b/)) {
+                    // People frequently write "ION" instead of the correct spelling, "Ion." See https://github.com/tjcsl/ion/issues/805
+                    Messenger().error('We have detected the use of "ION" in all caps in your event. Please correct it to use "Ion", <a href="/docs/terminology" style="color:#7F7FFF">the official name</a>.');
+                    e.preventDefault();
+                    return;
+                }
+            });
         });
     </script>
 {% endblock %}
@@ -55,7 +69,7 @@
     <h2>
         {{ action_title }} Event
     </h2>
-    <form method="post">
+    <form method="post" id="event_form">
     <table>
     {% csrf_token %}
     <tr><td colspan="2">
@@ -83,10 +97,4 @@
     </table>
     </form>
 </div>
-<script>
-    // name of <textarea> is content
-    CKEDITOR.replace("id_description", {
-        width: "600px"
-    });
-</script>
 {% endblock %}


### PR DESCRIPTION
## Proposed changes
- Block the text "ION" in announcements (closes #805)
  * Also clean up some of the announcement templates as necessary to make this change possible
- Block the text "ION" in events (related to #805)
  * Also clean up the edit/modify/request event template as necessary to make this change possible

## Brief description of rationale
As per #805:
> Users are beginning to more actively use "ION" to refer to Ion. This is incorrect.
