### PR TITLE
Force reload signage page at 1:30 AM

### DIFF
--- a/intranet/templates/signage/base.html
+++ b/intranet/templates/signage/base.html
@@ -27,6 +27,15 @@
             }
             window.lockPage = '{{ sign.lock_page.pk }}';
             window.defaultPage = '{{ sign.default_page.pk }}';
+
+            var now = new Date();
+            var reloadTime = new Date();
+            reloadTime.setHours(1, 30, 0);
+            if(reloadTime > now) {
+                setTimeout(function() {
+                    window.location.reload(true);
+                }, reloadTime - now);
+            }
         </script>
         <script src="{% static 'js/vendor/jquery-1.10.2.min.js' %}"></script>
         <script src="{% static 'js/signage.js' %}"></script>


### PR DESCRIPTION
## Proposed changes
- Force reload signage page at 1:30 AM

## Brief description of rationale
Signage pages sometimes experience difficulty connecting when they have just started up (they reboot at 1 AM), and sometimes static files are cached and changes do not propagate correctly. Reloading at 1:30 solves both these problems.