### PR TITLE
Performance improvements

### DIFF
--- a/intranet/apps/announcements/models.py
+++ b/intranet/apps/announcements/models.py
@@ -157,7 +157,7 @@ class Announcement(models.Model):
 
     def is_visible_requester(self, user):
         try:
-            return self.announcementrequest and (user in self.announcementrequest.teachers_requested.all())
+            return self.announcementrequest_set.filter(teachers_requested__id=user.id).exists()
         except get_user_model().DoesNotExist:
             return False
 

--- a/intranet/apps/announcements/models.py
+++ b/intranet/apps/announcements/models.py
@@ -144,20 +144,16 @@ class Announcement(models.Model):
     def is_visible(self, user):
         return self in Announcement.objects.visible_to_user(user)
 
-    _announcementrequest = None  # type: AnnouncementRequest
+    # False, not None. This can be None if no AnnouncementRequest exists for this Announcement,
+    # and we should not reevaluate in that case.
+    _announcementrequest = False  # type: AnnouncementRequest
 
     @property
     def announcementrequest(self):
-        if self._announcementrequest:
-            return self._announcementrequest
+        if self._announcementrequest is False:
+            self._announcementrequest = self.announcementrequest_set.first()
 
-        a = self.announcementrequest_set
-        if a.count() > 0:
-            ar = a.first()
-            self._announcementrequest = ar
-            return ar
-
-        return None
+        return self._announcementrequest
 
     def is_visible_requester(self, user):
         try:

--- a/intranet/apps/dashboard/views.py
+++ b/intranet/apps/dashboard/views.py
@@ -304,6 +304,10 @@ def get_announcements_list(request, context):
         else:
             announcements = Announcement.objects.visible_to_user(user).filter(expiration_date__gt=timezone.now())
 
+    # We may query the announcement request multiple times while checking if the user submitted or approved the announcement.
+    # prefetch_related() will still make a separate query for each request, but the results are cached if we check them multiple times
+    announcements = announcements.prefetch_related("announcementrequest_set")
+
     if context["events_admin"] and context["show_all"]:
         events = Event.objects.all()
     else:

--- a/intranet/apps/dashboard/views.py
+++ b/intranet/apps/dashboard/views.py
@@ -304,6 +304,10 @@ def get_announcements_list(request, context):
         else:
             announcements = Announcement.objects.visible_to_user(user).filter(expiration_date__gt=timezone.now())
 
+    # Load information on the user who posted the announcement
+    # Unless the announcement has a custom author (some do, but not all), we will need the user information to construct the byline,
+    announcements = announcements.select_related("user")
+
     # We may query the announcement request multiple times while checking if the user submitted or approved the announcement.
     # prefetch_related() will still make a separate query for each request, but the results are cached if we check them multiple times
     announcements = announcements.prefetch_related("announcementrequest_set")

--- a/intranet/apps/eighth/models.py
+++ b/intranet/apps/eighth/models.py
@@ -376,15 +376,12 @@ class EighthActivity(AbstractBaseEighthModel):
         if not user:
             return []
 
-        activities = set(user.restricted_activity_set.values_list("id", flat=True))
+        q = Q(users_allowed=user.id) | Q(groups_allowed__user=user.id)
 
         if user and user.grade and user.grade.number and user.grade.name and 9 <= user.grade.number <= 12:
-            activities |= set(EighthActivity.objects.filter(**{"{}_allowed".format(user.grade.name_plural): True}).values_list("id", flat=True))
+            q |= Q(**{"{}_allowed".format(user.grade.name_plural): True})
 
-        for group in user.groups.all():
-            activities |= set(group.restricted_activity_set.values_list("id", flat=True))
-
-        return list(activities)
+        return EighthActivity.objects.filter(q).values_list("id", flat=True)
 
     @classmethod
     def available_ids(cls) -> List[int]:

--- a/intranet/apps/eighth/models.py
+++ b/intranet/apps/eighth/models.py
@@ -363,7 +363,7 @@ class EighthActivity(AbstractBaseEighthModel):
         return name
 
     @classmethod
