### PR TITLE
fix(bus): reset bus routes in a Celery task

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -193,6 +193,7 @@ intranet/apps/bus/api.py
 intranet/apps/bus/consumers.py
 intranet/apps/bus/models.py
 intranet/apps/bus/serializers.py
+intranet/apps/bus/tasks.py
 intranet/apps/bus/tests.py
 intranet/apps/bus/urls.py
 intranet/apps/bus/views.py

--- a/docs/sourcedoc/intranet.apps.bus.rst
+++ b/docs/sourcedoc/intranet.apps.bus.rst
@@ -44,6 +44,14 @@ intranet.apps.bus.serializers module
    :undoc-members:
    :show-inheritance:
 
+intranet.apps.bus.tasks module
+------------------------------
+
+.. automodule:: intranet.apps.bus.tasks
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 intranet.apps.bus.tests module
 ------------------------------
 

--- a/intranet/apps/bus/tasks.py
+++ b/intranet/apps/bus/tasks.py
@@ -1,0 +1,14 @@
+from celery import shared_task
+from celery.utils.log import get_task_logger
+
+from .models import Route
+
+logger = get_task_logger(__name__)
+
+
+@shared_task
+def reset_routes() -> None:
+    logger.info("Resetting bus routes")
+
+    for route in Route.objects.all():
+        route.reset_status()

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -5,6 +5,7 @@ import re
 import sys
 from typing import Any, Dict, List, Tuple  # noqa
 
+import celery.schedules
 import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
@@ -789,6 +790,7 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": FCPS_EMERGENCY_CACHE_UPDATE_INTERVAL,
         "args": (),
     },
+    "reset-routes": {"task": "intranet.apps.bus.tasks.reset_routes", "schedule": celery.schedules.crontab(hour=8, minute=0), "args": ()},
 }
 
 MAINTENANCE_MODE = False


### PR DESCRIPTION
## Proposed changes
- Reset bus routes in a Celery task

## Brief description of rationale
The cron job that resets bus routes is not currently being run in production. We should run it in a Celery task.