### PR TITLE
Fix appearance of some links in dark mode

### DIFF
--- a/intranet/static/css/dark/base.scss
+++ b/intranet/static/css/dark/base.scss
@@ -114,8 +114,9 @@ table.cke_dialog {
 }
 
 a.btn-link:link, a.btn-link:visited, a.btn-link:hover, a.btn-link:active {
-    color: #B7B7B7;
+    color: white;
     background-color: black;
+    text-shadow: none;
 }
 
 .btn-link {


### PR DESCRIPTION
## Proposed changes
- Fix appearance of some links in dark mode

## Brief description of rationale
The text-shadow makes it look blurred, and the light gray is inconsistent.