### PR TITLE
Fix size of feature announcements on dashboard

### DIFF
--- a/intranet/static/css/dashboard.scss
+++ b/intranet/static/css/dashboard.scss
@@ -285,3 +285,12 @@ div[data-placeholder]:not(:focus):not([data-div-placeholder-content]):before {
         opacity: 1;
     }
 }
+
+.main div.primary-content {
+    @media (min-width: 801px) {
+        padding-right: 316px;
+    }
+    @media (min-width: 961px) {
+        padding-right: 432px;
+    }
+}


### PR DESCRIPTION
## Proposed changes
- Fix size of feature announcements on dashboard

## Brief description of rationale
Deploying #903 revealed a bug in the dashboard CSS: On wider screens, the feature announcement text is not restricted in width and stretches past the start of the widgets on the right. This fixes that bug.