### PR TITLE
Improve Kerberos authentication code

### DIFF
--- a/intranet/apps/auth/backends.py
+++ b/intranet/apps/auth/backends.py
@@ -110,7 +110,7 @@ class KerberosAuthenticationBackend:
     @staticmethod
     def try_single_kinit(*, username: str, realm: str, password: str, timeout: Union[int, float]) -> KerberosAuthenticationResult:
         try:
-            kinit = pexpect.spawnu("/usr/bin/kinit {}@{}".format(username, realm), timeout=timeout)
+            kinit = pexpect.spawn("/usr/bin/kinit {}@{}".format(username, realm), timeout=timeout, encoding="utf-8")
             kinit.expect(":")
             kinit.sendline(password)
             returned = kinit.expect([pexpect.EOF, "password:"])


### PR DESCRIPTION
## Proposed changes
- Use enum to indicate authentication result
- Clean up KRB5CCNAME deletion code
- Move kinit/pexpect code into a separate method
- `pexpect.spawnu()` -> `pexpect.spawn()`
- Pass Kerberos cache name on command line

## Brief description of rationale
The current Kerberos authentication code is very messy and has some potential race conditions.

This should be reviewed at least twice and heavily tested.