-    def restricted_activities_available_to_user(cls, user: "get_user_model()") -> List["EighthActivity"]:
+    def restricted_activities_available_to_user(cls, user: "get_user_model()") -> List[int]:
         """Finds the restricted activities available to the given user.
 
         Args:

--- a/intranet/apps/eighth/serializers.py
+++ b/intranet/apps/eighth/serializers.py
@@ -282,7 +282,7 @@ class EighthBlockDetailSerializer(serializers.Serializer):
         roomings = EighthActivity.rooms.through.objects.filter(eighthactivity_id__in=activity_ids).select_related("eighthroom", "eighthactivity")
         overridden_roomings = EighthScheduledActivity.rooms.through.objects.filter(
             eighthscheduledactivity_id__in=scheduled_activity_ids
-        ).select_related("eighthroom", "eighthscheduledactivity")
+        ).select_related("eighthroom")
 
         for rooming in roomings:
             activity_id = rooming.eighthactivity.id
@@ -297,7 +297,7 @@ class EighthBlockDetailSerializer(serializers.Serializer):
 
         activities_rooms_overridden = []
         for rooming in overridden_roomings:
-            scheduled_activity_id = rooming.eighthscheduledactivity.id
+            scheduled_activity_id = rooming.eighthscheduledactivity_id
 
             activity_id = scheduled_activity_to_activity_map[scheduled_activity_id]
             if activity_id not in activities_rooms_overridden:

--- a/intranet/apps/eighth/views/signup.py
+++ b/intranet/apps/eighth/views/signup.py
@@ -131,8 +131,8 @@ def eighth_signup_view(request, block_id=None):
         surrounding_blocks = EighthBlock.objects.get_blocks_this_year()
         schedule = []
 
-        signups = EighthSignup.objects.filter(user=user).select_related("scheduled_activity__block", "scheduled_activity__activity")
-        block_signup_map = {s.scheduled_activity.block.id: s.scheduled_activity for s in signups}
+        signups = EighthSignup.objects.filter(user=user).select_related("scheduled_activity", "scheduled_activity__activity")
+        block_signup_map = {s.scheduled_activity.block_id: s.scheduled_activity for s in signups}
 
         waitlists = EighthWaitlist.objects.filter(user=user).select_related("scheduled_activity__block", "scheduled_activity__activity")
         block_waitlist_map = {w.scheduled_activity.block.id: w.scheduled_activity for w in waitlists}

--- a/intranet/apps/eighth/views/signup.py
+++ b/intranet/apps/eighth/views/signup.py
@@ -134,8 +134,11 @@ def eighth_signup_view(request, block_id=None):
         signups = EighthSignup.objects.filter(user=user).select_related("scheduled_activity", "scheduled_activity__activity")
         block_signup_map = {s.scheduled_activity.block_id: s.scheduled_activity for s in signups}
 
-        waitlists = EighthWaitlist.objects.filter(user=user).select_related("scheduled_activity__block", "scheduled_activity__activity")
-        block_waitlist_map = {w.scheduled_activity.block.id: w.scheduled_activity for w in waitlists}
+        if settings.ENABLE_WAITLIST:
+            waitlists = EighthWaitlist.objects.filter(user=user).select_related("scheduled_activity__activity")
+        else:
+            waitlists = EighthWaitlist.objects.none()
+        block_waitlist_map = {w.scheduled_activity.block_id: w.scheduled_activity for w in waitlists}
 
         today = timezone.localdate()
 


### PR DESCRIPTION
## Proposed changes
- Improve `Announcement.announcementrequest` property -- reduce duplication and never reevaluate
- Prefetch `AnnouncmentRequest`s when listing announcements (they may be queried multiple times)
- Simplify `Announcement.is_visible_requester()` query (WARNING: changes behavior slightly)
- Reuse already-queried `EighthBlock` in signup view
- Don't query unneeded block/waitlist/scheduled activity information
- Fix type annotation
- Improve `EighthActivity.restricted_activities_available_to_user() `
- Fetch user information when listing announcements

## Brief description of rationale
See #958