### PR TITLE
Change href to `javascript:void(0)` instead of `#` on signage

### DIFF
--- a/intranet/static/js/signage.js
+++ b/intranet/static/js/signage.js
@@ -42,7 +42,7 @@ var resetPage = function () {
 
     $('.signage-container').find('.strip-links iframe').each(function () {
         $(this).contents().find('a').each(function() {
-            this.href = "#";
+            this.href = "javascript:void(0)";
             $(this).click(function (e) {
                 e.preventDefault();
             });

--- a/intranet/utils/html.py
+++ b/intranet/utils/html.py
@@ -37,13 +37,13 @@ def link_removal_callback(  # pylint: disable=unused-argument
     """Internal callback for ``nullify_links()``."""
     for key in tuple(attrs.keys()):
         if isinstance(key, tuple) and "href" in key:
-            attrs[key] = "#"
+            attrs[key] = "javascript:void(0)"
 
     return attrs
 
 
 def nullify_links(text: str) -> str:
-    """Given a string containing HTML, changes the ``href`` attribute of any links to "#" to render
+    """Given a string containing HTML, changes the ``href`` attribute of any links to "javascript:void(0)" to render
     the link useless.
 
     Args:


### PR DESCRIPTION
## Proposed changes
- Change href to `javascript:void(0)` instead of `#` on signage

## Brief description of rationale
It appears that an href of `#` targets the current page, which causes some weird bugs in signage's iframes.