### PR TITLE
Eighth fixes/tweaks

### DIFF
--- a/intranet/apps/eighth/models.py
+++ b/intranet/apps/eighth/models.py
@@ -1682,10 +1682,10 @@ class EighthSignupManager(Manager):
         if EighthSignup.objects.filter(user=user, scheduled_activity__block=scheduled_activity.block).exists():
             logger.error(
                 "Duplicate signup before creating signup for user %d in activity %d, block %d, scheduled activity %d",
-                self.user.id,
-                self.scheduled_activity.activity.id,
-                self.scheduled_activity.block.id,
-                self.scheduled_activity.id,
+                user.id,
+                scheduled_activity.activity.id,
+                scheduled_activity.block.id,
+                scheduled_activity.id,
             )
             raise ValidationError("EighthSignup already exists for this user on this block.")
 
@@ -1694,11 +1694,11 @@ class EighthSignupManager(Manager):
         if EighthSignup.objects.exclude(pk=signup.pk).filter(user=user, scheduled_activity__block=scheduled_activity.block).nocache().exists():
             logger.error(
                 "Duplicate signup after creating signup %d to sign up user %d in activity %d, block %d, scheduled activity %d; deleting",
-                self.id,
-                self.user.id,
-                self.scheduled_activity.activity.id,
-                self.scheduled_activity.block.id,
-                self.scheduled_activity.id,
+                signup.id,
+                user.id,
+                scheduled_activity.activity.id,
+                scheduled_activity.block.id,
+                scheduled_activity.id,
             )
             signup.delete()
             raise ValidationError("EighthSignup already exists for this user on this block.")

--- a/intranet/apps/eighth/models.py
+++ b/intranet/apps/eighth/models.py
@@ -1366,7 +1366,7 @@ class EighthScheduledActivity(AbstractBaseEighthModel):
         if not waitlist:
             if not self.is_both_blocks():
                 try:
-                    existing_signup = EighthSignup.objects.get(user=user, scheduled_activity__block=self.block)
+                    existing_signup = EighthSignup.objects.nocache().get(user=user, scheduled_activity__block=self.block)
                 except EighthSignup.DoesNotExist:
                     add_breadcrumb(
                         category="eighth-signup",
@@ -1391,7 +1391,7 @@ class EighthScheduledActivity(AbstractBaseEighthModel):
 
                     logger.debug("Successfully signed user %d up for single-block activity %d in block %d", user.id, self.activity.id, self.block.id)
 
-                    if signup.has_conflict():
+                    if signup.has_conflict(nocache=True):
                         try:
                             signup.save()
                         except ValidationError as e:
@@ -1679,7 +1679,7 @@ class EighthSignupManager(Manager):
             scheduled_activity: The EighthScheduledActivity to sign the user up for.
 
         """
-        if EighthSignup.objects.filter(user=user, scheduled_activity__block=scheduled_activity.block).exists():
+        if EighthSignup.objects.filter(user=user, scheduled_activity__block=scheduled_activity.block).nocache().exists():
             logger.error(
                 "Duplicate signup before creating signup for user %d in activity %d, block %d, scheduled activity %d",
                 user.id,


### PR DESCRIPTION
## Proposed changes
- Fix log messages in `EighthSignup.objects.create_signup()` duplicate checks
- Ignore cache more aggressively in `EighthScheduledActivity.add_user()`

## Brief description of rationale
The log message bug was revealed in production, and the cache changes in 199c85373bfb0f44e700e00a0c917d7b5b8a2e38 have failed to prevent duplicate signups.