### PR TITLE
Add formatting check to Travis build

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 150
-exclude=*/migrations/*
+exclude=*/migrations/*,*/stubs/*,secret*

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 - npm install sass
 - pip install -U pip setuptools
 - pip install -U -r requirements.txt
-- pip install -U coveralls flake8 pylint pylint-django pylint-plugin-utils codacy-coverage isort
+- pip install -U coveralls flake8 pylint pylint-django pylint-plugin-utils codacy-coverage isort black autopep8
 before_script:
 - cp intranet/settings/travis_secret.py intranet/settings/secret.py
 - sudo systemctl start rabbitmq-server
@@ -44,6 +44,7 @@ script:
 - coverage run -a ./manage.py migrate
 - ./manage.py collectstatic --noinput -v 0
 - ./scripts/build_ensure_no_changes.sh ./scripts/build_docs.sh
+- ./scripts/build_ensure_no_changes.sh ./scripts/format.sh
 - isort --check --recursive intranet
 after_success:
 - ./scripts/push_docs.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Please see [our security policy](SECURITY.md). Do not report security vulnerabil
 ## Pull Requests
 - All PRs should target `dev`, not `master`.
 - If the change is anything more than a simple typo or a fairly obvious fix, please [set up a development environment](docs/setup/vagrant.rst) and test the change there before submitting a PR.
-- It is strongly recommended that you [run `flake8`, `pylint`, `isort`](docs/developing/styleguide.rst#what-is-enforced-in-the-build), and [the test suite](docs/developing/testing.rst#running-tests) to ensure that the build will pass. Please also read the entire [style guide](docs/developing/styleguide.rst).
+- It is strongly recommended that you [run `flake8`, `pylint`, `isort`, `scripts/format.sh`](docs/developing/styleguide.rst#what-is-enforced-in-the-build), and [the test suite](docs/developing/testing.rst#running-tests) to ensure that the build will pass. Please also read the entire [style guide](docs/developing/styleguide.rst).
 - Please read [Formatting commit messages](docs/developing/howto.rst#formatting-commit-messages).
 - If your PR closes an issue, include "Closes #XXX" or similar in the messages of the commits that close each issue so the issues will be [automatically closed](https://help.github.com/en/articles/closing-issues-using-keywords) when the commits are merged into `master`.
   Note that including this text in your PR's description will have no effect because the PR will be merged into `dev`, not `master`, so GitHub does not close the issue. You must add the auto-closing keywords to the *commit* messages.

--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -3493,6 +3493,7 @@ scripts/build_docs.sh
 scripts/build_ensure_no_changes.sh
 scripts/build_sources.sh
 scripts/export_fixtures.sh
+scripts/format.sh
 scripts/get_ldif.py
 scripts/import_fixtures.sh
 scripts/make_dark_pattern_images.py

--- a/docs/developing/styleguide.rst
+++ b/docs/developing/styleguide.rst
@@ -2,7 +2,7 @@
 Coding Style Guide
 ******************
 
-Follow `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ (the official style guide for Python). Most PEP8 formatting conventions are enforced in the build by ``pylint`` and/or ``flake8``. Therefore, if you do not follow them, the build may not pass.
+Follow `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ (the official style guide for Python). Most PEP8 formatting conventions are enforced in the build by ``pylint``, ``flake8``, and a combination of ``black``, ``autopep8``, and ``isort``. Therefore, if you do not follow them, the build may not pass.
 
 However, for Ion, we limit the lengths of lines to 150 characters, not 80 characters.
 
@@ -16,6 +16,7 @@ Main points
 - Separate method definitions inside a class with a single blank line.
 - Use two spaces before inline comments and one space between the pound sign and comment.
 - Use a plugin for your text editor to check for/remind you of PEP8 conventions.
+- When in doubt, running ``./scripts/format.sh`` will fix a lot of things.
 - Capitalize and punctuate comments and Git commit messages properly.
 
 What is enforced in the build
@@ -28,12 +29,17 @@ At the time of this writing, the Travis build runs the following commands:
         flake8 --max-line-length 150 --exclude=*/migrations/* .
         pylint --jobs=0 --disable=fixme,broad-except,global-statement,attribute-defined-outside-init intranet/
         isort --check --recursive intranet
+        ./scripts.format.sh
+
+Note: When the ``./scripts/format.sh`` check is run, the build will fail if it has to make any changes.
 
 ``flake8`` is a PEP8 style checker, ``pylint`` is a linter (but it also enforces some PEP8 conventions), and ``isort``, when called with these options, checks that all imports are sorted alphabetically.
 
+``./scripts/format.sh`` runs ``black intranet && autopep8 --in-place --recursive intranet && isort --recursive intranet``. The reason for the multiple commands is that ``black`` introduces certain formatting changes which ``flake8``/``pylint`` do not agree with (and offers no options to change them), so we have ``autopep8`` fix it.
+
 It is recommended that you run all of these locally before opening a pull request (though the Ion developers sometimes skip running the ``pylint`` check locally because it takes a long time to run). All of them are intended to be run from the root directory of the Git repository.
 
-If ``flake8`` or ``pylint`` throw errors, the error messages are usually human-readable. if ``isort`` gives any errors, you can have it automatically correct the order of all imports by running ``isort --recursive intranet``.
+If ``flake8`` or ``pylint`` throw errors, the error messages are usually human-readable. if ``isort`` gives any errors, you can have it automatically correct the order of all imports by running ``isort --recursive intranet``. If the build fails because running ``scripts/format.sh`` resulted in changes, you can simply run  ``./scripts/format.sh`` to fix your formatting.
 
 Imports
 =======

--- a/intranet/__init__.py
+++ b/intranet/__init__.py
@@ -1,3 +1,3 @@
 from .celery import app as celery_app
 
-__all__ = ('celery_app',)
+__all__ = ("celery_app",)

--- a/intranet/apps/sessionmgmt/views.py
+++ b/intranet/apps/sessionmgmt/views.py
@@ -60,10 +60,7 @@ def trust_session_view(request):
 
         if not TrustedSession.objects.filter(user=request.user, session_key=request.session.session_key).exists():
             TrustedSession.objects.create(
-                user=request.user,
-                session_key=request.session.session_key,
-                description=description,
-                device_type=device_type,
+                user=request.user, session_key=request.session.session_key, description=description, device_type=device_type
             )
 
         request.session.set_expiry(7 * 24 * 60 * 60)  # Trusted sessions expire after a week

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -96,8 +96,12 @@ class UserManager(DjangoUserManager):
             A ``QuerySet`` of user objects who have a birthday on a given date and have made their birthday public.
 
         """
-        return User.objects.filter(properties___birthday__month=month, properties___birthday__day=day, properties__self_show_birthday=True,
-                                   properties__parent_show_birthday=True)
+        return User.objects.filter(
+            properties___birthday__month=month,
+            properties___birthday__day=day,
+            properties__self_show_birthday=True,
+            properties__parent_show_birthday=True,
+        )
 
     def get_students(self):
         """Get user objects that are students (quickly)."""

--- a/intranet/apps/users/tests.py
+++ b/intranet/apps/users/tests.py
@@ -99,8 +99,9 @@ class UserTest(IonTestCase):
         login_user.save()
 
         users = [
-            get_user_model().objects.create(first_name=first_name, last_name=last_name, username=first_name[0].lower() + last_name.lower()[:7],
-                                            user_type="teacher")
+            get_user_model().objects.create(
+                first_name=first_name, last_name=last_name, username=first_name[0].lower() + last_name.lower()[:7], user_type="teacher"
+            )
             for first_name, last_name in [
                 ("Michael", "Williams"),
                 ("Miguel", "Wilson"),
@@ -216,8 +217,9 @@ class UserTest(IonTestCase):
 
     def test_user_with_name(self):
         users = [
-            get_user_model().objects.create(first_name=first_name, last_name=last_name, username=first_name[0].lower() + last_name.lower()[:7],
-                                            user_type="teacher")
+            get_user_model().objects.create(
+                first_name=first_name, last_name=last_name, username=first_name[0].lower() + last_name.lower()[:7], user_type="teacher"
+            )
             for first_name, last_name in [
                 ("Michael", "Williams"),
                 ("Miguel", "Wilson"),

--- a/intranet/middleware/session_management.py
+++ b/intranet/middleware/session_management.py
@@ -9,14 +9,17 @@ class SessionManagementMiddleware:
     """
     Handles session management.
     """
+
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
         if request.user is not None and request.user.is_authenticated:
             if isinstance(request.session.get("login_time", None), float):
-                if request.user.last_global_logout_time is not None \
-                   and request.session["login_time"] < request.user.last_global_logout_time.timestamp():
+                if (
+                    request.user.last_global_logout_time is not None
+                    and request.session["login_time"] < request.user.last_global_logout_time.timestamp()
+                ):
                     # This is how global logouts work for non-trusted sessions. We automatically log the user out if the user's most recent global
                     # logout happened since the time they logged in (in this session).
                     logout(request)

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -761,7 +761,7 @@ CELERY_TASK_SERIALIZER = "pickle"
 MAINTENANCE_MODE = False
 
 # Django User Agents configuration
-USER_AGENTS_CACHE = 'default'
+USER_AGENTS_CACHE = "default"
 
 # The Referrer-policy header
 REFERRER_POLICY = "strict-origin-when-cross-origin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,20 @@
 [tool.black]
 line-length = 150
-exclude="migrations"
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  | media
+  | migrations
+  | secret.*
+  | stubs
+)/
+'''

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd "$(dirname -- "$(dirname -- "$(readlink -f "$0")")")"
+
+black intranet && autopep8 --in-place --recursive intranet && isort --recursive intranet


### PR DESCRIPTION
## Proposed changes
- Update `flake8`/`black` exclude lists
- Run `black`/`autopep8`/`isort` in Travis build
- Format everything with new `format.sh` script

## Brief description of rationale
@theo-o has been slowly blackifying the codebase. This makes it official and enforces it.

Note: `autopep8` is needed because on certain things `black` does not agree with `flake8`/`pylint`, so we have `autopep8` fix those.