### PR TITLE
Add special message for users of the unofficial iOS app

### DIFF
--- a/intranet/apps/context_processors.py
+++ b/intranet/apps/context_processors.py
@@ -166,3 +166,7 @@ def oauth_toolkit(request):
                 return {"applications_tokens": applications_tokens}
 
     return {}
+
+
+def settings_export(request):
+    return {"DJANGO_SETTINGS": settings}

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -44,6 +44,9 @@ ENABLE_BUS_DRIVER = True
 ENABLE_PRE_EIGHTH_REDIRECT = False
 NOTIFY_ADMIN_EMAILS = None
 
+IOS_APP_CLIENT_IDS = []  # Attempting to OAuth to an application with one of these client IDs will result in a *special* error message
+# See templates/oauth2_provider/authorize.html
+
 EMERGENCY_MESSAGE = None  # type: str
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
@@ -342,6 +345,7 @@ TEMPLATES = [
                 "intranet.apps.context_processors.show_bus_button",
                 "intranet.apps.context_processors.enable_dark_mode",
                 "intranet.apps.context_processors.oauth_toolkit",  # Django OAuth Toolkit-related middleware
+                "intranet.apps.context_processors.settings_export",  # "Exports" django.conf.settings as DJANGO_SETTINGS
             ),
             "debug": True,  # Only enabled if DEBUG is true as well
             "loaders": ("django.template.loaders.filesystem.Loader", "django.template.loaders.app_directories.Loader"),

--- a/intranet/templates/oauth2_provider/authorize.html
+++ b/intranet/templates/oauth2_provider/authorize.html
@@ -61,6 +61,9 @@
                 </div>
             </form>
 
+        {% elif request.GET.client_id in DJANGO_SETTINGS.IOS_APP_CLIENT_IDS %}
+            <h2 style="height: initial; white-space: initial; padding: 5px 10px;">Please do not use the unofficial Ion iOS app</h2>
+            <p style="padding: 10px">The app is not maintained by the Sysadmins and has been known to display incorrect signup information. Please use the Ion web interface to sign up for eighth periods.</p>
         {% else %}
             <h2>Error: {{ error.error }}</h2>
             <p>{{ error.description }}</p>


### PR DESCRIPTION
## Proposed changes
- Add special message for users of the unofficial iOS app

## Brief description of rationale
People are complaining about the unofficial iOS app not working. We should head off these complaints by adding a specific message explaining that they should not use it.