### PR TITLE
Require asgiref>=3.2.3

### DIFF
--- a/Ion.egg-info/requires.txt
+++ b/Ion.egg-info/requires.txt
@@ -52,6 +52,7 @@ setuptools-git==1.2
 Sphinx==2.2.1
 sphinx-bootstrap-theme==0.7.1
 pillow>=6.2.0
+asgiref>=3.2.3
 
 [:python_version < "3.7"]
 aiocontextvars==0.2.2

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -55,5 +55,6 @@ sphinx-bootstrap-theme==0.7.1
 # Not direct dependencies, but need to be bumped for some reason
 # (for example, bug or security fixes)
 pillow>=6.2.0
+asgiref>=3.2.3
 # Needed for sentry-sdk 0.12.0
 aiocontextvars==0.2.2; python_version < "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,5 +55,6 @@ sphinx-bootstrap-theme==0.7.1
 # Not direct dependencies, but need to be bumped for some reason
 # (for example, bug or security fixes)
 pillow>=6.2.0
+asgiref>=3.2.3
 # Needed for sentry-sdk 0.12.0
 aiocontextvars==0.2.2; python_version < "3.7"


### PR DESCRIPTION
## Proposed changes
- Require asgiref>=3.2.3

## Brief description of rationale
In production, we are experiencing [errors](https://sentry.tjhsst.edu/tjcsl/ion/issues/1984) (internal) that appear to be originating from `asgiref` following the `channels` upgrade over the weekend. Production has `asgiref` version `3.2.0` installed; upgrading to the latest micro release may fix this.