### PR TITLE
Eliminate settings.SENIOR_GRADUATION_YEAR

### DIFF
--- a/intranet/apps/announcements/tests.py
+++ b/intranet/apps/announcements/tests.py
@@ -1,8 +1,8 @@
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
 from ...test.ion_test import IonTestCase
+from ...utils.date import get_senior_graduation_year
 from ..users.models import Group
 
 
@@ -10,7 +10,7 @@ class AnnouncementTest(IonTestCase):
     """Tests for the announcements module."""
 
     def setUp(self):
-        self.user = get_user_model().objects.get_or_create(username="awilliam", graduation_year=settings.SENIOR_GRADUATION_YEAR + 1)[0]
+        self.user = get_user_model().objects.get_or_create(username="awilliam", graduation_year=get_senior_graduation_year() + 1)[0]
 
     def test_get_announcements(self):
         self.login()

--- a/intranet/apps/api/tests.py
+++ b/intranet/apps/api/tests.py
@@ -5,12 +5,12 @@ import urllib.parse
 from oauth2_provider.models import AccessToken, get_application_model
 from oauth2_provider.settings import oauth2_settings
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils import timezone
 
 from ...test.ion_test import IonTestCase
+from ...utils.date import get_senior_graduation_year
 from ..bus.models import Route
 from ..eighth.models import EighthActivity, EighthBlock, EighthRoom, EighthScheduledActivity, EighthSignup
 from ..schedule.models import Block, Day, DayType, Time
@@ -22,7 +22,7 @@ class ApiTest(IonTestCase):
     """Tests for the api module."""
 
     def setUp(self):
-        self.user = get_user_model().objects.get_or_create(username="awilliam", graduation_year=(settings.SENIOR_GRADUATION_YEAR + 1))[0]
+        self.user = get_user_model().objects.get_or_create(username="awilliam", graduation_year=(get_senior_graduation_year() + 1))[0]
         self.application = Application(
             name="Test Application",
             redirect_uris="http://localhost http://example.com http://example.it",

--- a/intranet/apps/auth/views.py
+++ b/intranet/apps/auth/views.py
@@ -19,6 +19,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic.base import View
 
+from ...utils.date import get_senior_graduation_date, get_senior_graduation_year
 from ...utils.helpers import dark_mode_enabled, get_ap_week_warning
 from ..dashboard.views import dashboard_view, get_fcps_emerg
 from ..eighth.models import EighthBlock
@@ -135,8 +136,8 @@ def index_view(request, auth_form=None, force_login=False, added_context=None, h
             "bg_pattern": get_bg_pattern(request),
             "theme": get_login_theme(),
             "login_warning": login_warning,
-            "senior_graduation": settings.SENIOR_GRADUATION,
-            "senior_graduation_year": settings.SENIOR_GRADUATION_YEAR,
+            "senior_graduation": get_senior_graduation_date().strftime("%B %d %Y %H:%M:%S"),
+            "senior_graduation_year": get_senior_graduation_year(),
             "sports_events": sports_events,
             "school_events": school_events,
             "should_not_index_page": has_next_page,

--- a/intranet/apps/dashboard/views.py
+++ b/intranet/apps/dashboard/views.py
@@ -8,6 +8,7 @@ from django.shortcuts import render
 from django.urls import reverse
 from django.utils import timezone
 
+from ...utils.date import get_senior_graduation_date, get_senior_graduation_year
 from ...utils.helpers import get_ap_week_warning, get_fcps_emerg
 from ..announcements.models import Announcement, AnnouncementRequest
 from ..eighth.models import EighthBlock, EighthScheduledActivity, EighthSignup
@@ -305,8 +306,8 @@ def add_widgets_context(request, context):
                 "schedule": schedule,
                 "last_displayed_block": schedule[-1] if schedule else None,
                 "no_signup_today": no_signup_today,
-                "senior_graduation": settings.SENIOR_GRADUATION,
-                "senior_graduation_year": settings.SENIOR_GRADUATION_YEAR,
+                "senior_graduation": get_senior_graduation_date().strftime("%B %d %Y %H:%M:%S"),
+                "senior_graduation_year": get_senior_graduation_year(),
             }
         )
 

