### PR TITLE
refactor(emerg): fix links on FCPS emergency announcements

### DIFF
--- a/intranet/apps/emerg/views.py
+++ b/intranet/apps/emerg/views.py
@@ -8,6 +8,8 @@ from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
 
+from ...utils.html import safe_fcps_emerg_html
+
 logger = logging.getLogger(__name__)
 
 
@@ -61,6 +63,10 @@ def check_emerg():
         for cd in soup.findAll(text=True):
             if isinstance(cd, CData):
                 body += cd
+
+        title = safe_fcps_emerg_html(title, settings.FCPS_EMERGENCY_PAGE)
+        body = safe_fcps_emerg_html(body, settings.FCPS_EMERGENCY_PAGE)
+
         message = "<h3>{}: </h3>{}".format(title, body)
         message = message.strip()
     else:

--- a/intranet/utils/html.py
+++ b/intranet/utils/html.py
@@ -1,3 +1,4 @@
+import urllib.parse
 from typing import Mapping, Optional, Tuple, Union
 
 import bleach
@@ -54,3 +55,18 @@ def nullify_links(text: str) -> str:
 
     """
     return bleach.linkify(text, [link_removal_callback])
+
+
+def safe_fcps_emerg_html(text: str, base_url: str) -> str:
+    def translate_link_attr(  # pylint: disable=unused-argument
+        attrs: Mapping[Union[str, Tuple[Optional[str]]], str], new: bool = False
+    ) -> Optional[Mapping[Union[str, Tuple[Optional[str]]], str]]:
+        for key in tuple(attrs.keys()):
+            if isinstance(key, tuple) and "href" in key:
+                # Translate links that don't specify a protocol/host
+                # For example, /a/b will be translated to (something like) https://fcps.edu/a/b
+                attrs[key] = urllib.parse.urljoin(base_url, attrs[key])
+
+        return attrs
+
+    return bleach.linkify(bleach.clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES, styles=ALLOWED_STYLES), [translate_link_attr])


### PR DESCRIPTION
## Proposed changes
- Fix links on FCPS emergency announcements
- Strip unsafe tags while we're at it

## Brief description of rationale
The latest FCPS emergency announcement about COVID-19 has a link to `/news/coronavirus-update` that is currently broken. Using `urljoin()` on link URLs fixes this.

This has been tested on a setup that is very similar to production.