### PR TITLE
Don't partially hide announcements on announcement view page

### DIFF
--- a/intranet/static/js/dashboard/announcements.js
+++ b/intranet/static/js/dashboard/announcements.js
@@ -10,6 +10,10 @@ $(document).ready(function() {
     });
 
     function updatePartiallyHidden() {
+        if(window.disable_partially_hidden_announcements) {
+            return;
+        }
+
         $(".announcement:not(.toggled):not(.hidden).partially-hidden").each(function() {
             var content = $(this).find(".announcement-content");
             if(content.height() <= 200) {

--- a/intranet/templates/announcements/view.html
+++ b/intranet/templates/announcements/view.html
@@ -15,6 +15,7 @@
 
 {% block js %}
     {{ block.super }}
+    <script>var disable_partially_hidden_announcements = true;</script>
     <script src="{% static 'js/dashboard/announcements.js' %}"></script>
 {% endblock %}
 


### PR DESCRIPTION
## Proposed changes
- Don't partially hide announcements on announcement view page

## Brief description of rationale
If the user is only looking at one announcement, it should not be
collapsed.