### PR TITLE
Session management tweaks

### DIFF
--- a/intranet/static/css/sessionmgmt.scss
+++ b/intranet/static/css/sessionmgmt.scss
@@ -11,6 +11,7 @@ ul.trusted-sessions {
         border-radius: 5px;
 
         padding: 6px 10px;
+        margin-bottom: 5px;
     }
 }
 


### PR DESCRIPTION
## Proposed changes
- Add bottom margin to device information "box"
- Fail more gracefully (no 404) if the user tries to revoke a session that has already been revoked

## Brief description of rationale
The "boxes" displaying information on each trusted device don't look good when squashed up against each other, and the 404 error is unexpected.