### PR TITLE
Encourage students to sign up for eighth periods earlier

### DIFF
--- a/intranet/apps/eighth/views/signup.py
+++ b/intranet/apps/eighth/views/signup.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import time
 
@@ -9,6 +10,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.shortcuts import get_object_or_404, redirect, render
+from django.utils import timezone
 from django.views.decorators.http import require_POST
 
 from ....utils.helpers import is_entirely_digit
@@ -130,6 +132,8 @@ def eighth_signup_view(request, block_id=None):
         waitlists = EighthWaitlist.objects.filter(user=user).select_related("scheduled_activity__block", "scheduled_activity__activity")
         block_waitlist_map = {w.scheduled_activity.block.id: w.scheduled_activity for w in waitlists}
 
+        today = timezone.localdate()
+
         for b in surrounding_blocks:
             info = {
                 "id": b.id,
@@ -139,6 +143,7 @@ def eighth_signup_view(request, block_id=None):
                 "current_signup": getattr(block_signup_map.get(b.id, {}), "activity", None),
                 "current_signup_cancelled": getattr(block_signup_map.get(b.id, {}), "cancelled", False),
                 "current_waitlist": getattr(block_waitlist_map.get(b.id, {}), "activity", None),
+                "within_few_days": b.date >= today and b.date <= today + datetime.timedelta(days=2),
                 "locked": b.locked,
             }
 

