### PR TITLE
Printing tweaks

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -502,6 +502,7 @@ intranet/apps/printing/__init__.py
 intranet/apps/printing/admin.py
 intranet/apps/printing/forms.py
 intranet/apps/printing/models.py
+intranet/apps/printing/tests.py
 intranet/apps/printing/urls.py
 intranet/apps/printing/views.py
 intranet/apps/printing/magic_files/COPYING

--- a/docs/sourcedoc/intranet.apps.printing.rst
+++ b/docs/sourcedoc/intranet.apps.printing.rst
@@ -28,6 +28,14 @@ intranet.apps.printing.models module
    :undoc-members:
    :show-inheritance:
 
+intranet.apps.printing.tests module
+-----------------------------------
+
+.. automodule:: intranet.apps.printing.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 intranet.apps.printing.urls module
 ----------------------------------
 

--- a/intranet/apps/printing/tests.py
+++ b/intranet/apps/printing/tests.py
@@ -1,0 +1,11 @@
+from django.urls import reverse
+
+from ...test.ion_test import IonTestCase
+
+
+class PrintingTest(IonTestCase):
+    def test_printing_view(self):
+        self.make_admin()
+
+        response = self.client.get(reverse("printing"))
+        self.assertEqual(response.status_code, 200)

--- a/intranet/apps/printing/views.py
+++ b/intranet/apps/printing/views.py
@@ -152,7 +152,7 @@ def get_mimetype(tmpfile_name):
     return mimetype
 
 
-def convert_file(tmpfile_name):
+def convert_file(tmpfile_name, orig_fname):
     detected = get_mimetype(tmpfile_name)
     no_conversion = ["application/pdf", "text/plain"]
     soffice_convert = [
@@ -169,6 +169,14 @@ def convert_file(tmpfile_name):
 
     if detected == "application/postscript":
         return convert_pdf(tmpfile_name, "pdf2ps")
+
+    # Not detected
+
+    if orig_fname.endswith((".doc", ".docx")):
+        raise InvalidInputPrintingError(
+            "Invalid file type {}<br>Note: It looks like you are trying to print a Word document. Word documents don't always print correctly, so we "
+            "recommend that you convert to a PDF before printing.".format(detected)
+        )
 
     raise InvalidInputPrintingError("Invalid file type {}".format(detected))
 
@@ -224,7 +232,7 @@ def print_job(obj, do_print=True):
 
     logger.debug(tmpfile_name)
 
-    tmpfile_name = convert_file(tmpfile_name)
+    tmpfile_name = convert_file(tmpfile_name, filebase)
     logger.debug(tmpfile_name)
 
     if not tmpfile_name:

--- a/intranet/apps/printing/views.py
+++ b/intranet/apps/printing/views.py
@@ -316,7 +316,7 @@ def print_view(request):
             else:
                 messages.success(
                     request,
-                    "Your file was submitted to the printer."
+                    "Your file was submitted to the printer. "
                     "If the printers are experiencing trouble, please contact the "
                     "Student Systems Administrators by filling out the feedback "
                     "form.",


### PR DESCRIPTION
## Proposed changes
- Add missing space
- Recommend users convert to a PDF if a file with a `.doc` or `.docx` extension can't be identified (has been tested in a development environment)
- Add a test to make sure the printing page renders correctly

## Brief description of rationale
Fixes a bug, adds a test (however minimal), and gives a helpful message to (likely) confused users.