### PR TITLE
Fix font issues in bus display on signage

### DIFF
--- a/intranet/static/js/bus.js
+++ b/intranet/static/js/bus.js
@@ -335,6 +335,9 @@ $(function() {
                         text.path(space.getAttribute('d'));
                         text.textPath().attr("path", space.getAttribute('d'));
                         text.style('pointer-events', 'none');
+                        // Signage displays may not have Helvetica or Arial installed, so we provide some sane
+                        // fallbacks to avoid issues that have appeared in the past with the "sans-serif" default.
+                        text.font("family", "Helvetica, Arial, 'Open Sans', 'Liberation Sans', sans-serif");
 
                         if(window.isSignage) {
                             var tspan = $(text.node).find("tspan");

--- a/intranet/templates/signage/pages/bus.html
+++ b/intranet/templates/signage/pages/bus.html
@@ -89,7 +89,7 @@
         font-size: 100%;
     }
     svg text.extra-small {
-        font-size: 80%;
+        font-size: 90%;
     }
     </style>
 {% endblock %}


### PR DESCRIPTION
## Proposed changes
- Fix font issues in bus display on signage

## Brief description of rationale
In production, the signage displays don't have Helvetica and Arial (the default fonts specified by SVG.js) installed. Instead, they fall back on the `sans-serif` default. Whatever this defaults to is a significantly different size from Helvetica and Arial, which results in behavior such as the route names overflowing the bus rectangles.

This change also allows adjusting the font size to something more legible.