### PR TITLE
fix(eighth): order eighth period blocks by block_letter

### DIFF
--- a/intranet/apps/eighth/views/attendance.py
+++ b/intranet/apps/eighth/views/attendance.py
@@ -373,7 +373,7 @@ def take_attendance_view(request, scheduled_activity_id):
 
         if request.user.is_eighth_admin:
             context["scheduled_activities"] = EighthScheduledActivity.objects.filter(block__id=scheduled_activity.block.id)
-            context["blocks"] = EighthBlock.objects.filter(date__gte=get_start_date(request)).order_by("date")
+            context["blocks"] = EighthBlock.objects.filter(date__gte=get_start_date(request)).order_by("date", "block_letter")
 
         if request.resolver_match.url_name == "eighth_admin_export_attendance_csv":
             response = http.HttpResponse(content_type="text/csv")


### PR DESCRIPTION
## Proposed changes
- order eighth period blocks by block_letter in addition to date in take attendance view
- 
- 

## Brief description of rationale
The blocks for admins on the take attendance page are not properly ordered.
