### PR TITLE
Fix strange behavior of partially hidden announcements

### DIFF
--- a/intranet/static/js/dashboard/announcements.js
+++ b/intranet/static/js/dashboard/announcements.js
@@ -25,6 +25,9 @@ $(document).ready(function() {
                     announcementToggle.call($(this).closest(".announcement"));
                 });
             }
+            else {
+                content.off("click");
+            }
         });
     }
     updatePartiallyHidden();
@@ -38,6 +41,8 @@ $(document).ready(function() {
 
         if(announcement.hasClass("partially-hidden")) {
             announcement.addClass("toggled");
+
+            announcement.find(".announcement-content").off("click");
 
             announcementContent.animate(
                 {"max-height": announcement.find(".announcement-content").height()},


### PR DESCRIPTION
## Proposed changes
- Fix strange behavior of partially hidden announcements

## Brief description of rationale
If a "partially hidden" announcement is clicked to expand it and then clicked again (the body, not the title), it collapses and non-printable characters are added to the title. This behavior is unexpected, and this PR fixes it.