### PR TITLE
Fixes

### DIFF
--- a/intranet/apps/eighth/utils.py
+++ b/intranet/apps/eighth/utils.py
@@ -6,7 +6,7 @@ DATE_FORMAT = "%m-%d-%Y"
 
 
 def get_start_date(request):
-    if "start_date" in request.session:
+    if "start_date" in request.session and request.session.get("start_date_set_date") == timezone.localdate().strftime(DATE_FORMAT):
         date = request.session["start_date"]
         return datetime.strptime(date, DATE_FORMAT).date()
     else:
@@ -17,3 +17,4 @@ def get_start_date(request):
 
 def set_start_date(request, start_date):
     request.session["start_date"] = start_date.strftime(DATE_FORMAT)
+    request.session["start_date_set_date"] = timezone.localdate().strftime(DATE_FORMAT)

--- a/intranet/templates/signage/pages/eighth.html
+++ b/intranet/templates/signage/pages/eighth.html
@@ -113,6 +113,7 @@
             width: 100%;
             margin-top: 0;
             border-top: 1px solid #d8d8d8;
+            border-left: 0;
         }
         .eighth-signup.activity-detail-selected #activity-list > ul.all-activities {
             margin-bottom: 400px;


### PR DESCRIPTION
## Proposed changes
- Hide left border of activity detail div in vertical view on eighth signage page
- Make eighth admin start date expire daily

## Brief description of rationale
The border CSS fix is simply an annoyance. The start date change is only a problem because of the recent adoption of session management, which effectively means users have to manually adjust their start date.