### PR TITLE
Unpin pylint from 2.4.4 and fix build for 2.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 - npm install sass
 - pip install -U pip setuptools
 - pip install -U -r requirements.txt
-- pip install -U coveralls flake8 pylint==2.4.4 pylint-django pylint-plugin-utils codacy-coverage isort black autopep8
+- pip install -U coveralls flake8 pylint pylint-django pylint-plugin-utils codacy-coverage isort black autopep8
 before_script:
 - cp intranet/settings/travis_secret.py intranet/settings/secret.py
 - sudo systemctl start rabbitmq-server

--- a/intranet/apps/eighth/models.py
+++ b/intranet/apps/eighth/models.py
@@ -604,7 +604,7 @@ class EighthBlock(AbstractBaseEighthModel):
 
     history = HistoricalRecords()
 
-    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
+    def save(self, *args, **kwargs):  # pylint: disable=signature-differs
         """Capitalize the first letter of the block name."""
         letter = getattr(self, "block_letter", None)
         if letter and len(letter) >= 1:
@@ -1650,7 +1650,7 @@ class EighthScheduledActivity(AbstractBaseEighthModel):
             self.save(update_fields=["cancelled"])
 
             if not self.is_both_blocks or self.block.block_letter != "B":
-                from .notifications import activity_cancelled_email  # pylint: disable=import-outside-toplevel
+                from .notifications import activity_cancelled_email  # pylint: disable=import-outside-toplevel,cyclic-import
 
                 activity_cancelled_email(self)
 
@@ -1666,7 +1666,7 @@ class EighthScheduledActivity(AbstractBaseEighthModel):
             self.cancelled = False
             self.save(update_fields=["cancelled"])
 
-    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
+    def save(self, *args, **kwargs):  # pylint: disable=signature-differs
         super(EighthScheduledActivity, self).save(*args, **kwargs)
 
     class Meta:
@@ -1778,7 +1778,7 @@ class EighthSignup(AbstractBaseEighthModel):
 
     archived_was_absent = models.BooleanField(default=False, blank=True)
 
-    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
+    def save(self, *args, **kwargs):  # pylint: disable=signature-differs
         if self.has_conflict(nocache=True):
             logger.error(
                 "Duplicate signup while saving signup %d for user %d in activity %d, block %d, scheduled activity %d",
@@ -1795,7 +1795,7 @@ class EighthSignup(AbstractBaseEighthModel):
 
     history = HistoricalRecords()
 
-    def validate_unique(self, *args, **kwargs):  # pylint: disable=arguments-differ
+    def validate_unique(self, *args, **kwargs):  # pylint: disable=signature-differs
         """Checked whether more than one EighthSignup exists for a User on a given EighthBlock."""
         super(EighthSignup, self).validate_unique(*args, **kwargs)
 

--- a/intranet/apps/eighth/views/admin/attendance.py
+++ b/intranet/apps/eighth/views/admin/attendance.py
@@ -320,7 +320,7 @@ def migrate_outstanding_passes_view(request):
         activity.administrative = True
 
         if not activity.description:
-            activity.description = "Pass received from the 8th period " "office was not turned in."
+            activity.description = "Pass received from the 8th period office was not turned in."
 
         activity.save()
         invalidate_obj(activity)

--- a/intranet/apps/polls/models.py
+++ b/intranet/apps/polls/models.py
@@ -264,4 +264,4 @@ class AnswerVote(models.Model):  # record of total selection of a given answer c
     is_writing = models.BooleanField(default=False)  # enables distinction between writing/std answers
 
     def __str__(self):
-        return self.choice
+        return str(self.choice)

--- a/intranet/utils/deletion.py
+++ b/intranet/utils/deletion.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def set_historical_user(collector, field, sub_objs, using):
-    from intranet.apps.eighth.models import EighthSignup, EighthSponsor  # pylint: disable=import-outside-toplevel
+    from intranet.apps.eighth.models import EighthSignup, EighthSponsor  # pylint: disable=import-outside-toplevel,cyclic-import
 
     teststaff, _ = get_user_model().objects.get_or_create(id=7011)
     for obj in sub_objs:


### PR DESCRIPTION
## Proposed changes
- Unpin pylint from 2.4.4 and fix build for 2.5.x

## Brief description of rationale
Once the upstream issues mentioned in #990 are resolved, we should switch back to the latest version of Pylint.