### PR TITLE
Unlock dark mode globally

### DIFF
--- a/intranet/apps/context_processors.py
+++ b/intranet/apps/context_processors.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 
 from intranet.apps.notifications.models import NotificationConfig
 
-from ..utils.helpers import dark_mode_enabled
+from ..utils.helpers import dark_mode_enabled, dark_mode_unlocked_globally
 from .schedule.models import Day
 
 logger = logging.getLogger(__name__)
@@ -170,7 +170,7 @@ def enable_dark_mode(request):
     """
     Export whether dark mode is enabled.
     """
-    return {"dark_mode_enabled": dark_mode_enabled(request)}
+    return {"dark_mode_enabled": dark_mode_enabled(request), "dark_mode_unlocked_globally": dark_mode_unlocked_globally()}
 
 
 def oauth_toolkit(request):

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -17,7 +17,7 @@ from django.utils.functional import cached_property
 
 from intranet.middleware import threadlocals
 
-from ...utils.helpers import is_entirely_digit
+from ...utils.helpers import dark_mode_unlocked_globally, is_entirely_digit
 from ..bus.models import Route
 from ..eighth.models import EighthBlock, EighthSignup, EighthSponsor
 from ..groups.models import Group
@@ -1000,7 +1000,7 @@ class UserDarkModeProperties(models.Model):
 
     @property
     def dark_mode_unlocked(self):
-        return self._dark_mode_unlocked
+        return dark_mode_unlocked_globally() or self._dark_mode_unlocked
 
     def __str__(self):
         return str(self.user)

--- a/intranet/static/css/base.scss
+++ b/intranet/static/css/base.scss
@@ -847,6 +847,45 @@ body.fire * {
     }
 }
 
+.new-feature {
+    background: #0048ab;
+    margin: 0 auto 10px;
+    color: white;
+    padding: 5px;
+    padding-left: 10px;
+    border-radius: 5px;
+    @media (max-width: 700px) {
+        max-width: 100%;
+    }
+    @media (min-width: 700px) and (max-width: 950px) {
+        max-width: 75%;
+    }
+    @media (min-width: 950px) {
+        max-width: 50%;
+    }
+
+    &-text {
+        font-size: 15px;
+    }
+
+    &-close {
+        cursor: pointer;
+        vertical-align: middle;
+        float: right;
+        margin: 0px 5px 0px 10px;
+        position: relative;
+        font-size: 17px;
+
+        &:hover {
+            color: #d8d8d8;
+        }
+    }
+
+    a:link, a:visited {
+        color: #acacff;
+    }
+}
+
 .selectize-input {
     padding-right: 40px !important;
 }

--- a/intranet/static/css/eighth.signup.scss
+++ b/intranet/static/css/eighth.signup.scss
@@ -261,40 +261,6 @@ $headerblue: #0048ab;
     }
 }
 
-.new-feature {
-    background: $headerblue;
-    margin: 0 auto 10px;
-    color: white;
-    padding: 5px;
-    border-radius: 5px;
-    @media (max-width: 700px) {
-        max-width: 100%;
-    }
-    @media (min-width: 700px) and (max-width: 950px) {
-        max-width: 75%;
-    }
-    @media (min-width: 950px) {
-        max-width: 50%;
-    }
-
-    &-text {
-        font-size: 15px;
-    }
-
-    &-close {
-        cursor: pointer;
-        vertical-align: middle;
-        float: right;
-        padding: 5px;
-        position: relative;
-        font-size: 20px;
-
-        &:hover {
-            color: $color1;
-        }
-    }
-}
-
 .search {
     &-wrapper {
         position: relative;

--- a/intranet/static/js/dashboard/common.js
+++ b/intranet/static/js/dashboard/common.js
@@ -6,4 +6,7 @@ $(function() {
     $('.widget.extra-widgets-show').click(function() {
         $('body').addClass('show-extra-widgets');
     });
+    $(".new-feature-close").click(function(e) {
+        $(e.target).closest(".new-feature").hide("slow");
+    });
 });

--- a/intranet/templates/dashboard/dashboard.html
+++ b/intranet/templates/dashboard/dashboard.html
@@ -55,6 +55,17 @@
 
 {% if show_widgets %}
 
+{% if dark_mode_unlocked_globally and not request.user.dark_mode_properties.dark_mode_enabled %}
+<div class="primary-content">
+    <div class="new-feature" style="margin: 0px 0px 10px 0px; max-width: fit-content;">
+        <div class="new-feature-close">
+            <i class="fas fa-times"></i>
+        </div>
+        <span class="new-feature-text"><i class="fas fa-rocket" style="padding-right: 2px"></i> Ion now has a dark mode! You can enable it in <a href="{% url 'preferences' %}">Preferences</a>.</span>
+    </div>
+</div>
+{% endif %}
+
 <div class="widgets{% if eighth_sponsor and request.user.is_student %} student-sponsor{% endif %}">
     {% if is_student %}
         {% include "eighth/signup_widget.html" %}

--- a/intranet/utils/helpers.py
+++ b/intranet/utils/helpers.py
@@ -187,3 +187,7 @@ def dark_mode_enabled(request):
         return request.user.dark_mode_properties.dark_mode_unlocked and request.user.dark_mode_properties.dark_mode_enabled
     else:
         return request.COOKIES.get("dark-mode-enabled", "") == "1"
+
+
+def dark_mode_unlocked_globally():
+    return timezone.localdate() >= datetime.date(2019, 10, 30)


### PR DESCRIPTION
## Proposed changes
- Unlock dark mode globally
- Add a "new feature" description to the dashboard mentioning dark mode and directing the user to the "Preferences" page to enable it

## Brief description of rationale
Dark mode has been tested and should be ready for school-wide deployment.