### PR TITLE
fix(dashboard): fix graduation date added in template

### DIFF
--- a/intranet/templates/dashboard/seniors.html
+++ b/intranet/templates/dashboard/seniors.html
@@ -1,5 +1,5 @@
 
-<div class="widget extra-widget seniors-widget" data-graduation-date="{{ senior_graduation|date:"F d Y H:i:s" }}" data-graduation-year="{{ senior_graduation_year }}">
+<div class="widget extra-widget seniors-widget" data-graduation-date="{{ senior_graduation }}" data-graduation-year="{{ senior_graduation_year }}">
     <div class="widget-title">
         <h2>
             {% if is_senior %}


### PR DESCRIPTION
## Proposed changes
- Fix graduation date added in template

## Brief description of rationale
This breaks the graduation countdown.

In #989, I preserved the previous value of the `senior_graduation` variable (a string representation of the graduation date) but for unknown reasons I also added the `date` filter here. The `date` filter tries to operate on this string, fails, and yields an empty string. The JS tries to parse this, fails, and displays bad information to the user.