### PR TITLE
Setup selectize correctly on eighth admin pages

### DIFF
--- a/intranet/static/js/eighth/ui_init.js
+++ b/intranet/static/js/eighth/ui_init.js
@@ -38,6 +38,12 @@ $(function() {
         });
     });
 
+    $("select[multiple='']").not(".remote-source").each(function(i, el) {
+        $(el).selectize({
+            maxOptions: 99999
+        });
+    });
+
     var safeFieldRenderer = function(field) {
         return function(data, escape) {
             return "<div>" + data[field] + "</div>";


### PR DESCRIPTION
## Proposed changes
- Setup selectize correctly on eighth admin pages

## Brief description of rationale
Recently, selectize inputs have not been showing up on some eighth admin pages. There is a chance that this is an unintentional side effect of #933, but I'm not sure.