### PR TITLE
Emergency app updates

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -336,6 +336,7 @@ intranet/apps/emailfwd/migrations/0001_initial.py
 intranet/apps/emailfwd/migrations/__init__.py
 intranet/apps/emerg/__init__.py
 intranet/apps/emerg/api.py
+intranet/apps/emerg/tasks.py
 intranet/apps/emerg/views.py
 intranet/apps/emerg/migrations/__init__.py
 intranet/apps/error/__init__.py

--- a/docs/sourcedoc/intranet.apps.emerg.rst
+++ b/docs/sourcedoc/intranet.apps.emerg.rst
@@ -12,6 +12,14 @@ intranet.apps.emerg.api module
    :undoc-members:
    :show-inheritance:
 
+intranet.apps.emerg.tasks module
+--------------------------------
+
+.. automodule:: intranet.apps.emerg.tasks
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 intranet.apps.emerg.views module
 --------------------------------
 

--- a/intranet/apps/emerg/tasks.py
+++ b/intranet/apps/emerg/tasks.py
@@ -1,0 +1,12 @@
+from celery import shared_task
+from celery.utils.log import get_task_logger
+
+from .views import update_emerg_cache
+
+logger = get_task_logger(__name__)
+
+
+@shared_task
+def update_emerg_cache_task() -> None:
+    logger.debug("Updating FCPS emergency info")
+    update_emerg_cache(custom_logger=logger)

--- a/intranet/apps/emerg/views.py
+++ b/intranet/apps/emerg/views.py
@@ -41,6 +41,7 @@ def check_emerg():
         "There are no major announcements at this time.",
         "There are no major emergency announcements at this time.",
         "There are no emergencies at this time.",
+        "Site under maintenance",  # We don't want to get people's attention like this just to tell them that fcps.edu is under maintenance
     ]
     for b in bad_strings:
         if b in res:

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -749,6 +749,10 @@ FCPS_EMERGENCY_PAGE = "https://www.fcps.edu/alert_msg_feed"  # type: str
 # The timeout for the request to FCPS' emergency page (in seconds)
 FCPS_EMERGENCY_TIMEOUT = 5
 
+# How frequently the emergency announcement cache should be updated by the Celerybeat task.
+# This should be less than CACHE_AGE["emerg"].
+FCPS_EMERGENCY_CACHE_UPDATE_INTERVAL = CACHE_AGE["emerg"] - 30
+
 # Show an iframe with tjStar activity data
 if TJSTAR_MAP is None:
     TJSTAR_MAP = False
@@ -763,6 +767,14 @@ CELERY_BROKER_URL = "amqp://localhost"
 
 CELERY_ACCEPT_CONTENT = ["json", "pickle"]
 CELERY_TASK_SERIALIZER = "pickle"
+
+CELERY_BEAT_SCHEDULE = {
+    "update-fcps-emergency-cache": {
+        "task": "intranet.apps.emerg.tasks.update_emerg_cache_task",
+        "schedule": FCPS_EMERGENCY_CACHE_UPDATE_INTERVAL,
+        "args": (),
+    },
+}
 
 MAINTENANCE_MODE = False
 


### PR DESCRIPTION
## Proposed changes
- Check for "under maintenance" message in emergency info
- Update FCPS emergency info in a Celery task (closes #926)

## Brief description of rationale
- We should not show messages to the user if FCPS's website goes into maintenance mode.
- As explained in #926, the current strategy of updating emergency announcements in the views is suboptimal.