### PR TITLE
Enforce static/template file formatting (currently just no trailing whitespace)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ script:
 - ./manage.py collectstatic --noinput -v 0
 - ./scripts/build_ensure_no_changes.sh ./scripts/build_docs.sh
 - ./scripts/build_ensure_no_changes.sh ./scripts/format.sh
+- ./scripts/build_ensure_no_changes.sh ./scripts/static_templates_format.sh
 - isort --check --recursive intranet
 after_success:
 - ./scripts/push_docs.sh

--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -3509,4 +3509,5 @@ scripts/import_fixtures.sh
 scripts/make_dark_pattern_images.py
 scripts/push_docs.sh
 scripts/restart_celery.sh
+scripts/static_templates_format.sh
 scripts/update_docs_sources.sh

--- a/docs/developing/styleguide.rst
+++ b/docs/developing/styleguide.rst
@@ -6,6 +6,8 @@ Follow `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ (the official style g
 
 However, for Ion, we limit the lengths of lines to 150 characters, not 80 characters.
 
+Note: CSS/JS/template formatting is enforced by ``scripts/static_templates_format.sh``. Currently, this just strips trailing whitespace.
+
 Main points
 ===========
 
@@ -30,8 +32,9 @@ At the time of this writing, the Travis build runs the following commands:
         pylint --jobs=0 --disable=fixme,broad-except,global-statement,attribute-defined-outside-init intranet/
         isort --check --recursive intranet
         ./scripts.format.sh
+        ./scripts/static_templates_format.sh  # Static/template files
 
-Note: When the ``./scripts/format.sh`` check is run, the build will fail if it has to make any changes.
+Note: When the ``./scripts/format.sh`` and ``./scripts/static_templates_format.sh`` checks are run, the build will fail if they have to make any changes.
 
 ``flake8`` is a PEP8 style checker, ``pylint`` is a linter (but it also enforces some PEP8 conventions), and ``isort``, when called with these options, checks that all imports are sorted alphabetically.
 

--- a/intranet/static/manifest.json
+++ b/intranet/static/manifest.json
@@ -2,12 +2,12 @@
   "short_name": "TJ Intranet",
   "name": "TJ Intranet",
   "icons": [
-    {  
-      "src": "/static/img/logos/touch/touch-icon128.png",  
+    {
+      "src": "/static/img/logos/touch/touch-icon128.png",
       "sizes": "128x128",
       "type": "image/png"
     },
-    {  
+    {
       "src": "/static/img/logos/touch/touch-icon144.png",
       "sizes": "144x144",
       "type": "image/png"
@@ -28,13 +28,13 @@
       "type": "image/png"
     },
     {
-      "src": "/static/img/logos/touch/touch-icon512.png",  
+      "src": "/static/img/logos/touch/touch-icon512.png",
       "sizes": "512x512",
       "type": "image/png"
     }
   ],
   "background_color": "#0048AB",
-  "theme_color": "#0048AB", 
+  "theme_color": "#0048AB",
   "start_url": "/",
   "display": "standalone",
   "orientation": "portrait",

--- a/intranet/templates/announcements/delete.html
+++ b/intranet/templates/announcements/delete.html
@@ -49,7 +49,7 @@
         <input type="submit" value="Expire">
         <br>
         <br>
-        <a href="#" id="delete" class="button"><i class='fas fa-exclamation-triangle'></i> Full Delete</a> &nbsp; 
+        <a href="#" id="delete" class="button"><i class='fas fa-exclamation-triangle'></i> Full Delete</a> &nbsp;
     </form>
 </div>
 <script>

--- a/intranet/templates/announcements/emails/announcement_approved.html
+++ b/intranet/templates/announcements/emails/announcement_approved.html
@@ -9,7 +9,7 @@
     The announcement that you submitted,
 {% else %}
     The announcement,
-{% endif %} <b>{{ announcement.title }}</b>, was posted by 
+{% endif %} <b>{{ announcement.title }}</b>, was posted by
 {% if request.posted_by %}
     {{ request.posted_by.full_name }}.
 {% else %}

--- a/intranet/templates/announcements/request_status.html
+++ b/intranet/templates/announcements/request_status.html
@@ -76,7 +76,7 @@
 
     <br>
     <br>
-    
+
     {% if rejected %}
         <h3><i class="fas fa-info-circle"></i> {{ rejected|length }} already rejected</h3>
         {% for req in rejected %}

--- a/intranet/templates/dashboard/admin.html
+++ b/intranet/templates/dashboard/admin.html
@@ -3,8 +3,8 @@
         <h2>
             Intranet Administration
         </h2>
-        <div class="info">  
-            <a href="/djangoadmin/" class="button small-button">Django Admin</a>  
+        <div class="info">
+            <a href="/djangoadmin/" class="button small-button">Django Admin</a>
         </div>
     </div>
     <div class="widget-content">

--- a/intranet/templates/dashboard/dashboard.html
+++ b/intranet/templates/dashboard/dashboard.html
@@ -86,13 +86,13 @@
     {% endif %}
 
     {% include "dashboard/eighth_info.html" %}
-    
+
     {% include "dashboard/links.html" %}
 
     {% if is_student %}
         {% include "dashboard/seniors.html" %}
     {% endif %}
-    
+
     {% include "dashboard/birthdays.html" %}
 </div>
 {% endif %}

--- a/intranet/templates/eighth/absences.html
+++ b/intranet/templates/eighth/absences.html
@@ -77,9 +77,9 @@
                     {% endif %}
                 </tr>
             {% empty %}
-                
+
                     <tr><td colspan="5">{% if request.user == user %}<i class="far fa-smile"></i> You have no absences.{% else %}No absences.{% endif %}</td></tr>
-                
+
             {% endfor %}
         </table>
         <br>

--- a/intranet/templates/eighth/activity.html
+++ b/intranet/templates/eighth/activity.html
@@ -110,7 +110,7 @@
                     {{ room }}{% if not forloop.last %}, {% endif %}
                 {% endfor %}</dd>
         {% endif %}
-        
+
     </dl>
 
     <section class="user-info-eighth sponsor">
@@ -206,6 +206,6 @@
         <br>
     </section>
 
-    
+
 </div>
 {% endblock %}

--- a/intranet/templates/eighth/admin/add_block.html
+++ b/intranet/templates/eighth/admin/add_block.html
@@ -81,7 +81,7 @@ $(function() {
     });
 });
 check_submit = function() {
-    
+
     var val = $("input[name=blocks][type=text]").val();
     console.debug(val, "text");
     if(val) {

--- a/intranet/templates/eighth/admin/distribute_group.html
+++ b/intranet/templates/eighth/admin/distribute_group.html
@@ -40,12 +40,12 @@
 {% block admin_main %}
     {% if show_selection %}
         <form action="{% url 'eighth_admin_distribute_action' %}" method="post">
-            
+
             {% if users_type == "unsigned" %}
                 <p>{{ users|length }} user{{ users|length|pluralize }} have not signed up for any activities on {{ eighthblock }}.</p>
             {% elif users_type == "group" %}
                 <b>Group:</b> {{ group }} - {{ users|length }} member{{ users|length|pluralize }}<br>
-                <a href="{% url 'eighth_admin_edit_group' group.id %}" class="button">Modify Group</a> &nbsp; 
+                <a href="{% url 'eighth_admin_edit_group' group.id %}" class="button">Modify Group</a> &nbsp;
             {% endif %}
             <button onclick="distribute(); return false">Evenly Distribute</button>
             <br>

--- a/intranet/templates/eighth/admin/no_signups_roster.html
+++ b/intranet/templates/eighth/admin/no_signups_roster.html
@@ -34,7 +34,7 @@
     {% if profile_user.is_student %}
         <script>
             $(document).ready(function() {
-                
+
             });
         </script>
     {% endif %}

--- a/intranet/templates/eighth/admin/sign_up_group.html
+++ b/intranet/templates/eighth/admin/sign_up_group.html
@@ -17,7 +17,7 @@
         <form action="" method="post" name="wizard">{% csrf_token %}
             {{ wizard.management_form }}
             <p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
-            
+
 
             {% if block_obj %}
                 <b>Block:</b> {{ block_obj }}

--- a/intranet/templates/eighth/admin/upload_group.html
+++ b/intranet/templates/eighth/admin/upload_group.html
@@ -96,7 +96,7 @@ textarea[name=filetext] {
         <tr>
             <td>{{ user.0 }}</td>
             <td>
-                <input type="checkbox" name="user_id" value="{{ user.1.id }}" checked> 
+                <input type="checkbox" name="user_id" value="{{ user.1.id }}" checked>
             </td>
             <td>
                 {% if user.1.display_name %}{{ user.1.display_name }}{% else %}{{ user.1.full_name }}{% endif %} ({{ user.1.student_id }}{% if user.1.grade_number %}, {{ user.grade_number }}{% elif user.1.is_teacher %}, Staff{% endif %})
@@ -126,7 +126,7 @@ textarea[name=filetext] {
             {% if user.1 %}
                 {% for u in user.1 %}
                 <td>
-                    <input type="checkbox" name="add_user" value="{{ u.id }}"> 
+                    <input type="checkbox" name="add_user" value="{{ u.id }}">
                 </td>
                 <td>
                     {{ u.display_name }} ({{ u.student_id }}, {{ u.grade }})

--- a/intranet/templates/eighth/display.html
+++ b/intranet/templates/eighth/display.html
@@ -408,7 +408,7 @@
 
             <span class="activity-rooms">
                 <% if (rooms.length != 0) {%>
-                    <%_.each(rooms, function(r, i) { if (i + 1 != rooms.length) {%><%= r %>, <%} else { %><%= r %><%} })%> 
+                    <%_.each(rooms, function(r, i) { if (i + 1 != rooms.length) {%><%= r %>, <%} else { %><%= r %><%} })%>
                 <%}%>
             </span>
 

--- a/intranet/templates/eighth/emails/absence.html
+++ b/intranet/templates/eighth/emails/absence.html
@@ -6,7 +6,7 @@
     You now have {{ num_absences }} Eighth Period absence{{ num_absences|pluralize }}:</p>
 
 
-    <b>{{ signup.scheduled_activity.block }}</b>: 
+    <b>{{ signup.scheduled_activity.block }}</b>:
         {{ signup.scheduled_activity.full_title }}
     <br>
         <span style="color: orange">

--- a/intranet/templates/eighth/emails/signup_status.html
+++ b/intranet/templates/eighth/emails/signup_status.html
@@ -9,7 +9,7 @@
 
 
 {% for blk in blocks %}
-    <b>{{ blk.block }}</b>: 
+    <b>{{ blk.block }}</b>:
     {% if blk.signup %}
         {{ blk.signup.scheduled_activity.full_title }}
     {% else %}
@@ -38,11 +38,11 @@
 
 
 {% if issues > 0 %}
-    <p>Please make sure to correct the above issue{{ issues|pluralize }} before 
+    <p>Please make sure to correct the above issue{{ issues|pluralize }} before
     {% if block_signup_time %}
-        {{ block_signup_time }} on {{ block_date }}. 
+        {{ block_signup_time }} on {{ block_date }}.
     {% else %}
-        {{ block_date }}. 
+        {{ block_date }}.
     {% endif %}
     </p>
 {% endif %}

--- a/intranet/templates/eighth/emails/signup_status.txt
+++ b/intranet/templates/eighth/emails/signup_status.txt
@@ -5,7 +5,7 @@
     {% if blk.signup %}
         {% if blk.cancelled %}&#x26a0; The activity you selected was cancelled. You need to choose a new activity.{% else %}&#x2713; You have selected an activity.{% endif %}
     {% else %}&#x26a0; You have not selected an activity. You need to choose an activity.{% endif %}
-    
+
 
 {% endfor %}
 

--- a/intranet/templates/eighth/profile_header.html
+++ b/intranet/templates/eighth/profile_header.html
@@ -1,6 +1,6 @@
 
 <a href="{% url 'eighth_profile' profile_user.id %}">
-    <div class="{% if profile_user.is_student %}multiple-pics{% endif %} preferred-user-picture">    
+    <div class="{% if profile_user.is_student %}multiple-pics{% endif %} preferred-user-picture">
         <img src="/profile/picture/{{ profile_user.id }}" alt="Preferred Picture" title="View Eighth Profile" width="86" height="107.5">
     </div>
 </a>

--- a/intranet/templates/eighth/roster.html
+++ b/intranet/templates/eighth/roster.html
@@ -29,7 +29,7 @@
     {% if profile_user.is_student %}
         <script>
             $(document).ready(function() {
-                
+
             });
         </script>
     {% endif %}

--- a/intranet/templates/eighth/signup_widget.html
+++ b/intranet/templates/eighth/signup_widget.html
@@ -18,7 +18,7 @@
         <div class="info">
             <a href="{% url 'eighth_signup' %}" class="btn-link">View more blocks</a>
         </div>
-        
+
     </div>
     <div class="widget-content">
     {% for block in schedule %}

--- a/intranet/templates/eighth/take_attendance.html
+++ b/intranet/templates/eighth/take_attendance.html
@@ -312,8 +312,8 @@
                                     <form name="pass-form-{{ pass.id }}" action="{% url 'eighth_accept_pass' pass.id %}" method="post">
                                         {% csrf_token %}
                                         <input type="hidden" name="status" value="">
-                                        <a href="#" onclick="return false" class="pass-form-submit-link button" data-form="pass-form-{{ pass.id }}" data-status="accept"><i class="fas fa-check"></i></a> 
-                                         &nbsp; 
+                                        <a href="#" onclick="return false" class="pass-form-submit-link button" data-form="pass-form-{{ pass.id }}" data-status="accept"><i class="fas fa-check"></i></a>
+                                         &nbsp;
 
                                         <a href="#" onclick="return false" class="pass-form-submit-link button" data-form="pass-form-{{ pass.id }}" data-status="reject"><i class="fas fa-times"></i></a>
                                     </form>

--- a/intranet/templates/events/event.html
+++ b/intranet/templates/events/event.html
@@ -22,7 +22,7 @@
             <a href="{% url 'event' event.id %}" class="event-link">
                 {{ event.title }}
             </a>
-        {% else %}    
+        {% else %}
             {{ event.title }}
         {% endif %}
 
@@ -71,7 +71,7 @@
                 {% include "announcements/announcement.html" %}
             {% endwith %}
         {% endif %}
-        
+
         <div class="event-content">
             {{ event.description|safe }}
         </div>
@@ -129,7 +129,7 @@
 
             {% if request.user in event.attending.all %}
                 <span class="attend-status">
-                    You are <b style="color: green">attending</b> this event. 
+                    You are <b style="color: green">attending</b> this event.
                     {% if show_attend %}
                         <a href="#" data-form-submit="no-attend-form-{{ event.id }}" class="button small-button no-attend-button">
                             <i class="fas fa-times"></i>
@@ -139,7 +139,7 @@
                 </span>
             {% else %}
                 <span class="attend-status">
-                    You are <b style="color: red">not attending</b> this event. 
+                    You are <b style="color: red">not attending</b> this event.
                     {% if show_attend %}
                         <a href="#" data-form-submit="attend-form-{{ event.id }}" class="button small-button attend-button">
                             <i class="fas fa-check"></i>

--- a/intranet/templates/events/scheduled_activity.html
+++ b/intranet/templates/events/scheduled_activity.html
@@ -13,7 +13,7 @@
     </div>
     <a href="{% url 'eighth_signup' schact.block.id %}?activity={{ schact.activity.id }}" class="button small-button">
         Sign Up
-    </a> &nbsp; 
+    </a> &nbsp;
     <a href="{% url 'eighth_roster' schact.id %}" class="button small-button">
         View Roster
     </a>

--- a/intranet/templates/events/tjstar_widget.html
+++ b/intranet/templates/events/tjstar_widget.html
@@ -5,6 +5,6 @@
         </h2>
     </div>
     <div class="widget-content">
-        <iframe src="https://tjstar.tjhsst.edu/widget/{{ tjstar_uuid }}" style="width: 100%;height: 150px;overflow: hidden" scrolling="no"></iframe>  
+        <iframe src="https://tjstar.tjhsst.edu/widget/{{ tjstar_uuid }}" style="width: 100%;height: 150px;overflow: hidden" scrolling="no"></iframe>
     </div>
 </div>

--- a/intranet/templates/feedback/form.html
+++ b/intranet/templates/feedback/form.html
@@ -63,7 +63,7 @@
     <p>
         Note that if you're having technical issues, we recommend that you email <a href="mailto:sysadmins@tjhsst.edu">sysadmins@tjhsst.edu</a> instead.
     </p>
-    
+
     <form action="{% url 'send_feedback' %}" method="post">
             {% csrf_token %}
             {{ form.as_p }}
@@ -77,7 +77,7 @@
 <script>
     // name of <textarea> is content
     CKEDITOR.replace("comments", {
-        
+
     });
 
 </script>

--- a/intranet/templates/files/delete.html
+++ b/intranet/templates/files/delete.html
@@ -43,7 +43,7 @@
         <form action="" method="POST">
             {% csrf_token %}
             <input name="path" type="hidden" value="{{ request.GET.dir|urlencode }}">
-            <a class="button" href="{% url 'files_type' host.code %}?dir={{ remote_dir|urlencode }}">Cancel</a> &nbsp; 
+            <a class="button" href="{% url 'files_type' host.code %}?dir={{ remote_dir|urlencode }}">Cancel</a> &nbsp;
             <input name="confirm" type="submit" value="Delete">
         </form>
 

--- a/intranet/templates/files/home.html
+++ b/intranet/templates/files/home.html
@@ -33,9 +33,9 @@
 
                 <a href="{% url 'files_type' host.code %}">
                     {% if host.linux %}
-                        <i class="fab fa-linux"></i> 
+                        <i class="fab fa-linux"></i>
                     {% elif host.windows %}
-                        <i class="fab fa-windows"></i> 
+                        <i class="fab fa-windows"></i>
                     {% endif %}
 
                     <span>

--- a/intranet/templates/groups/addmodify.html
+++ b/intranet/templates/groups/addmodify.html
@@ -10,7 +10,7 @@
 {% block css %}
     {{ block.super }}
     {% stylesheet 'groups' %}
-    
+
 {% endblock %}
 
 {% block js %}
@@ -53,7 +53,7 @@
     <form action="" method="post">
         <h3>Add users to this group:</h3>
         {% csrf_token %}
-        
+
         <input type="submit">
     </form>
 </div>

--- a/intranet/templates/itemreg/register_delete.html
+++ b/intranet/templates/itemreg/register_delete.html
@@ -31,12 +31,12 @@
         Delete {{ type|title }}
     </h2>
     <br>
-    
+
     <b>Are you sure you want to delete {{ obj }}?</b>
     <form method="post" action="">
         {% csrf_token %}
         <input type="hidden" name="confirm" value="1">
-        <a href="{% url 'itemreg' %}" class="button">Cancel</a> &nbsp; 
+        <a href="{% url 'itemreg' %}" class="button">Cancel</a> &nbsp;
         <input type="submit" value="Delete">
     </form>
 

--- a/intranet/templates/lostfound/founditem_delete.html
+++ b/intranet/templates/lostfound/founditem_delete.html
@@ -31,7 +31,7 @@
         Delete {{ founditem.title }}
     </h2>
     <br>
-    
+
     <b>Are you sure you want to delete {{ founditem.title }}?</b>
     <form method="post" action="">
         {% csrf_token %}
@@ -41,9 +41,9 @@
         <input type="radio" name="mark_retrieved" id="mark_retrieved" value="">
         <label for="mark_retrieved">Mark Retrieved</label>
         <br>
-         
+
         <input type="hidden" name="confirm" value="1">
-        <a href="{% url 'lostfound' %}" class="button">Cancel</a> &nbsp; 
+        <a href="{% url 'lostfound' %}" class="button">Cancel</a> &nbsp;
         <input type="submit" value="Delete">
     </form>
 

--- a/intranet/templates/lostfound/lostitem_delete.html
+++ b/intranet/templates/lostfound/lostitem_delete.html
@@ -31,7 +31,7 @@
         Delete {{ lostitem.title }}
     </h2>
     <br>
-    
+
     <b>Are you sure you want to delete {{ lostitem.title }}?</b>
     <form method="post" action="">
         {% csrf_token %}
@@ -41,9 +41,9 @@
         <input type="radio" name="mark_found" id="mark_found" value="">
         <label for="mark_found">Mark Found</label>
         <br>
-        
+
         <input type="hidden" name="confirm" value="1">
-        <a href="{% url 'lostfound' %}" class="button">Cancel</a> &nbsp; 
+        <a href="{% url 'lostfound' %}" class="button">Cancel</a> &nbsp;
         <input type="submit" value="Delete">
     </form>
 

--- a/intranet/templates/oauth2_provider/authorize.html
+++ b/intranet/templates/oauth2_provider/authorize.html
@@ -8,7 +8,7 @@
         .block-center {
             text-align: center;
         }
-        
+
         h3.block-center-heading {
             height: auto;
         }

--- a/intranet/templates/parking/form.html
+++ b/intranet/templates/parking/form.html
@@ -33,7 +33,7 @@ b, .parking table th {
     {% if request.user.is_parking_admin %}
         <p>You are a parking admin. <a href="/djangoadmin/parking/">View the admin interface</a></p>
     {% endif %}
-    
+
     <h2>
         Parking Applications
     </h2>

--- a/intranet/templates/polls/poll.html
+++ b/intranet/templates/polls/poll.html
@@ -11,7 +11,7 @@
             <a href="{% url 'poll' poll.id %}" class="poll-link">
                 {{ poll.title }}
             </a>
-        {% else %}    
+        {% else %}
             {{ poll.title }}
         {% endif %}
         {% if not poll.visible %} (HIDDEN){% endif %}

--- a/intranet/templates/schedule/admin_home.html
+++ b/intranet/templates/schedule/admin_home.html
@@ -10,7 +10,7 @@
     {{ block.super }}
     <script src="{% static 'vendor/selectize.js-0.12.4/dist/js/standalone/selectize.min.js' %}"></script>
     <script src="{% static 'vendor/datetimepicker-2.4.5/jquery.datetimepicker.js' %}"></script>
-    
+
     <script>
 function modify_daytype_form() {
     var v = $("select#modify_daytypes").val();
@@ -277,7 +277,7 @@ $(function() {
             <th class="weekend">Saturday</th>
             <th class="weekend">Sunday</th>
         </tr>
-        {% for week in sch %}        
+        {% for week in sch %}
         <tr>
             {% for day in week %}
             <td{% if forloop.counter == 6 or forloop.counter == 7 %} class="weekend"{% endif %}>
@@ -305,7 +305,7 @@ $(function() {
                     <b>No schedule assigned.</b>
                 {% endif %}
                 <span class="buttons"{% if not day.schedule %} style="visibility: visible"{% endif %}>
-                    
+
                     <a class="button change-daytype-button" title="Change Day Type" href="{% url 'schedule_add' %}?date={{ day.formatted_date }}" data-endpoint="{% url 'schedule_add' %}" data-date="{{ day.formatted_date }}">
                         <i class='edit fas fa-exchange-alt'></i>
                     </a>

--- a/intranet/templates/schedule/embed.html
+++ b/intranet/templates/schedule/embed.html
@@ -15,7 +15,7 @@
     .center-wrapper {
         min-height: auto;
     }
-    
+
     .center-wrapper .center {
         margin: 0;
         top: 0;

--- a/intranet/templates/schedule/month.html
+++ b/intranet/templates/schedule/month.html
@@ -30,7 +30,7 @@
     </td>
     {% endfor %}
     </tr>
-    
+
 </table>
 </div>
 {% endfor %}

--- a/intranet/templates/schedule/week.html
+++ b/intranet/templates/schedule/week.html
@@ -29,6 +29,6 @@
     {% endfor %}
     <td{% if not hide_arrows %} class="chevron"><a href="?date={{ week_data.next_week }}" class="chevron schedule-right" title="Next Week"><i class="fas fa-chevron-right"></i></a>{% else %}>{% endif %}</td>
     </tr>
-    
+
 </table>
 </div>

--- a/intranet/templates/users/class.html
+++ b/intranet/templates/users/class.html
@@ -35,7 +35,7 @@
                 Period <a href="{% url 'period_courses' class.period %}">{{ class.period }}</a>
             </h3>
             <h3>
-                Teacher: 
+                Teacher:
                 {% if class.teacher %}
                     <a href="{% url 'user_profile' class.teacher.id %}">{{ class.teacher.full_name }}</a>
                 {% else %}

--- a/scripts/static_templates_format.sh
+++ b/scripts/static_templates_format.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+cd "$(dirname -- "$(dirname -- "$(readlink -f -- "$0")")")"
+
+# Remove trailing whitespace for all JS/CSS/SCSS/txt/JSON/SVG static files
+find intranet/static -name vendor -prune -o -type f '(' -name '*.js' -o -name '*.css' -o -name '*.scss' -o -name '*.txt' -o -name '*.json' -o -name '*.svg' ')' -exec sed -i 's/\s\+$//' '{}' ';'
+# Remove trailing whitespace for all templates
+find intranet/templates -type f -exec sed -i 's/\s\+$//' '{}' ';'


### PR DESCRIPTION
## Proposed changes
- Add script to format static/template files (currently just removes trailing whitespace)
- Remove trailing whitespace from static/template files
- Add static/template file format script to build

## Brief description of rationale
We enforce strict formatting for code, but not for static files and templates. We should begin moving in that direction.