### PR TITLE
Close incoming websocket connections that don't match a route

### DIFF
--- a/intranet/routing.py
+++ b/intranet/routing.py
@@ -2,12 +2,27 @@
 Defines routes for channels
 https://channels.readthedocs.io/en/latest/topics/routing.html
 """
+from typing import Optional
 
 from channels.auth import AuthMiddlewareStack
+from channels.generic.websocket import WebsocketConsumer
 from channels.routing import ProtocolTypeRouter, URLRouter
 
 from django.conf.urls import url
 
 from .apps.bus.consumers import BusConsumer
 
-application = ProtocolTypeRouter({"websocket": AuthMiddlewareStack(URLRouter([url(r"^bus/$", BusConsumer)]))})
+
+class WebsocketCloseConsumer(WebsocketConsumer):
+    def connect(self):
+        self.accept()
+        self.close()
+
+    def receive(self, text_data: Optional[str] = None, bytes_data: Optional[bytes] = None):
+        pass
+
+    def disconnect(self, code):
+        pass
+
+
+application = ProtocolTypeRouter({"websocket": AuthMiddlewareStack(URLRouter([url(r"^bus/$", BusConsumer), url(r"^.*$", WebsocketCloseConsumer)]))})


### PR DESCRIPTION
## Proposed changes
- Close incoming websocket connections that don't match a route

## Brief description of rationale
Should actually fix the `CancelledError`s mentioned in #891.