### PR TITLE
Improve login theme system

### DIFF
--- a/intranet/apps/auth/helpers.py
+++ b/intranet/apps/auth/helpers.py
@@ -1,9 +1,11 @@
 import logging
 import re
+from typing import Dict
 
 import pexpect
 
 from django.conf import settings
+from django.utils import timezone
 
 logger = logging.getLogger(__name__)
 
@@ -45,3 +47,34 @@ def change_password(form_data):
     if exitstatus == 0:
         return {"unable_to_set": False}
     return {"unable_to_set": True}
+
+
+def get_login_theme_name() -> str:
+    """Get the name of the currently active login theme (e.g. "snow" or "piday").
+
+    Returns:
+        The name of the currently active login theme.
+
+    """
+    today = timezone.localdate()
+    if today.month == 12 or today.month == 1:
+        # Snow
+        return "snow"
+    elif today.month == 3 and (14 <= today.day <= 16):
+        return "piday"
+    elif (today.month == 10 and 30 <= today.day <= 31) or (today.month == 11 and today.day == 1):
+        return "halloween"
+
+    return None
+
+
+LOGIN_THEMES = {
+    "snow": {"js": "themes/snow/snow.js", "css": "themes/snow/snow.css"},
+    "piday": {"js": "themes/piday/piday.js", "css": "themes/piday/piday.css"},
+    "halloween": {"js": "themes/halloween/halloween.js", "css": "themes/halloween/halloween.css"},
+}
+
+
+def get_login_theme() -> Dict[str, Dict[str, str]]:
+    """Load a custom login theme (e.g. snow)"""
+    return LOGIN_THEMES.get(get_login_theme_name(), {})

--- a/intranet/apps/auth/views.py
+++ b/intranet/apps/auth/views.py
@@ -19,7 +19,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic.base import View
 
-from ...utils.helpers import dark_mode_enabled, get_ap_week_warning, halloween_mode_enabled
+from ...utils.helpers import dark_mode_enabled, get_ap_week_warning
 from ..dashboard.views import dashboard_view, get_fcps_emerg
 from ..eighth.models import EighthBlock
 from ..events.models import Event
@@ -27,7 +27,7 @@ from ..schedule.views import schedule_context
 from . import backends  # pylint: disable=unused-import # noqa # Load it so the Prometheus metrics get added
 from . import signals  # pylint: disable=unused-import # noqa # Load it so the signals get registered
 from .forms import AuthenticateForm
-from .helpers import change_password
+from .helpers import change_password, get_login_theme
 
 logger = logging.getLogger(__name__)
 auth_logger = logging.getLogger("intranet_auth")
@@ -77,22 +77,6 @@ def get_bg_pattern(request):
     file_path = "img/patterns/dark/" if dark_mode_enabled(request) else "img/patterns/"
 
     return static(file_path + random.choice(files))
-
-
-def get_login_theme():
-    """Load a custom login theme (e.g. snow)"""
-    today = timezone.localdate()
-    if today.month == 12 or today.month == 1:
-        # Snow
-        return {"js": "themes/snow/snow.js", "css": "themes/snow/snow.css"}
-
-    if today.month == 3 and (14 <= today.day <= 16):
-        return {"js": "themes/piday/piday.js", "css": "themes/piday/piday.css"}
-
-    elif halloween_mode_enabled():
-        return {"js": "themes/halloween/halloween.js", "css": "themes/halloween/halloween.css"}
-
-    return {}
 
 
 def get_week_sports_school_events() -> Tuple[Container[Event], Container[Event]]:

--- a/intranet/utils/helpers.py
+++ b/intranet/utils/helpers.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.template.loader import get_template
 from django.utils import timezone
 
+from ..apps.auth.helpers import get_login_theme_name
 from ..apps.emerg.views import get_emerg
 
 logger = logging.getLogger("intranet.settings")
@@ -183,19 +184,14 @@ def dark_mode_enabled(request):
     if request.GET.get("dark", None):
         return request.GET["dark"] in ["1", "True"]
 
-    if (
-        request.resolver_match is not None
-        and (request.resolver_match.url_name == "login" or (request.resolver_match.url_name == "index" and not request.user.is_authenticated))
-        and halloween_mode_enabled()
+    if request.resolver_match is not None and (
+        request.resolver_match.url_name == "login" or (request.resolver_match.url_name == "index" and not request.user.is_authenticated)
     ):
-        return True
+        theme_name = get_login_theme_name()
+        if theme_name == "halloween":
+            return True
 
     if request.user.is_authenticated:
         return request.user.dark_mode_properties.dark_mode_enabled
     else:
         return request.COOKIES.get("dark-mode-enabled", "") == "1"
-
-
-def halloween_mode_enabled():
-    today = timezone.localdate()
-    return (today.month == 10 and 30 <= today.day <= 31) or (today.month == 11 and today.day == 1)


### PR DESCRIPTION
## Proposed changes
- Improve login theme system

## Brief description of rationale
It is not easy to tell which login theme is active if changes need to be made other than including the CSS/JS files (such as with halloween mode, which needs dark mode to be enabled). This fixes that issue.