### PR TITLE
Shrink bus route name even more when it overflows on signage

### DIFF
--- a/intranet/templates/signage/pages/bus.html
+++ b/intranet/templates/signage/pages/bus.html
@@ -89,7 +89,7 @@
         font-size: 100%;
     }
     svg text.extra-small {
-        font-size: 90%;
+        font-size: 80%;
     }
     </style>
 {% endblock %}


### PR DESCRIPTION
## Proposed changes
- Shrink bus route name even more when it overflows on signage

## Brief description of rationale
The route name is illegible in certain cases.