### PR TITLE
Ignore cache in duplicate signup metric export

### DIFF
--- a/intranet/apps/eighth/views/monitoring.py
+++ b/intranet/apps/eighth/views/monitoring.py
@@ -36,6 +36,7 @@ def metrics_view(request):
         )
         .filter(unique_signups__lt=F("total_signups"))
         .values_list("id", F("total_signups") - F("unique_signups"))
+        .nocache()
     ):
         metrics['intranet_eighth_duplicate_signups{{block_id="{}"}}'.format(block_id)] = num_duplicates
 


### PR DESCRIPTION
## Proposed changes
- Ignore cache in duplicate signup metric export

## Brief description of rationale
It seems to have been displaying inaccurate results due to caching.