### PR TITLE
Validate commit message formats in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_script:
 - sudo systemctl start rabbitmq-server
 - psql -U postgres -c 'create database ion'
 - ./scripts/build_ensure_no_changes.sh ./scripts/build_sources.sh
+- ./scripts/validate-commit-messages.py $TRAVIS_COMMIT_RANGE
 script:
 - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then flake8 --max-line-length 150 --exclude=*/migrations/* .; fi
 - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pylint --jobs=0 --disable=fixme,broad-except,global-statement,attribute-defined-outside-init,cyclic-import intranet/; fi

--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -3537,3 +3537,4 @@ scripts/push_docs.sh
 scripts/restart_celery.sh
 scripts/static_templates_format.sh
 scripts/update_docs_sources.sh
+scripts/validate-commit-messages.py

--- a/scripts/validate-commit-messages.py
+++ b/scripts/validate-commit-messages.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+import re
+import subprocess
+import sys
+
+
+def get_output(cmd):
+    return subprocess.run(cmd, stdout=subprocess.PIPE, check=True).stdout.decode()
+
+
+def join_nicely(items):
+    items = list(map(str, items))
+    if len(items) > 2:
+        return ", ".join(items[:-1]) + ", and " + items[-1]
+    else:
+        return " and ".join(items)
+
+
+def pluralize(value, singular="", plural="s"):
+    return singular if value == 1 else plural
+
+
+commits = []
+for arg in filter(bool, map(str.strip, sys.argv[1:])):
+    if ".." in arg:
+        commits.extend(get_output(["git", "log", "--format=%H", arg]).split())
+    else:
+        commits.append(arg)
+
+if not commits:
+    sys.exit(0)
+
+
+failed = False
+
+for commit in commits:
+    short_hash = get_output(["git", "show", "--format=format:%h", "--no-patch", commit])
+
+    msg = get_output(["git", "show", "--format=format:%B", "--no-patch", commit])
+    lines = msg.splitlines()
+
+    errors = []
+
+    if re.search(
+        r"^(build|chore|ci|docs|feat|fix|perf|refactor|style|test)(\([a-z]+\))?: .*$",
+        lines[0],
+    ) is None:
+        errors.append("First line does not match format")
+
+    if len(lines) > 1 and lines[1]:
+        errors.append("Second line must be empty")
+
+    long_lines = [i + 1 for i, line in enumerate(lines) if len(line) > 72]
+    if long_lines:
+        errors.append(
+            "Line{} {} {} too long. Please limit all lines to 72 characters.".format(
+                pluralize(len(long_lines)),
+                join_nicely(long_lines),
+                pluralize(len(long_lines), "is", "are"),
+            )
+        )
+
+    if errors:
+        print("The format of commit {} is invalid:".format(short_hash), file=sys.stderr)
+        for error in errors:
+            print("* {}".format(error), file=sys.stderr)
+
+        failed = True
+
+
+if failed:
+    sys.exit(1)
+else:
+    print(
+        "This commit message matches the correct format; *please review it for its content*.",
+        file=sys.stderr,
+    )


### PR DESCRIPTION
## Proposed changes
- Validate commit message formats in CI

## Brief description of rationale
We should validate the formats of commit messages in CI to ensure all commit messages meet our standards.