### PR TITLE
Fixes

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -3523,6 +3523,7 @@ intranet/utils/helpers.py
 intranet/utils/html.py
 intranet/utils/locking.py
 intranet/utils/serialization.py
+intranet/utils/session.py
 migrations/__init__.py
 scripts/build_docs.sh
 scripts/build_ensure_no_changes.sh

--- a/Ion.egg-info/requires.txt
+++ b/Ion.egg-info/requires.txt
@@ -42,7 +42,6 @@ psycopg2==2.8.4
 pycryptodome==3.9.4
 pysftp==0.2.9
 python-dateutil==2.8.1
-python-gssapi==0.6.4
 python-magic==0.4.15
 reportlab==3.5.32
 requests==2.22.0

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -42,7 +42,6 @@ psycopg2==2.8.4
 pycryptodome==3.9.4
 pysftp==0.2.9
 python-dateutil==2.8.1
-python-gssapi==0.6.4
 python-magic==0.4.15
 reportlab==3.5.32
 requests==2.22.0

--- a/docs/sourcedoc/intranet.utils.rst
+++ b/docs/sourcedoc/intranet.utils.rst
@@ -68,6 +68,14 @@ intranet.utils.serialization module
    :undoc-members:
    :show-inheritance:
 
+intranet.utils.session module
+-----------------------------
+
+.. automodule:: intranet.utils.session
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 
 Module contents
 ---------------

--- a/intranet/apps/printing/forms.py
+++ b/intranet/apps/printing/forms.py
@@ -18,7 +18,7 @@ class PrintJobForm(forms.ModelForm):
         super(PrintJobForm, self).__init__(*args, **kwargs)
 
         if printers:
-            self.fields["printer"].choices = [("", "Select a printer...")] + [(i, i) for i in printers]
+            self.fields["printer"].choices = [("", "Select a printer...")] + list(printers.items())
 
     def validate_size(self):
         filesize = self.file.__sizeof__()

--- a/intranet/apps/printing/views.py
+++ b/intranet/apps/printing/views.py
@@ -54,13 +54,9 @@ def get_printers() -> List[str]:
         names = []
         for line in lines:
             if "requests since" in line:
-                names.append(line.split(" ", 1)[0])
-
-        if "Please_Select_a_Printer" in names:
-            names.remove("Please_Select_a_Printer")
-
-        if "" in names:
-            names.remove("")
+                name = line.split(" ", 1)[0]
+                if name and name != "Please_Select_a_Printer":
+                    names.append(name)
 
         cache.set(key, names, timeout=settings.CACHE_AGE["printers_list"])
         return names
@@ -309,7 +305,7 @@ def print_job(obj: PrintJob, do_print: bool = True):
             )
 
         if do_print:
-            args = ["lpr", "-P", "{}".format(printer), "{}".format(final_filename)]
+            args = ["lpr", "-P", printer, final_filename]
 
             if obj.page_range:
                 args.extend(["-o", "page-ranges={}".format(obj.page_range)])

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -446,7 +446,10 @@ CACHEOPS = {
 
 if not TESTING:
     # Settings for django-redis-sessions
-    SESSION_ENGINE = "redis_sessions.session"
+
+    # We use a custom "wrapper" session engine that inherits from django-redis-session's session engine.
+    # It allows customization of certain session-related behavior. See the comments in intranet/utils/session.py for more details.
+    SESSION_ENGINE = "intranet.utils.session"
 
     SESSION_REDIS_HOST = "127.0.0.1"
     SESSION_REDIS_PORT = 6379

--- a/intranet/utils/session.py
+++ b/intranet/utils/session.py
@@ -1,0 +1,29 @@
+from redis_sessions.session import SessionStore as BaseSessionStore
+
+
+class SessionStore(BaseSessionStore):  # pylint: disable=abstract-method
+    def load(self):
+        orig_session_key = self._session_key
+        data = super().load()
+
+        if self._session_key is None and orig_session_key is not None:
+            # If django-redis-sessions encounters ANY errors while loading
+            # the session, it ignores them and sets self._session_key to
+            # None. This makes Django's session middleware delete the
+            # "sessionid" cookie in the user's browser.
+            # The effect here is to clear the session of any user who visits
+            # while Redis is down, logging them out.
+            # So if django-redis-sessions set self._session_key to None, we
+            # take special action.
+
+            # First, we temporarily reset self._session_key.
+            self._session_key = orig_session_key
+            # Then we ping the server. If we encounter an error here, the
+            # the session ID won't get cleared in the user's browser during the
+            # response (because we just reset it above).
+            self.server.ping()
+            # If we got here, the server is reachable and it was probably some
+            # other error.
+            self._session_key = None
+
+        return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,6 @@ psycopg2==2.8.4
 pycryptodome==3.9.4
 pysftp==0.2.9
 python-dateutil==2.8.1
-python-gssapi==0.6.4
 python-magic==0.4.15
 reportlab==3.5.32
 requests==2.22.0


### PR DESCRIPTION
## Proposed changes
- Add `django-redis-sessions` wrapper to fix undesired behavior
- Remove unneeded `python-gssapi` dependency
- Improve temporary file handling in printing view
- Perform minor cleanup on printing code
- Display printer descriptions instead of printer names on print page
- Fix method of counting pages for text files

## Brief description of rationale
- Because of eccentricities in `django-redis-sessions` and Django's session middleware, if a user visits Ion while Redis is down, their session will be cleared and they will be logged out without warning. This wrapper should fix that behavior.
- `python-gssapi` is no longer needed.
- Temporary printing files:
  - Fix potential race condition caused by improper usage of `tempfile.NamedTemporaryFile`
  - Remove temporary files at the end (we still have the original upload; we just don't need redundant copies)
- The printing app honestly needs a complete rewrite, but some of this code just makes my eyes hurt too badly to wait that long.
- The raw printer names cannot contain spaces or other special characters, so they are not very user-friendly. The printer descriptions, however, can, so we should display those to the user instead.
- The current method of counting pages in text files is flawed.