### PR TITLE
Dark mode tweaks

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -735,6 +735,7 @@ intranet/static/css/dark/schedule.scss
 intranet/static/css/dark/schedule.widget.scss
 intranet/static/css/dark/select.scss
 intranet/static/css/dark/welcome.scss
+intranet/static/img/Eighth-Icons-dark.svg
 intranet/static/img/Eighth-Icons.png
 intranet/static/img/Eighth-Icons.svg
 intranet/static/img/Eighth-Icons@2x.png

--- a/intranet/static/css/dark/eighth.signup.scss
+++ b/intranet/static/css/dark/eighth.signup.scss
@@ -6,6 +6,10 @@
     background-color: #282828;
 }
 
+.activity-icon {
+    background-image: url("/static/img/Eighth-Icons-dark.svg");
+}
+
 .day a, .day a:hover {
     color: #F0F0F0;
 }

--- a/intranet/static/css/dark/eighth.signup.scss
+++ b/intranet/static/css/dark/eighth.signup.scss
@@ -7,11 +7,11 @@
 }
 
 .day a, .day a:hover {
-    color: #B7B7B7;
+    color: #F0F0F0;
 }
 
 .no-activity-selected {
-    color: #909090;
+    color: #888888;
 }
 
 .middle > .block-title {

--- a/intranet/static/img/Eighth-Icons-dark.svg
+++ b/intranet/static/img/Eighth-Icons-dark.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="280px" height="20px" viewBox="0 0 280 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.0.4 (8054) - http://www.bohemiancoding.com/sketch -->
+    <title>Eighth-Icons</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <path id="path-1" d="M7.71428571,15.4285714 C11.9747681,15.4285714 15.4285714,11.9747681 15.4285714,7.71428571 C15.4285714,3.45380336 11.9747681,0 7.71428571,0 C3.45380336,0 0,3.45380336 0,7.71428571 C0,11.9747681 3.45380336,15.4285714 7.71428571,15.4285714 Z"></path>
+        <path id="path-3" d="M8.57142857,17.1428571 C13.3052979,17.1428571 17.1428571,13.3052979 17.1428571,8.57142857 C17.1428571,3.83755929 13.3052979,0 8.57142857,0 C3.83755929,0 0,3.83755929 0,8.57142857 C0,13.3052979 3.83755929,17.1428571 8.57142857,17.1428571 Z"></path>
+        <circle id="path-5" cx="8.14285714" cy="8.14285714" r="8.14285714"></circle>
+        <circle id="path-7" cx="8.57142857" cy="8.57142857" r="8.14285714"></circle>
+        <circle id="path-9" cx="8.57142857" cy="8.57142857" r="8.14285714"></circle>
+        <circle id="path-11" cx="8.14285714" cy="8.14285714" r="8.14285714"></circle>
+        <circle id="path-13" cx="8.57142857" cy="8.57142857" r="8.14285714"></circle>
+        <circle id="path-15" cx="8.57142857" cy="8.57142857" r="8.14285714"></circle>
+        <circle id="path-17" cx="8.14285714" cy="8.14285714" r="8.14285714"></circle>
+        <circle id="path-19" cx="8.14285714" cy="8.14285714" r="8.14285714"></circle>
+        <circle id="path-21" cx="8.57142857" cy="8.57142857" r="8.14285714"></circle>
+        <circle id="path-23" cx="8.14285714" cy="8.14285714" r="8.14285714"></circle>
+    </defs>
+    <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="Eighth-Icons" sketch:type="MSArtboardGroup">
+            <g id="Empty-Heart" sketch:type="MSLayerGroup" transform="translate(261.428571, 1.428571)" fill="#B7B7B7">
+                <path d="M16.2857143,6.19084821 C16.2857143,7.46522215 15.6285142,8.76264221 14.3140944,10.0831473 L8.9502551,15.2728795 C8.84693826,15.3766746 8.72066401,15.4285714 8.57142857,15.4285714 C8.42219313,15.4285714 8.29591888,15.3766746 8.19260204,15.2728795 L2.82015306,10.0658482 C2.76275482,10.019717 2.68383341,9.94475498 2.58338648,9.84095982 C2.48293955,9.73716466 2.3236618,9.54831796 2.10554847,9.27441406 C1.88743513,9.00051016 1.69228402,8.71940248 1.52008929,8.43108259 C1.34789455,8.1427627 1.19435654,7.79390086 1.05947066,7.38448661 C0.924584785,6.97507236 0.857142857,6.57719687 0.857142857,6.19084821 C0.857142857,4.92224068 1.22161625,3.93043512 1.95057398,3.21540179 C2.67953171,2.50036845 3.68685582,2.14285714 4.97257653,2.14285714 C5.32844566,2.14285714 5.69148412,2.20484499 6.06170281,2.32882254 C6.43192149,2.4528001 6.77630581,2.62002313 7.09486607,2.83049665 C7.41342634,3.04097017 7.68749885,3.23846634 7.91709184,3.42299107 C8.14668482,3.6075158 8.36479489,3.80357039 8.57142857,4.01116071 C8.77806226,3.80357039 8.99617232,3.6075158 9.22576531,3.42299107 C9.45535829,3.23846634 9.72943081,3.04097017 10.0479911,2.83049665 C10.3665513,2.62002313 10.7109356,2.4528001 11.0811543,2.32882254 C11.451373,2.20484499 11.8144115,2.14285714 12.1702806,2.14285714 C13.4560013,2.14285714 14.4633254,2.50036845 15.1922832,3.21540179 C15.9212409,3.93043512 16.2857143,4.92224068 16.2857143,6.19084821 Z M15.1836735,6.19084821 C15.1836735,5.72376999 15.1219713,5.31147872 14.9985651,4.95396205 C14.8751588,4.59644539 14.717316,4.31245455 14.5250319,4.10198103 C14.3327478,3.8915075 14.0988534,3.71995974 13.8233418,3.58733259 C13.5478303,3.45470544 13.2780625,3.36532761 13.0140306,3.31919643 C12.7499987,3.27306525 12.4687515,3.25 12.1702806,3.25 C11.8718097,3.25 11.5503844,3.32352047 11.2059949,3.47056362 C10.8616054,3.61760676 10.5444849,3.80212873 10.2546237,4.02413504 C9.96476258,4.24614136 9.71651889,4.45372857 9.5098852,4.6469029 C9.30325152,4.84007723 9.13105936,5.01739131 8.99330357,5.17885045 C8.88998673,5.3057112 8.74936313,5.36914062 8.57142857,5.36914062 C8.39349401,5.36914062 8.25287041,5.3057112 8.14955357,5.17885045 C8.01179778,5.01739131 7.83960563,4.84007723 7.63297194,4.6469029 C7.42633825,4.45372857 7.17809456,4.24614136 6.88823342,4.02413504 C6.59837228,3.80212873 6.28125172,3.61760676 5.93686224,3.47056362 C5.59247277,3.32352047 5.27104741,3.25 4.97257653,3.25 C4.67410565,3.25 4.39285846,3.27306525 4.12882653,3.31919643 C3.8647946,3.36532761 3.59502689,3.45470544 3.31951531,3.58733259 C3.04400372,3.71995974 2.81010938,3.8915075 2.61782526,4.10198103 C2.42554113,4.31245455 2.26769832,4.59644539 2.14429209,4.95396205 C2.02088586,5.31147872 1.95918367,5.72376999 1.95918367,6.19084821 C1.95918367,7.15960306 2.49584923,8.18312333 3.56919643,9.26143973 L8.57142857,14.1051897 L13.565051,9.27008929 C14.644138,8.18600648 15.1836735,7.15960306 15.1836735,6.19084821 Z" id="" sketch:type="MSShapeGroup"></path>
+            </g>
+            <g id="Full-Heart" sketch:type="MSLayerGroup" transform="translate(241.428571, 1.428571)" fill="#E74141">
+                <path d="M8.57142857,15.4285714 C8.42219313,15.4285714 8.29591888,15.3766746 8.19260204,15.2728795 L2.82015306,10.0658482 C2.76275482,10.019717 2.68383341,9.94475498 2.58338648,9.84095982 C2.48293955,9.73716466 2.3236618,9.54831796 2.10554847,9.27441406 C1.88743513,9.00051016 1.69228402,8.71940248 1.52008929,8.43108259 C1.34789455,8.1427627 1.19435654,7.79390086 1.05947066,7.38448661 C0.924584785,6.97507236 0.857142857,6.57719687 0.857142857,6.19084821 C0.857142857,4.92224068 1.22161625,3.93043512 1.95057398,3.21540179 C2.67953171,2.50036845 3.68685582,2.14285714 4.97257653,2.14285714 C5.32844566,2.14285714 5.69148412,2.20484499 6.06170281,2.32882254 C6.43192149,2.4528001 6.77630581,2.62002313 7.09486607,2.83049665 C7.41342634,3.04097017 7.68749885,3.23846634 7.91709184,3.42299107 C8.14668482,3.6075158 8.36479489,3.80357039 8.57142857,4.01116071 C8.77806226,3.80357039 8.99617232,3.6075158 9.22576531,3.42299107 C9.45535829,3.23846634 9.72943081,3.04097017 10.0479911,2.83049665 C10.3665513,2.62002313 10.7109356,2.4528001 11.0811543,2.32882254 C11.451373,2.20484499 11.8144115,2.14285714 12.1702806,2.14285714 C13.4560013,2.14285714 14.4633254,2.50036845 15.1922832,3.21540179 C15.9212409,3.93043512 16.2857143,4.92224068 16.2857143,6.19084821 C16.2857143,7.46522215 15.6285142,8.76264221 14.3140944,10.0831473 L8.9502551,15.2728795 C8.84693826,15.3766746 8.72066401,15.4285714 8.57142857,15.4285714 L8.57142857,15.4285714 Z" id="" sketch:type="MSShapeGroup"></path>
+            </g>
+            <g id="Restricted" sketch:type="MSLayerGroup" transform="translate(230.000000, 10.000000) rotate(45.000000) translate(-230.000000, -10.000000) translate(222.285714, 2.285714)">
+                <use id="Oval-1" stroke="#B7B7B7" stroke-width="1.71428571" sketch:type="MSShapeGroup" xlink:href="#path-1"></use>
+                <path d="M7.71428571,0.936111399 L7.71428571,14.905953" id="Line-2" stroke="#B7B7B7" stroke-width="1.71428571" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+            </g>
+            <g id="10/10" sketch:type="MSLayerGroup" transform="translate(201.428571, 1.428571)">
+                <mask id="mask-4" sketch:name="Oval 1" fill="white">
+                    <use xlink:href="#path-3"></use>
+                </mask>
+                <use id="Oval-1" stroke="#B7B7B7" stroke-width="0.857142857" fill="#B7B7B7" sketch:type="MSShapeGroup" xlink:href="#path-3"></use>
+            </g>
+            <g id="9/10" sketch:type="MSLayerGroup" transform="translate(181.857143, 1.857143)">
+                <mask id="mask-6" sketch:name="Oval 1" fill="white">
+                    <use xlink:href="#path-5"></use>
+                </mask>
+                <use id="Oval-1" stroke="#B7B7B7" stroke-width="0.857142857" sketch:type="MSShapeGroup" xlink:href="#path-5"></use>
+                <path d="M8.14285714,-0.428571429 L8.14285714,8.14285714 L-0.428571429,-3.42857143 L-0.428571429,8.14285714 L-0.428571429,16.7142857 L8.14285714,16.7142857 L16.7142857,16.7142857 L16.7142857,-0.428571429 L8.14285714,-0.428571429 Z" id="Rectangle-1" fill="#B7B7B7" sketch:type="MSShapeGroup" mask="url(#mask-6)"></path>
+            </g>
+            <g id="8/10" sketch:type="MSLayerGroup" transform="translate(161.428571, 1.428571)">
+                <mask id="mask-8" sketch:name="Oval 1" fill="white">
+                    <use xlink:href="#path-7"></use>
+                </mask>
+                <use id="Oval-1" stroke="#B7B7B7" stroke-width="0.857142857" sketch:type="MSShapeGroup" xlink:href="#path-7"></use>
+                <path d="M8.57142857,7.61295788e-16 L8.57142857,8.57142857 L0,5.44285583 L0,17.1428571 L8.57142857,17.1428571 L17.1428571,17.1428571 L17.1428571,7.61295788e-16 L8.57142857,7.61295788e-16 Z" id="Rectangle-1" fill="#B7B7B7" sketch:type="MSShapeGroup" mask="url(#mask-8)"></path>
+            </g>
+            <g id="7/10" sketch:type="MSLayerGroup" transform="translate(141.428571, 1.428571)">
+                <mask id="mask-10" sketch:name="Oval 1" fill="white">
+                    <use xlink:href="#path-9"></use>
+                </mask>
+                <use id="Oval-1" stroke="#B7B7B7" stroke-width="0.857142857" sketch:type="MSShapeGroup" xlink:href="#path-9"></use>
+                <path d="M8.57142857,0 L8.57142857,8.57142857 L-17.828574,17.1428571 L8.57142857,17.1428571 L17.1428571,17.1428571 L17.1428571,0 L8.57142857,0 Z" id="Rectangle-1" fill="#B7B7B7" sketch:type="MSShapeGroup" mask="url(#mask-10)"></path>
+            </g>
+            <g id="6/10" sketch:type="MSLayerGroup" transform="translate(121.857143, 1.857143)">
+                <mask id="mask-12" sketch:name="Oval 1" fill="white">
+                    <use xlink:href="#path-11"></use>
+                </mask>
+                <use id="Oval-1" stroke="#B7B7B7" stroke-width="0.857142857" sketch:type="MSShapeGroup" xlink:href="#path-11"></use>
+                <path d="M8.14285714,-0.428571429 L8.14285714,8.1860496 L1.92857143,16.7142857 L8.14285714,16.7142857 L16.7142857,16.7142857 L16.7142857,-0.428571429 L8.14285714,-0.428571429 Z" id="Rectangle-1" fill="#B7B7B7" sketch:type="MSShapeGroup" mask="url(#mask-12)"></path>
+            </g>
+            <g id="5/10" sketch:type="MSLayerGroup" transform="translate(101.428571, 1.428571)">
+                <mask id="mask-14" sketch:name="Oval 1" fill="white">
+                    <use xlink:href="#path-13"></use>
+                </mask>
+                <use id="Oval-1" stroke="#B7B7B7" stroke-width="0.857142857" sketch:type="MSShapeGroup" xlink:href="#path-13"></use>
+                <rect id="Rectangle-1" fill="#B7B7B7" sketch:type="MSShapeGroup" mask="url(#mask-14)" x="8.57142857" y="0" width="8.57142857" height="17.1428571"></rect>
+            </g>
+            <g id="4/10" sketch:type="MSLayerGroup" transform="translate(81.428571, 1.428571)">
+                <mask id="mask-16" sketch:name="Oval 1" fill="white">
+                    <use xlink:href="#path-15"></use>
+                </mask>
+                <use id="Oval-1" stroke="#B7B7B7" stroke-width="0.857142857" sketch:type="MSShapeGroup" xlink:href="#path-15"></use>
+                <path d="M8.57142857,3.80647894e-16 L8.57142857,8.57142857 L14.7857143,17.1428571 L17.1428571,8.57142857 L17.1428571,3.80647894e-16 L8.57142857,3.80647894e-16 Z" id="Rectangle-1" fill="#B7B7B7" sketch:type="MSShapeGroup" mask="url(#mask-16)"></path>
+            </g>
+            <g id="3/10" sketch:type="MSLayerGroup" transform="translate(61.857143, 1.857143)">
+                <mask id="mask-18" sketch:name="Oval 1" fill="white">
+                    <use xlink:href="#path-17"></use>
+                </mask>
+                <use id="Oval-1" stroke="#B7B7B7" stroke-width="0.857142857" sketch:type="MSShapeGroup" xlink:href="#path-17"></use>
+                <path d="M8.14285714,-0.428571429 L8.14285714,8.14285714 L16.7142857,11.2714299 L16.7142857,8.14285714 L16.7142857,-0.428571429 L8.14285714,-0.428571429 Z" id="Rectangle-1" fill="#B7B7B7" sketch:type="MSShapeGroup" mask="url(#mask-18)"></path>
+            </g>
+            <g id="2/10" sketch:type="MSLayerGroup" transform="translate(41.857143, 1.857143)">
+                <mask id="mask-20" sketch:name="Oval 1" fill="white">
+                    <use xlink:href="#path-19"></use>
+                </mask>
+                <use id="Oval-1" stroke="#B7B7B7" stroke-width="0.857142857" sketch:type="MSShapeGroup" xlink:href="#path-19"></use>
+                <path d="M8.14285714,-0.428571429 L8.14285714,8.14285714 L34.5428571,-0.428571429 L8.14285714,-0.428571429 Z" id="Rectangle-2" fill="#B7B7B7" sketch:type="MSShapeGroup" mask="url(#mask-20)"></path>
+            </g>
+            <g id="1/10" sketch:type="MSLayerGroup" transform="translate(21.428571, 1.428571)">
+                <mask id="mask-22" sketch:name="Oval 1" fill="white">
+                    <use xlink:href="#path-21"></use>
+                </mask>
+                <use id="Oval-1" stroke="#B7B7B7" stroke-width="0.857142857" sketch:type="MSShapeGroup" xlink:href="#path-21"></use>
+                <path d="M8.57142857,0 L8.57142857,8.57142857 L14.5785714,0 L8.57142857,0 Z" id="Rectangle-2" fill="#B7B7B7" sketch:type="MSShapeGroup" mask="url(#mask-22)"></path>
+            </g>
+            <g id="0/10" sketch:type="MSLayerGroup" transform="translate(1.857143, 1.857143)">
+                <mask id="mask-24" sketch:name="Oval 1" fill="white">
+                    <use xlink:href="#path-23"></use>
+                </mask>
+                <use id="Oval-1" stroke="#B7B7B7" stroke-width="0.857142857" sketch:type="MSShapeGroup" xlink:href="#path-23"></use>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
## Proposed changes
-  Change eighth signup block colors to create better contrast between signed up and not signed up blocks
- Use brighter activity icons in dark mode to increase contrast against background

## Brief description of rationale
In both cases, this increases contrast in places where there is low contrast.