--- a/intranet/apps/dataimport/tests.py
+++ b/intranet/apps/dataimport/tests.py
@@ -14,12 +14,11 @@ class YearCleanupTest(IonTestCase):
         out = StringIO()
         year = timezone.now().year
         turnover_date = datetime(year, 7, 1)
-        with self.settings(SENIOR_GRADUATION_YEAR=year + 1):
-            call_command("year_cleanup", stdout=out)
+        call_command("year_cleanup", stdout=out, senior_grad_year=year + 1)
         output = [
             "In pretend mode.",
             "Turnover date set to: {}".format(turnover_date.strftime("%c")),
-            "OK: SENIOR_GRADUATION_YEAR = {} in settings/__init__.py".format(year + 1),
+            "OK: senior_grad_year = {}".format(year + 1),
             "Resolving absences",
             "Updating welcome state",
             "Deleting graduated users",

--- a/intranet/apps/eighth/tests.py
+++ b/intranet/apps/eighth/tests.py
@@ -1,12 +1,12 @@
 import datetime
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import urlencode
 
 from ...test.ion_test import IonTestCase
+from ...utils.date import get_senior_graduation_year
 from ..groups.models import Group
 from ..users.models import Email
 from .exceptions import SignupException
@@ -39,7 +39,7 @@ class EighthTest(EighthAbstractTest):
     """
 
     def setUp(self):
-        self.user = get_user_model().objects.get_or_create(username="awilliam", graduation_year=settings.SENIOR_GRADUATION_YEAR + 1, id=8889)[0]
+        self.user = get_user_model().objects.get_or_create(username="awilliam", graduation_year=get_senior_graduation_year() + 1, id=8889)[0]
 
     def create_sponsor(self):
         user = get_user_model().objects.get_or_create(username="ateacher", first_name="A", last_name="Teacher", user_type="teacher")[0]
@@ -140,7 +140,7 @@ class EighthTest(EighthAbstractTest):
         """Do some sample signups."""
 
         self.make_admin()
-        user1 = get_user_model().objects.create(username="user1", graduation_year=settings.SENIOR_GRADUATION_YEAR + 1)
+        user1 = get_user_model().objects.create(username="user1", graduation_year=get_senior_graduation_year() + 1)
         block1 = self.add_block(date="2015-01-01", block_letter="A")
         room1 = self.add_room(name="room1", capacity=1)
 
@@ -154,7 +154,7 @@ class EighthTest(EighthAbstractTest):
         """Make sure users cannot sign up for blacklisted activities."""
 
         self.make_admin()
-        user1 = get_user_model().objects.create(username="user1", graduation_year=settings.SENIOR_GRADUATION_YEAR)
+        user1 = get_user_model().objects.create(username="user1", graduation_year=get_senior_graduation_year())
         block1 = self.add_block(date="2015-01-01", block_letter="A")
         room1 = self.add_room(name="room1", capacity=1)
 
@@ -213,7 +213,7 @@ class EighthTest(EighthAbstractTest):
     def test_both_blocks(self):
         """Make sure that signing up for a both blocks activity works."""
         self.make_admin()
-        user1 = get_user_model().objects.create(username="user1", graduation_year=settings.SENIOR_GRADUATION_YEAR + 1)
+        user1 = get_user_model().objects.create(username="user1", graduation_year=get_senior_graduation_year() + 1)
         group1 = Group.objects.create(name="group1")
         user1.groups.add(group1)
         block1 = self.add_block(date="2015-01-01", block_letter="A")
@@ -245,7 +245,7 @@ class EighthTest(EighthAbstractTest):
 
     def test_signup_status_email(self):
         self.make_admin()
-        user1 = get_user_model().objects.create(username="user1", graduation_year=settings.SENIOR_GRADUATION_YEAR + 1)
+        user1 = get_user_model().objects.create(username="user1", graduation_year=get_senior_graduation_year() + 1)
         Email.objects.get_or_create(address="awilliam@tjhsst.edu", user=user1)
         block1 = self.add_block(date="2015-01-01", block_letter="A")
         block2 = self.add_block(date="2015-01-01", block_letter="B")
@@ -311,7 +311,7 @@ class EighthTest(EighthAbstractTest):
     def test_take_attendance_cancelled(self):
         """ Make sure students in a cancelled activity are marked as absent when the button is pressed. """
         self.make_admin()
-        user1 = get_user_model().objects.create(username="user1", graduation_year=settings.SENIOR_GRADUATION_YEAR + 1)
+        user1 = get_user_model().objects.create(username="user1", graduation_year=get_senior_graduation_year() + 1)
         block1 = self.add_block(date="3000-11-11", block_letter="A")
 
         room1 = self.add_room(name="room1", capacity=1)
@@ -343,7 +343,7 @@ class EighthTest(EighthAbstractTest):
     def test_switch_cancelled_sticky(self):
         """Make sure users can switch out of cancelled activities even if they are stickied in."""
         self.make_admin()
-        user1 = get_user_model().objects.create(username="user1", graduation_year=settings.SENIOR_GRADUATION_YEAR + 1)
+        user1 = get_user_model().objects.create(username="user1", graduation_year=get_senior_graduation_year() + 1)
 
         EighthActivity.objects.all().delete()
         EighthBlock.objects.all().delete()

--- a/intranet/apps/eighth/views/activities.py
+++ b/intranet/apps/eighth/views/activities.py
@@ -15,7 +15,7 @@ from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
 
-from ....utils.date import get_date_range_this_year
+from ....utils.date import get_date_range_this_year, get_senior_graduation_year
 from ....utils.serialization import safe_json
 from ...auth.decorators import deny_restricted
 from ..models import EighthActivity, EighthBlock, EighthScheduledActivity
@@ -200,7 +200,7 @@ def calculate_statistics(activity, start_date=None, all_years=False, year=None, 
 
     old_blocks = 0
 
-    if year is not None and year == settings.SENIOR_GRADUATION_YEAR:
+    if year is not None and year == get_senior_graduation_year():
         start_date = datetime.today()
 
     if start_date is None or future:
@@ -211,7 +211,7 @@ def calculate_statistics(activity, start_date=None, all_years=False, year=None, 
         past_start_date = activities.count() - filtered_activities.count()
 
     if not all_years:
-        if year is None or year == settings.SENIOR_GRADUATION_YEAR:
+        if year is None or year == get_senior_graduation_year():
             year_start, year_end = get_date_range_this_year()
         else:
             year_start, year_end = get_date_range_this_year(datetime(year, 1, 1))

--- a/intranet/apps/emailfwd/tests.py
+++ b/intranet/apps/emailfwd/tests.py
@@ -1,14 +1,14 @@
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
 from ...test.ion_test import IonTestCase
+from ...utils.date import get_senior_graduation_year
 
 
 class EmailFwdTest(IonTestCase):
     def test_email_fwd(self):
         """Email Forward sanity check."""
-        get_user_model().objects.get_or_create(username="awilliam", graduation_year=settings.SENIOR_GRADUATION_YEAR)
+        get_user_model().objects.get_or_create(username="awilliam", graduation_year=get_senior_graduation_year())
         self.login()
 
         response = self.client.get(reverse("senior_emailfwd"))

--- a/intranet/apps/parking/tests.py
+++ b/intranet/apps/parking/tests.py
@@ -1,8 +1,8 @@
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
 from ...test.ion_test import IonTestCase
+from ...utils.date import get_senior_graduation_year
 from .models import CarApplication, ParkingApplication
 
 
@@ -16,7 +16,7 @@ class ParkingTest(IonTestCase):
         return user
 
     def test_parking_form_junior(self):
-        user = self.login_with_args("awilliam", settings.SENIOR_GRADUATION_YEAR + 1)
+        user = self.login_with_args("awilliam", get_senior_graduation_year() + 1)
 
         response = self.client.post(reverse("parking_form"), data={"email": user.tj_email, "mentorship": False})
 
@@ -41,7 +41,7 @@ class ParkingTest(IonTestCase):
         self.assertTrue(parking_apps[0].cars.count(), 1)
 
     def test_invalid_user(self):
-        user = self.login_with_args("bwilliam", settings.SENIOR_GRADUATION_YEAR + 2)
+        user = self.login_with_args("bwilliam", get_senior_graduation_year() + 2)
 
         response = self.client.post(reverse("parking_form"), data={"email": user.tj_email, "mentorship": False})
 

--- a/intranet/apps/polls/views.py
+++ b/intranet/apps/polls/views.py
@@ -4,7 +4,6 @@ import logging
 from collections import OrderedDict
 
 from django import http
-from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
@@ -12,6 +11,7 @@ from django.core.serializers import serialize
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 
+from ...utils.date import get_senior_graduation_year
 from ...utils.html import safe_html
 from ..auth.decorators import deny_restricted
 from .forms import PollForm
@@ -311,7 +311,7 @@ def generate_choice(name, votes, total_count, do_gender=True, show_answers=False
     }
 
     for yr in range(9, 14):
-        yr_votes = votes.filter(user__graduation_year=settings.SENIOR_GRADUATION_YEAR + 12 - yr)
+        yr_votes = votes.filter(user__graduation_year=get_senior_graduation_year() + 12 - yr)
         choice["votes"][yr] = {
             "all": yr_votes.count(),
             "male": yr_votes.filter(user__gender=True).count() if do_gender else 0,

--- a/intranet/apps/preferences/tests.py
+++ b/intranet/apps/preferences/tests.py
@@ -1,9 +1,9 @@
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test.client import RequestFactory
 from django.urls import reverse
 
 from ...test.ion_test import IonTestCase
+from ...utils.date import get_senior_graduation_year
 from ..bus.models import Route
 from .forms import EmailForm
 from .views import save_bus_route
@@ -11,7 +11,7 @@ from .views import save_bus_route
 
 class PreferencesTest(IonTestCase):
     def setUp(self):
-        self.user = get_user_model().objects.get_or_create(username="awilliam", id="99999", graduation_year=settings.SENIOR_GRADUATION_YEAR + 1)[0]
+        self.user = get_user_model().objects.get_or_create(username="awilliam", id="99999", graduation_year=get_senior_graduation_year() + 1)[0]
         route_names = ["JT-002", "JT-001"]
         for route_name in route_names:
             Route.objects.get_or_create(route_name=route_name, space="", bus_number="")

--- a/intranet/apps/seniors/models.py
+++ b/intranet/apps/seniors/models.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.db import models
 
+from ...utils.date import get_senior_graduation_year
+
 
 class College(models.Model):
     name = models.CharField(max_length=1000)
@@ -15,7 +17,7 @@ class College(models.Model):
 
 class SeniorManager(models.Manager):
     def filled(self):
-        return Senior.objects.exclude(college=None, major=None).filter(user__graduation_year=settings.SENIOR_GRADUATION_YEAR)
+        return Senior.objects.exclude(college=None, major=None).filter(user__graduation_year=get_senior_graduation_year())
 
 
 class Senior(models.Model):

--- a/intranet/apps/seniors/views.py
+++ b/intranet/apps/seniors/views.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 
-from ...settings import SENIOR_GRADUATION_YEAR
+from ...utils.date import get_senior_graduation_year
 from ..auth.decorators import deny_restricted
 from .forms import SeniorForm
 from .models import Senior
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 def seniors_home_view(request):
     seniors = (
         Senior.objects.exclude(college=None, major=None)
-        .filter(user__graduation_year=SENIOR_GRADUATION_YEAR)
+        .filter(user__graduation_year=get_senior_graduation_year())
         .order_by("user__last_name", "user__first_name")
     )
     try:

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -17,6 +17,7 @@ from django.utils.functional import cached_property
 
 from intranet.middleware import threadlocals
 
+from ...utils.date import get_senior_graduation_year
 from ...utils.helpers import is_entirely_digit
 from ..bus.models import Route
 from ..eighth.models import EighthBlock, EighthSignup, EighthSponsor
@@ -87,7 +88,7 @@ class UserManager(DjangoUserManager):
 
     def get_students(self) -> Union[Collection["User"], QuerySet]:  # pylint: disable=unsubscriptable-object
         """Get user objects that are students (quickly)."""
-        users = User.objects.filter(user_type="student", graduation_year__gte=settings.SENIOR_GRADUATION_YEAR)
+        users = User.objects.filter(user_type="student", graduation_year__gte=get_senior_graduation_year())
         users = users.exclude(id__in=EXTRA)
 
         return users
@@ -1317,7 +1318,7 @@ class Grade:
         if graduation_year is None:
             self._number = 13
         else:
-            self._number = settings.SENIOR_GRADUATION_YEAR - int(graduation_year) + 12
+            self._number = get_senior_graduation_year() - int(graduation_year) + 12
 
         if 9 <= self._number <= 12:
             self._name = [elem[1] for elem in GRADE_NUMBERS if elem[0] == self._number][0]

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -737,11 +737,10 @@ GIT = {
     "commit_github_url": helpers.get_current_commit_github_url(PROJECT_ROOT),
 }
 
-# Senior graduation year
-SENIOR_GRADUATION_YEAR = 2019
-
-# Senior graduation date in Javascript-readable format
-SENIOR_GRADUATION = datetime.datetime(year=SENIOR_GRADUATION_YEAR, month=6, day=18, hour=19).strftime("%B %d %Y %H:%M:%S")
+# Senior graduation date.
+# The year will be replaced as appropriate (determined in
+# intranet/utils/date.py based on YEAR_TURNOVER_MONTH).
+SENIOR_GRADUATION_DATE = datetime.datetime(year=2000, month=6, day=18, hour=19)
 
 # Month (1-indexed) after which a new school year begins
 # July = 7

--- a/intranet/templates/dashboard/seniors.html
+++ b/intranet/templates/dashboard/seniors.html
@@ -1,5 +1,5 @@
 
-<div class="widget extra-widget seniors-widget" data-graduation-date="{{ senior_graduation }}" data-graduation-year="{{ senior_graduation_year }}">
+<div class="widget extra-widget seniors-widget" data-graduation-date="{{ senior_graduation|date:"F d Y H:i:s" }}" data-graduation-year="{{ senior_graduation_year }}">
     <div class="widget-title">
         <h2>
             {% if is_senior %}

--- a/intranet/templates/eighth/admin/start_of_year.html
+++ b/intranet/templates/eighth/admin/start_of_year.html
@@ -21,7 +21,6 @@
 {% else %}
 <form id="start-of-year" action="{% url 'eighth_admin_maintenance_start_of_year' %}" method="POST">
     {% csrf_token %}
-    <input type="hidden" name="confirm" value="true">
     <p><b>Are you sure? <span style="color:red">This action will DESTROY data!</span></b></p>
     <p>Pressing the button below will run the start of year scripts. This includes:</p>
     <ul style="margin-bottom:10px">
@@ -30,6 +29,10 @@
         <li>Removing signup information for graduated users</li>
         <li>Resetting the welcome notification for all users</li>
     </ul>
+
+    <h4>The current graduation year for seniors is <strong>{{ senior_graduation_year }}</strong>. Accounts for all students graduating up to and including this year, and all associated data, will be <strong>PERMANENTLY REMOVED</strong>.</h4>
+    <input type="checkbox" name="confirm" required> Confirm permanent data destruction
+
     <a class="button" href="{% url 'eighth_admin_maintenance' %}">Go Back</a> <button type="submit">Run Start of Year Scripts</button>
 </form>
 {% endif %}

--- a/intranet/utils/date.py
+++ b/intranet/utils/date.py
@@ -26,3 +26,11 @@ def get_date_range_this_year(now=None):
         date_start = datetime.datetime(now.year, settings.YEAR_TURNOVER_MONTH + 1, 1, 0, 0, 0)
         date_end = datetime.datetime(now.year + 1, settings.YEAR_TURNOVER_MONTH, 1, 0, 0, 0)
     return timezone.make_aware(date_start), timezone.make_aware(date_end)
+
+
+def get_senior_graduation_year(*, now=None):
+    return get_date_range_this_year(now=now)[1].year
+
+
+def get_senior_graduation_date():
+    return settings.SENIOR_GRADUATION_DATE.replace(year=get_senior_graduation_year())


### PR DESCRIPTION
## Proposed changes
- Eliminate `settings.SENIOR_GRADUATION_YEAR` in favor of auto-detection based on current date.

## Brief description of rationale
Updating `settings.SENIOR_GRADUATION_YEAR` is annoying.