### PR TITLE
Don't show horizontal scrollbars when resizing eighth admin page

### DIFF
--- a/intranet/static/css/eighth.admin.scss
+++ b/intranet/static/css/eighth.admin.scss
@@ -171,7 +171,7 @@ table.choose-fields td {
     text-align: center;
 }
 
-@media (max-width: 835px) {
+@media (max-width: 945px) {
     .primary-content .admin-dashboard #add-room-form {
         #id_name {
             width: 60px;
@@ -184,7 +184,7 @@ table.choose-fields td {
     }
 }
 
-@media (max-width: 750px) {
+@media (max-width: 785px) {
     tr .admin-section {
         &:last-of-type:not(:first-of-type) {
             padding-left: 5px;

--- a/intranet/static/css/responsive.scss
+++ b/intranet/static/css/responsive.scss
@@ -313,7 +313,7 @@
 
 /* EIGHTH ADMIN UI */
 
-@media (max-width: 695px) {
+@media (max-width: 750px) {
     /* flatten table */
     td.admin-section {
         .admin-dashboard & {
@@ -322,7 +322,11 @@
             height: auto;
             padding-left: 0;
         }
+    }
+}
 
+@media (max-width: 785px) {
+    td.admin-section {
         tr &:last-of-type:not(:first-of-type) {
             padding-left: 0;
         }


### PR DESCRIPTION
## Proposed changes
- Don't show horizontal scrollbars when resizing eighth admin page

## Brief description of rationale
The eighth admin page is able to adapt to a range of screen sizes, but
there are some size ranges where horizontal scrollbars are shown despite
having enough screen space to avoid this.