### PR TITLE
Add check to commit message validation script

### DIFF
--- a/scripts/validate-commit-messages.py
+++ b/scripts/validate-commit-messages.py
@@ -49,6 +49,9 @@ for commit in commits:
     if re.search(r"^(build|chore|ci|docs|feat|fix|perf|refactor|style|test)(\([a-z]+\))?: .*$", lines[0],) is None:
         errors.append("First line does not match format")
 
+    if re.search(r"[^:]: [a-z].*$", lines[0]) is None:
+        errors.append("First letter in commit message description is not lowercase.")
+
     if len(lines) > 1 and lines[1]:
         errors.append(
             "Second line must be empty. Please put a blank line between the subject (first line) and the body/extended description (third line "

--- a/scripts/validate-commit-messages.py
+++ b/scripts/validate-commit-messages.py
@@ -3,6 +3,11 @@ import re
 import subprocess
 import sys
 
+"""
+This script attempts to verify that certain
+basic commit message conventions are followed.
+"""
+
 
 def get_output(cmd):
     return subprocess.run(cmd, stdout=subprocess.PIPE, check=True).stdout.decode()


### PR DESCRIPTION
## Proposed changes
- Add a check in the commit message validation script for non-lowercase first letter in commit message
- Adds comment explaining commit message validation script.

## Brief description of rationale
Some developers forget to abide by [our commit message format standards](https://github.com/tjcsl/ion/blob/master/docs/developing/howto.rst#formatting-commit-messages). This PR attempts to increase automation of testing of these standards.