### PR TITLE
Remove duplicated JS includes in schedule calendar page

### DIFF
--- a/intranet/templates/schedule/calendar.html
+++ b/intranet/templates/schedule/calendar.html
@@ -9,9 +9,6 @@
     {{ block.super }}
     <script src="{% static 'vendor/selectize.js-0.12.4/dist/js/standalone/selectize.min.js' %}"></script>
     <script src="{% static 'vendor/datetimepicker-2.4.5/jquery.datetimepicker.js' %}"></script>
-    <script src="{% static 'js/vendor/jquery-1.10.2.min.js' %}"></script>
-    <script src="{% static 'js/vendor/jquery.cookie.js' %}"></script>
-    <script src="{% static 'js/common.js' %}"></script>
     <script src="{% static 'js/schedule.js' %}"></script>
     <script src="{% static 'js/login.js' %}"></script>
     <script>


### PR DESCRIPTION
## Proposed changes
- Remove duplicated JS includes in schedule calendar page

## Brief description of rationale
This fixes a bug where the dropdown in the nav does not work on the
calendar page. Essentially, we use a custom animation "easing" function
that's defined in jQuery UI, but the re-include of jQuery (core)
replaces the easing function list, removing that function.

Also, in general we shouldn't be including the same JS file twice.