### PR TITLE
Fix Pylint unused argument warnings

### DIFF
--- a/intranet/apps/api/views.py
+++ b/intranet/apps/api/views.py
@@ -13,7 +13,7 @@ def perma_reverse(request, view, *args, **kwargs):
 
 @api_view(("GET",))
 @permission_classes((AllowAny,))
-def api_root(request, format=None):  # pylint: disable=redefined-builtin; It doesn't appear we can change this keyword argument name
+def api_root(request, format=None):  # pylint: disable=redefined-builtin,unused-argument; It doesn't appear we can change this keyword argument name
     r"""Welcome to the Ion API!
 
     Documentation is below. <pk> refers to the unique id of a certain object - this is shown as "id" in most lists and references.

--- a/intranet/apps/auth/signals.py
+++ b/intranet/apps/auth/signals.py
@@ -5,7 +5,7 @@ from django.contrib.auth.signals import user_logged_in, user_logged_out
 from ..sessionmgmt.models import TrustedSession
 
 
-def user_login(sender, request, **kwargs):
+def user_login(sender, request, **kwargs):  # pylint: disable=unused-argument
     if request is not None:
         request.session["login_time"] = time.time()
 
@@ -14,7 +14,7 @@ def user_login(sender, request, **kwargs):
         TrustedSession.delete_expired_sessions(user=request.user)
 
 
-def user_logout(sender, request, **kwargs):
+def user_logout(sender, request, **kwargs):  # pylint: disable=unused-argument
     # Delete the associated TrustedSession if it exists
     TrustedSession.objects.filter(session_key=request.session.session_key).delete()
 

--- a/intranet/apps/files/views.py
+++ b/intranet/apps/files/views.py
@@ -500,7 +500,7 @@ def files_upload(request, fstype=None):
                 messages.error(request, "Access to the path you provided is restricted.")
                 return redirect("/files/{}?dir={}".format(fstype, default_dir))
 
-            handle_file_upload(request.FILES["file"], fstype, fsdir, sftp, request)
+            handle_file_upload(request.FILES["file"], fsdir, sftp, request)
             return redirect("/files/{}?dir={}".format(fstype, fsdir))
     else:
         form = UploadFileForm()
@@ -508,7 +508,7 @@ def files_upload(request, fstype=None):
     return render(request, "files/upload.html", context)
 
 
-def handle_file_upload(file, fstype, fsdir, sftp, request=None):
+def handle_file_upload(file, fsdir, sftp, request=None):
     try:
         sftp.chdir(fsdir)
     except exceptions as e:

--- a/intranet/apps/signage/pages.py
+++ b/intranet/apps/signage/pages.py
@@ -11,11 +11,11 @@ def hello_world(page, sign, request):
     return {"message": "{} from {} says Hello".format(page.name, sign.name)}
 
 
-def announcements(page, sign, request):
+def announcements(page, sign, request):  # pylint: disable=unused-argument
     return {"public_announcements": Announcement.objects.filter(groups__isnull=True, expiration_date__gt=timezone.now())}
 
 
-def bus(page, sign, request):
+def bus(page, sign, request):  # pylint: disable=unused-argument
     now = timezone.localtime()
     day = Day.objects.today()
     if day is not None and day.end_time is not None:

--- a/intranet/middleware/traceback.py
+++ b/intranet/middleware/traceback.py
@@ -15,7 +15,7 @@ class UserTracebackMiddleware:
     def __call__(self, request):
         return self.get_response(request)
 
-    def process_exception(self, request, exception):
+    def process_exception(self, request, exception):  # pylint: disable=unused-argument
         if request.user.is_authenticated:
             request.META["AUTH_USER"] = "{}".format(request.user.username)
         else:


### PR DESCRIPTION
## Proposed changes
- Fix new Pylint unused argument warnings

## Brief description of rationale
Fixes the build.

Most of these cases need to match standard interfaces of some kind, so we have to just ignore the warnings.