### PR TITLE
Update static error pages

### DIFF
--- a/intranet/templates/error/static/501.html
+++ b/intranet/templates/error/static/501.html
@@ -83,7 +83,7 @@
         <div class="center">
             <div class="error">
                 <div class="logo"></div>
-                <h1>Internal Server Error - HTTP 501</h1>
+                <h1>Not Implemented - HTTP 501</h1>
                 <p>
                     There was an error processing your request.<br>
                     If this message continues to appear, please contact the <a href="mailto:intranet@tjhsst.edu">Intranet Development Team.

--- a/intranet/templates/error/static/503.html
+++ b/intranet/templates/error/static/503.html
@@ -83,10 +83,10 @@
         <div class="center">
             <div class="error">
                 <div class="logo"></div>
-                <h1>Internal Server Error - HTTP 503</h1>
+                <h1>Intranet is temporarily unavailable - HTTP 503</h1>
                 <p>
-                    There was an error processing your request.<br>
-                    If this message continues to appear, please contact the <a href="mailto:intranet@tjhsst.edu">Intranet Development Team.
+                    This site is currently undergoing maintenance. Try again in a few minutes.
+                    <script>setTimeout(function() { location = ""+location; }, 10000);</script>
                 </p>
             </div>
         </div>

--- a/intranet/templates/error/static/504.html
+++ b/intranet/templates/error/static/504.html
@@ -83,9 +83,10 @@
         <div class="center">
             <div class="error">
                 <div class="logo"></div>
-                <h1>Internal Server Error - HTTP 504</h1>
+                <!-- HTTP 504: Gateway timeout -->
+                <h1>Connection to application server timed out</h1>
                 <p>
-                    There was an error processing your request.<br>
+                    This error is likely temporary. Please wait a moment and try sending your request again.<br><br>
                     If this message continues to appear, please contact the <a href="mailto:intranet@tjhsst.edu">Intranet Development Team.
                 </p>
             </div>


### PR DESCRIPTION
## Proposed changes
- Update static error pages

## Brief description of rationale
The static error pages (used by Nginx in production) are inaccurate in some cases. This PR updates them to match the error templates and/or the correct HTTP status code meanings (for example, 504 means "Gateway Timeout," not "Internal Server Error").