### PR TITLE
fix(dashboard): fix broken Mathematica link

### DIFF
--- a/intranet/templates/dashboard/links.html
+++ b/intranet/templates/dashboard/links.html
@@ -39,7 +39,7 @@
           <a href="https://sites.google.com/fcpsschools.net/tjlibraryresources/home">Library Resources</a><br>
           <a href="https://tjhsst.fcps.edu/events">Events</a><br>
           <a href="https://tjhsst.fcps.edu/student-services/college-and-career-center">College/Career Center</a><br>
-          <a href="https://guides.tjhsst.edu/math/mathematica">Mathematica</a><br>
+          <a href="https://guides.tjhsst.edu/research/mathematica">Mathematica</a><br>
           <a href="https://webmail.tjhsst.edu/">Webmail</a><br>
           <a href="/uploads/PreArrangedAbsenceForm.pdf">Pre-Arranged Absence Form</a><br>
           <a href="https://tjhsst.fcps.edu/resources/challenge-success-tjhsst">Challenge Success</a>


### PR DESCRIPTION
## Proposed changes

- Change the Mathematica link from https://guides.tjhsst.edu/math/mathematica to https://guides.tjhsst.edu/research/mathematica

## Brief description of rationale

https://guides.tjhsst.edu/math/mathematica 404s, it has been replaced by https://guides.tjhsst.edu/research/mathematica