### PR TITLE
Restrict access to Django Prometheus metrics

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -690,6 +690,7 @@ intranet/middleware/__init__.py
 intranet/middleware/access_log.py
 intranet/middleware/ajax.py
 intranet/middleware/dark_mode.py
+intranet/middleware/monitoring.py
 intranet/middleware/profiler.py
 intranet/middleware/same_origin.py
 intranet/middleware/session_management.py

--- a/docs/sourcedoc/intranet.middleware.rst
+++ b/docs/sourcedoc/intranet.middleware.rst
@@ -28,6 +28,14 @@ intranet.middleware.dark\_mode module
    :undoc-members:
    :show-inheritance:
 
+intranet.middleware.monitoring module
+-------------------------------------
+
+.. automodule:: intranet.middleware.monitoring
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 intranet.middleware.profiler module
 -----------------------------------
 

--- a/intranet/middleware/monitoring.py
+++ b/intranet/middleware/monitoring.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from django.shortcuts import render
+
+
+class PrometheusAccessMiddleware:
+    """
+    Restricts access to Django Prometheus metrics to ALLOWED_METRIC_IPS and superusers.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # We would like to be able to just check request.resolver_match.app_name. Unfortunately, URL resolving has not taken place yet, so we can't.
+        if request.path == "/prometheus" or request.path.startswith("/prometheus/"):
+            remote_addr = request.META["HTTP_X_REAL_IP"] if "HTTP_X_REAL_IP" in request.META else request.META.get("REMOTE_ADDR", "")
+            is_superuser = request.user.is_authenticated and request.user.is_superuser
+
+            # If they're not from an IP on the white list and they're not a superuser, deny access
+            if remote_addr not in settings.ALLOWED_METRIC_SCRAPE_IPS and not is_superuser:
+                return render(request, "error/403.html", {"reason": "You are not authorized to view this page."}, status=403)
+
+        return self.get_response(request)

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -379,6 +379,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",  # Django X-Frame-Options
     "django.contrib.auth.middleware.AuthenticationMiddleware",  # Django auth
     "oauth2_provider.middleware.OAuth2TokenMiddleware",  # Django Oauth toolkit
+    "intranet.middleware.monitoring.PrometheusAccessMiddleware",  # Restricts access to Django Prometheus metrics to ALLOWED_METRIC_IPS and superusers
     "maintenance_mode.middleware.MaintenanceModeMiddleware",  # Maintenance mode
     "intranet.middleware.threadlocals.ThreadLocalsMiddleware",  # Thread locals
     "intranet.middleware.traceback.UserTracebackMiddleware",  # Include user in traceback


### PR DESCRIPTION
## Proposed changes
- Restrict access to Django Prometheus metrics

## Brief description of rationale
Non-superusers and hosts other than the `ALLOWED_METRIC_SCRAPE_IPS` do not need to see metrics.