### PR TITLE
Use Page.order to sort signage pages

### DIFF
--- a/intranet/apps/signage/models.py
+++ b/intranet/apps/signage/models.py
@@ -1,6 +1,20 @@
 from django.db import models
 
 
+class PageQuerySet(models.query.QuerySet):
+    def order_properly(self) -> "models.query.QuerySet[Page]":
+        """Returns a QuerySet containing all the pages in this QuerySet, but sorted in ascending
+        order by their ``order`` field (falling back on ``id`` when the ``order``
+        fields for two pages are the same).
+
+        Returns:
+            A QuerySet containing all the pages in this QuerySet sorted by their ``order`` and
+            ``id`` fields in ascending order.
+
+        """
+        return self.order_by("order", "id")
+
+
 class Page(models.Model):
     """
         iframe: True if page is just an iframe
@@ -16,6 +30,8 @@ class Page(models.Model):
 
         signs: set of signs which display this Page
     """
+
+    objects = PageQuerySet.as_manager()
 
     name = models.CharField(max_length=50)
 

--- a/intranet/templates/signage/base.html
+++ b/intranet/templates/signage/base.html
@@ -50,7 +50,7 @@
                     </div>
                 </div>
             </section>
-            {% for page in sign.pages.all %}
+            {% for page in sign.pages.order_properly %}
             <section class="signage-section signage-page page{% if page.iframe %} iframe{% else %} server{% endif %} {{ page.strip_links | yesno:"strip-links," }}" id="{{ page.pk }}">
                 {% if page.iframe %}
                 <iframe class="signage-iframe" src="{{ page.url }}" {% if page.sandbox %}sandbox{% endif %}>
@@ -65,7 +65,7 @@
         </div>
         <nav class="signage-nav show-back">
                 <a href="#page-home" data-page="home" class="signage-home-button"><i class="fas fa-2x fa-home"></i></a>
-            {% for page in sign.pages.all %}
+            {% for page in sign.pages.order_properly %}
                 {% if page.button %}
                 {# TODO: less hacky way of detecting button type #}
                 {% if "<" in page.button %}


### PR DESCRIPTION
## Proposed changes
- Use Page.order to sort signage pages

## Brief description of rationale
While attempting to deploy the eighth period signage page (added in 4f4c31599a549840666dc3798d4cc0adedfd46be) in production, I tried to set the `order` on the eighth page such that it would be placed above certain other pages. However, Ion did not recognize this option, preventing me from placing it correctly.