### PR TITLE
Bus/bus signage fixes

### DIFF
--- a/intranet/apps/bus/consumers.py
+++ b/intranet/apps/bus/consumers.py
@@ -14,6 +14,10 @@ class BusConsumer(JsonWebsocketConsumer):
         self.send_json(data)
 
     def receive_json(self, content):  # pylint: disable=arguments-differ
+        if content.get("type") == "keepalive":
+            self.send_json({"type": "keepalive-response"})
+            return
+
         if self.scope["user"].is_bus_admin:
             try:
                 route = Route.objects.get(id=content["id"])

--- a/intranet/static/js/bus.js
+++ b/intranet/static/js/bus.js
@@ -337,7 +337,32 @@ $(function() {
                         text.style('pointer-events', 'none');
 
                         if(window.isSignage) {
-                            $(text.node).find("tspan").attr({"x": 0, "dy": 20.5});
+                            var tspan = $(text.node).find("tspan");
+                            tspan.attr({"x": 0, "dy": 20.5});
+
+                            // If we run this directly, it hasn't rendered yet, so we have to run it after a timeout
+                            setTimeout(function() {
+                                var tbox = tspan.get(0).getBBox();
+                                var sbox = space.getBBox();
+
+                                var offset;
+                                var dimenDiff;
+                                if(tbox.width > tbox.height) {
+                                    dimenDiff = sbox.width - tbox.width;
+                                    offset = tbox.x - sbox.x;
+                                }
+                                else {
+                                    dimenDiff = sbox.height - tbox.height;
+                                    offset = tbox.y - sbox.y;
+                                }
+
+                                if(dimenDiff < offset + 5) {
+                                    text.node.classList.add("small");
+                                    if(route.attributes.route_name.length > 5) {
+                                        text.node.classList.add("extra-small");
+                                    }
+                                }
+                            }, 0);
                         }
                         space.style.fill = '#FFD800';
                         $(space).data({

--- a/intranet/static/js/bus.js
+++ b/intranet/static/js/bus.js
@@ -666,11 +666,12 @@ $(function() {
     socket.maxReconnectAttempts = null;
 
     let disconnected = false;
+    let disconnected_msg = null;
     window.appView = new bus.AppView();
 
     socket.onopen = () => {
-        if (disconnected) {
-            disconnected.update({
+        if (disconnected_msg) {
+            disconnected_msg.update({
                 message: 'Connection Restored',
                 type: 'success',
                 hideAfter: 3
@@ -684,12 +685,14 @@ $(function() {
 
     socket.onclose = () => {
         console.log('Disconnected');
-        let msg = Messenger().error({
-            message: 'Connection Lost',
-            hideAfter: 0,
-            showCloseButton: false
-        });
-        disconnected = msg;
+        if(window.Messenger) {
+            disconnected_msg = Messenger().error({
+                message: 'Connection Lost',
+                hideAfter: 0,
+                showCloseButton: false
+            });
+        }
+        disconnected = true;
     };
 
     if (enableBusDriver) {

--- a/intranet/templates/signage/pages/bus.html
+++ b/intranet/templates/signage/pages/bus.html
@@ -13,6 +13,8 @@
     {% stylesheet 'bus' %}
     {% stylesheet 'polls' %}
     {% stylesheet 'dashboard' %}
+    <link rel="stylesheet" href="{% static 'vendor/messenger/build/css/messenger.css' %}">
+    <link rel="stylesheet" href="{% static 'vendor/messenger/build/css/messenger-theme-flat.css' %}">
 {% endblock %}
 
 {% block js %}
@@ -51,6 +53,9 @@
     <script src="{% static 'js/pages/bus.js' %}"></script>
     <script src="{% static 'js/vendor/underscore-min.js' %}"></script>
     <script src="{% static 'js/vendor/backbone-min.js' %}"></script>
+    <script src="{% static 'js/common.header.js' %}"></script>
+    <script src="{% static 'vendor/messenger/build/js/messenger.min.js' %}"></script>
+    <script src="{% static 'vendor/messenger/build/js/messenger-theme-flat.js' %}"></script>
 
     <style media="screen">
     svg {

--- a/intranet/templates/signage/pages/bus.html
+++ b/intranet/templates/signage/pages/bus.html
@@ -85,6 +85,12 @@
         font-weight: bold;
         font-size: 110%;
     }
+    svg text.small {
+        font-size: 100%;
+    }
+    svg text.extra-small {
+        font-size: 90%;
+    }
     </style>
 {% endblock %}
 


### PR DESCRIPTION
## Proposed changes
- `bus`: Handle Messenger not being available better
- `bus`: Add keepalive feature (initiated by client, polls every 30 seconds and requires a response within 10 seconds)
- `signage`/`bus`: Include `messenger.js` so "Connection Lost" messages appear
- `signage`/`bus`: Shrink bus route text if it's too large to fit

## Brief description of rationale
All general bus app fixes.