### PR TITLE
fix(bus): shrink bus route text if it's too large (not on signage)

### DIFF
--- a/intranet/static/js/bus.js
+++ b/intranet/static/js/bus.js
@@ -364,6 +364,28 @@ $(function() {
                                 }
                             }, 0);
                         }
+                        else {
+                            var tspan = $(text.node).find("tspan");
+
+                            setTimeout(function() {
+                                var tbox = tspan.get(0).getBBox();
+                                var sbox = space.getBBox();
+
+                                var offset;
+                                var dimenDiff;
+                                if(tbox.width > tbox.height) {
+                                    dimenDiff = sbox.width - tbox.width;
+                                    offset = tbox.x - sbox.x;
+                                }
+                                else {
+                                    dimenDiff = sbox.height - tbox.height;
+                                    offset = tbox.y - sbox.y;
+                                }
+                                if(dimenDiff < offset + 5 || route.attributes.route_name.length > 5) {
+                                    text.node.classList.add("extra-small");
+                                }
+                            }, 0);
+                        }
                         space.style.fill = '#FFD800';
                         $(space).data({
                             'filled': true,

--- a/intranet/templates/bus/home.html
+++ b/intranet/templates/bus/home.html
@@ -13,6 +13,11 @@
     {% stylesheet 'bus' %}
     {% stylesheet 'polls' %}
     {% stylesheet 'dashboard' %}
+    <style>
+        svg text.extra-small {
+            font-size: 90%;
+        }
+    </style>
 {% endblock %}
 
 {% block js %}


### PR DESCRIPTION
## Proposed changes
- Shrink bus route text if it's too large (not on signage)

## Brief description of rationale
See faa6a63 and #858.