### PR TITLE
fix(polls): use distinct polls in `Poll.visible_to_user()`

### DIFF
--- a/intranet/apps/polls/models.py
+++ b/intranet/apps/polls/models.py
@@ -31,7 +31,7 @@ class PollManager(Manager):
 
         """
 
-        return Poll.objects.filter(visible=True).filter(Q(groups__in=user.groups.all()) | Q(groups__isnull=True))
+        return Poll.objects.filter(visible=True).filter(Q(groups__in=user.groups.all()) | Q(groups__isnull=True)).distinct()
 
 
 class Poll(models.Model):


### PR DESCRIPTION
## Proposed changes
- Resolve bug where non-distinct polls can be returned from `Poll.visible_to_user()`

## Brief description of rationale
Currently, non-distinct querysets can be returned from this method.