### PR TITLE
fix(vagrant): upgrade box to generic/ubuntu2004

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ end
 
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/bionic64"
+  config.vm.box = "generic/ubuntu2004"
   config.vm.boot_timeout = 1000
   if devconfig["use_vpn"]
       config.vm.network "public_network", bridge: devconfig["network_interface"]
@@ -62,7 +62,7 @@ Vagrant.configure("2") do |config|
     vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
     vb.name = "ion-vagrant"
     vb.memory = 2048 # the default of 512 gives us a OOM during setup.
-    # vb.gui = true
+    vb.gui = true
   end
 
 

--- a/config/provision_vagrant.sh
+++ b/config/provision_vagrant.sh
@@ -58,11 +58,6 @@ if [[ -x "$(which gem)" ]]; then
     echo "Uninstalling deprecated Ruby Sass (and Ruby)"
     echo
     gem uninstall sass
-    if dpkg -s rubygems; then
-        apt-get -y remove rubygems
-    else
-        apt-get -y remove rubygems-integration
-    fi
     apt-get -y remove ruby-dev
 fi
 apt-get -y install npm nodejs


### PR DESCRIPTION
## Proposed changes
- Upgrade vagrant box from `ubuntu/bionic64` to `generic/ubuntu2004`
- 
- 

## Brief description of rationale
Production uses postgres 12 which is available on ubuntu 20.04

Official Ubuntu image (`ubuntu/focal64`) takes a long time to boot compared to 
`generic/ubuntu2004`.

`generic/ubuntu2004` also supports a wider variety of Vagrant VM providers
