### PR TITLE
fix(templates): fix broken Livedoc links

### DIFF
--- a/intranet/templates/auth/about.html
+++ b/intranet/templates/auth/about.html
@@ -96,7 +96,7 @@
 
                 {% include "credits.html" %}
                 <br>
-                Additional thanks goes to <a href="https://livedoc.tjhsst.edu/wiki/Iodine#Intranet_Credits">the developers of the first two Intranet applications used at TJHSST</a>.
+                Additional thanks goes to <a href="https://web.archive.org/web/20190927134109/https://livedoc.tjhsst.edu/wiki/Iodine#Intranet_Credits">the developers of the first two Intranet applications used at TJHSST</a>.
                 <br>
                 <br>
                 <br>

--- a/intranet/templates/welcome/base.html
+++ b/intranet/templates/welcome/base.html
@@ -67,7 +67,7 @@
                     {% endif %}
 
                     {% if request.user.is_student %}
-                      <p>You can access your TJ email account ({{ request.user.tj_email }}) by going to <a href="https://webmail.tjhsst.edu" target="_blank">webmail.tjhsst.edu</a>. You can also use another mail client <a href="https://livedoc.tjhsst.edu/wiki/Accessing_your_TJ_Email" target="_blank">via IMAP</a>. Use your Intranet credentials.</p>
+                      <p>You can access your TJ email account ({{ request.user.tj_email }}) by going to <a href="https://webmail.tjhsst.edu" target="_blank">webmail.tjhsst.edu</a>. You can also use another mail client <a href="https://guides.tjhsst.edu/webmail/using-a-3rd-party-client" target="_blank">via IMAP</a>. Use your Intranet credentials.</p>
                     {% endif %}
 
                     <p>It is <b>strongly recommended</b> that you set up email forwarding, which will ensure that you see all of the messages sent to your account.</p>


### PR DESCRIPTION
## Proposed changes
- Replace the links pointing to https://livedoc.tjhsst.edu with archive.org links or links to documentation.tjhsst.edu.

## Brief description of rationale
Livedoc has been deprecated and taken down. Therefore, these links don't work anymore.

I'm not sure if I should replace the attribution link with an archive.org link or if we should add something to documentation.tjhsst.edu and link to that instead.