### PR TITLE
Remove links in announcements on signage server-side

### DIFF
--- a/intranet/apps/announcements/models.py
+++ b/intranet/apps/announcements/models.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 
 from ...utils.date import get_date_range_this_year, is_current_year
 from ...utils.deletion import set_historical_user
+from ...utils.html import nullify_links
 
 
 class AnnouncementManager(Manager):
@@ -170,6 +171,16 @@ class Announcement(models.Model):
     @property
     def dashboard_type(self):
         return "announcement"
+
+    @property
+    def content_no_links(self) -> str:
+        """Returns the content of this announcement with all links nullified.
+
+        Returns:
+            The content of this announcement with all links nullified.
+
+        """
+        return nullify_links(self.content)
 
     class Meta:
         ordering = ["-pinned", "-added"]

--- a/intranet/templates/signage/pages/announcements.html
+++ b/intranet/templates/signage/pages/announcements.html
@@ -57,7 +57,7 @@
                 {% endfor %}
             </div>
             <div class="announcement-content">
-                {{ announcement.content|safe }}
+                {{ announcement.content_no_links|safe }}
             </div>
         </div>
         {% endfor %}

--- a/intranet/utils/html.py
+++ b/intranet/utils/html.py
@@ -1,3 +1,5 @@
+from typing import Mapping, Optional, Tuple, Union
+
 import bleach
 
 ALLOWED_TAGS = ["a", "abbr", "acronym", "b", "br", "blockquote", "code", "em", "hr", "i", "li", "ol", "strong", "ul", "iframe", "img", "div", "p"]
@@ -27,3 +29,28 @@ ALLOWED_STYLES = [
 
 def safe_html(txt):
     return bleach.linkify(bleach.clean(txt, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES, styles=ALLOWED_STYLES))
+
+
+def link_removal_callback(  # pylint: disable=unused-argument
+    attrs: Mapping[Union[str, Tuple[Optional[str]]], str], new: bool = False
+) -> Optional[Mapping[Union[str, Tuple[Optional[str]]], str]]:
+    """Internal callback for ``nullify_links()``."""
+    for key in tuple(attrs.keys()):
+        if isinstance(key, tuple) and "href" in key:
+            attrs[key] = "#"
+
+    return attrs
+
+
+def nullify_links(text: str) -> str:
+    """Given a string containing HTML, changes the ``href`` attribute of any links to "#" to render
+    the link useless.
+
+    Args:
+        text: The HTML string in which links should be nullified.
+
+    Returns:
+        The HTML string with all links nullified.
+
+    """
+    return bleach.linkify(text, [link_removal_callback])


### PR DESCRIPTION
## Proposed changes
- Remove links in announcements on signage server-side

## Brief description of rationale
JS link stripping does not appear to be fully functional.