--- a/intranet/static/js/eighth/signup.js
+++ b/intranet/static/js/eighth/signup.js
@@ -225,6 +225,25 @@ $(function() {
                 var activity = activityModels.get(aid);
 
                 if (response.indexOf("added to waitlist") === -1) {
+                    // If:
+                    // - The signup succeeded
+                    // - The user is signing themselves up
+                    // - They have less then 40 minutes until signups close
+                    // - They are not going to be redirected when they finish signing up
+                    // - They are not already signed up for an activity ('.block.active-block .selected-activity .no-activity-selected' exists)
+                    // Then ask them to sign up sooner.
+                    if(response.toLowerCase().indexOf("successfully signed up") != -1
+                       && window.isSelfSignup
+                       && window.signupTime && window.signupTime - new Date() < 40 * 60 * 1000
+                       && !window.next_url
+                       && $(".block.active-block .selected-activity .no-activity-selected").length) {
+                        Messenger().info({
+                            message: 'In the future, please sign up for eighth period activities sooner.',
+                            hideAfter: 5,
+                            showCloseButton: false
+                        });
+                    }
+
                     if (!activity.attributes.both_blocks) {
                         $(".current-day .both-blocks .selected-activity").html("<span class='no-activity-selected'>\nNo activity selected</span>").attr("title", "");
                         $(".current-day .both-blocks").removeClass("both-blocks");

--- a/intranet/static/js/eighth/signup.js
+++ b/intranet/static/js/eighth/signup.js
@@ -282,6 +282,21 @@ $(function() {
 
                     $(".active-block.cancelled").removeClass("cancelled");
 
+                    if (!activity.attributes.both_blocks) {
+                        $(".current-day .blocks a[data-bid='" + bid + "'] .fa-exclamation-circle").css("display", "none");
+                        $(".current-day .blocks a[data-bid!='" + bid + "'] .fa-exclamation-circle").each(function() {
+                            if($(this).closest(".block").find(".selected-activity .no-activity-selected").length) {
+                                $(this).css("display", "");
+                            }
+                            else {
+                                $(this).css("display", "none");
+                            }
+                        });
+                    } else {
+                        $(".current-day .block-letter .fa-exclamation-circle").css("display", "none");
+                    }
+
+
                     var selectedActivity = activityModels.filter(function(a) {
                         return a.attributes.selected === true
                     });

--- a/intranet/templates/eighth/multi_signup.html
+++ b/intranet/templates/eighth/multi_signup.html
@@ -58,6 +58,8 @@
         window.isEighthAdmin = {% if request.user.is_eighth_admin %}true{% else %}false{% endif %};
         window.waitlistEnabled = {% if waitlist_enabled %}true{% else %}false{% endif %};
         window.blockIsToday = {% if active_block.is_today %}true{% else %}false{% endif %};
+        window.signupTime = new Date({{ active_block.date|date:'Y,m-1,j' }},{{ active_block.signup_time|time:'G,i' }});
+        window.isSelfSignup = {% if request.user == user %}true{% else %}false{% endif %};
         var pn = location.pathname.substring(7);
         window.isDefaultPage = (pn == "" || pn == "/" || pn == "/signup" || pn == "/signup/");
     </script>

--- a/intranet/templates/eighth/profile_signup.html
+++ b/intranet/templates/eighth/profile_signup.html
@@ -58,6 +58,8 @@
         window.isEighthAdmin = {% if request.user.is_eighth_admin %}true{% else %}false{% endif %};
         window.waitlistEnabled = {% if waitlist_enabled %}true{% else %}false{% endif %};
         window.blockIsToday = {% if active_block.is_today %}true{% else %}false{% endif %};
+        window.signupTime = new Date({{ active_block.date|date:'Y,m-1,j' }},{{ active_block.signup_time|time:'G,i' }});
+        window.isSelfSignup = {% if request.user == user %}true{% else %}false{% endif %};
         var pn = location.pathname.substring(7);
         window.isDefaultPage = (pn == "" || pn == "/" || pn == "/signup" || pn == "/signup/");
     </script>

--- a/intranet/templates/eighth/signup.html
+++ b/intranet/templates/eighth/signup.html
@@ -3,6 +3,7 @@
 {% load math %}
 {% load strings %}
 {% load pipeline %}
+{% load tz %}
 
 
 {% comment %}
@@ -380,8 +381,9 @@
                                     {% for b in day.blocks %}
                                         <a href="{% url 'eighth_signup' b.id %}{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" data-bid="{{ b.id }}">
                                             <div class="block{% if active_block.id == b.id %} active-block{% endif %}{% if b.current_signup_cancelled %} cancelled{% endif %}{% if b.current_signup.both_blocks %} both-blocks{% endif %}" title="{{ b.title }}">
-                                                <span class="block-letter{% if b.current_waitlist %} waitlist{% endif %}"{% if b.block_letter_width %} style="width: {{ b.block_letter_width }}px"{% endif %}>
+                                                <span class="block-letter{% if b.current_waitlist %} waitlist{% endif %}" style="{% if b.block_letter_width %}width: {{ b.block_letter_width }}px; {% endif %} position: relative;">
                                                     {{ b.block_letter }}
+                                                    <i class="fas fa-exclamation-circle" style="color: #C22; position: absolute; right: -7px; top: -7px;{% if b.current_signup or not b.within_few_days %} display: none;{% endif %}"></i>
                                                 </span>
                                                 {% if b.locked %}
                                                     <i class="fas fa-lock" title="The block is locked."></i>

--- a/intranet/templates/eighth/signup.html
+++ b/intranet/templates/eighth/signup.html
@@ -67,6 +67,8 @@
         window.isEighthAdmin = {% if request.user.is_eighth_admin %}true{% else %}false{% endif %};
         window.waitlistEnabled = {% if waitlist_enabled %}true{% else %}false{% endif %};
         window.blockIsToday = {% if active_block.is_today %}true{% else %}false{% endif %};
+        window.signupTime = new Date({{ active_block.date|date:'Y,m-1,j' }},{{ active_block.signup_time|time:'G,i' }});
+        window.isSelfSignup = {% if request.user == user %}true{% else %}false{% endif %};
         window.currentWaitlist = false;
         var pn = location.pathname.substring(7);
         window.isDefaultPage = (pn == "" || pn == "/" || pn == "/signup" || pn == "/signup/");

--- a/intranet/templates/nav.html
+++ b/intranet/templates/nav.html
@@ -13,7 +13,7 @@
                 <a href="{% url 'eighth_signup' %}">
                     <div class="nav-alert-container">
                         <i class="nav-icon eighth-icon"></i>
-                        {% if not request.user.signed_up_today %}
+                        {% if not request.user.signed_up_next_few_days %}
                         <i class="fas fa-exclamation-circle nav-alert" style="right: 18px"></i>
                         {% endif %}
                     </div>
@@ -31,7 +31,7 @@
                 <a href="{% if request.user.is_eighth_admin %}{% url 'eighth_admin_dashboard' %}{% else %}{% url 'eighth_redirect' %}{% endif %}">
                     <div class="nav-alert-container">
                         <i class="nav-icon eighth-icon"></i>
-                        {% if not request.user.signed_up_today %}
+                        {% if not request.user.signed_up_next_few_days %}
                         <i class="fas fa-exclamation-circle nav-alert"></i>
                         {% endif %}
                     </div>


### PR DESCRIPTION
## Proposed changes
- Display exclamation mark icon on nav if there are any blocks within the next 3 days the user is not signed up for
- Show message about signing up earlier if a user signs up within 40 minutes of the signup deadline
- Show exclamation mark next to any blocks within the next 3 days the user is not signed up for

Closes #818

I have tested this locally, but given that it touches important parts of the signup code, additional testing should be performed.

## Brief description of rationale
See #818