### PR TITLE
Add more prominent indicators of cancelled activities 

### DIFF
--- a/intranet/static/css/base.scss
+++ b/intranet/static/css/base.scss
@@ -893,3 +893,13 @@ body.fire * {
 .table-cell {
     display: table-cell;
 }
+
+body {
+    strong {
+        font-weight: bold;
+    }
+
+    em {
+        font-style: italic;
+    }
+}

--- a/intranet/templates/eighth/signup.html
+++ b/intranet/templates/eighth/signup.html
@@ -384,7 +384,7 @@
                                                 <span class="block-letter{% if b.current_waitlist %} waitlist{% endif %}" style="{% if b.block_letter_width %}width: {{ b.block_letter_width }}px; {% endif %} position: relative;">
                                                     {{ b.block_letter }}
                                                     {% if b.within_few_days %}
-                                                        <i class="fas fa-exclamation-circle" style="color: #C22; position: absolute; right: -7px; top: -7px;{% if b.current_signup %} display: none;{% endif %}"></i>
+                                                        <i class="fas fa-exclamation-circle" style="color: #C22; position: absolute; right: -7px; top: -7px;{% if b.current_signup and not b.current_signup_cancelled %} display: none;{% endif %}"></i>
                                                     {% endif %}
                                                 </span>
                                                 {% if b.locked %}
@@ -392,7 +392,7 @@
                                                 {% endif %}
                                                 <span class="selected-activity" title="{% if b.current_signup %}{{ b.current_signup.name_with_flags_no_restricted }}{% endif %}">
                                                     {% if b.current_signup_cancelled %}
-                                                        <strong>Cancelled</strong> -
+                                                        <strong>CANCELLED</strong> -
                                                     {% endif %}
                                                     {% if b.current_signup %}
                                                         {{ b.current_signup.name_with_flags_no_restricted }}


### PR DESCRIPTION
## Proposed changes
- Add more prominent indicators of cancelled activities (closes #887)
- Ensure `<strong>` and `<em>` styles apply

## Brief description of rationale
- See #887
- Noticed while fixing #887; including in this PR since it is related (the "Cancelled" text is already supposed to be bold, but isn't because of this bug)