### PR TITLE
feat(events): record admin actions over events and announcements

### DIFF
--- a/intranet/apps/announcements/views.py
+++ b/intranet/apps/announcements/views.py
@@ -218,11 +218,13 @@ def admin_approve_announcement_view(request, req_id):
                 announcement_posted_hook(request, announcement)
 
                 messages.success(request, "Successfully approved announcement request. It has been posted.")
+                logger.info("Admin %s approved announcement: %s (%s)", request.user, announcement, announcement.id)
             else:
                 req.rejected = True
                 req.rejected_by = request.user
                 req.save()
                 messages.success(request, "You did not approve this request. It will be hidden.")
+                logger.info("Admin %s rejected announcement: %s (%s)", request.user, req.title, req.id)
             return redirect("index")
 
     form = AnnouncementRequestForm(instance=req)
@@ -259,6 +261,7 @@ def add_announcement_view(request):
             obj.save()
             announcement_posted_hook(request, obj)
             messages.success(request, "Successfully added announcement.")
+            logger.info("Admin %s added announcement: %s (%s)", request.user, obj, obj.id)
             return redirect("index")
         else:
             messages.error(request, "Error adding announcement")
@@ -299,6 +302,7 @@ def modify_announcement_view(request, announcement_id=None):
             obj.content = safe_html(obj.content)
             obj.save()
             messages.success(request, "Successfully modified announcement.")
+            logger.info("Admin %s modified announcement: %s (%s)", request.user, announcement, announcement.id)
             return redirect("index")
         else:
             messages.error(request, "Error adding announcement")
@@ -329,10 +333,12 @@ def delete_announcement_view(request, announcement_id):
             if request.POST.get("full_delete", False):
                 a.delete()
                 messages.success(request, "Successfully deleted announcement.")
+                logger.info("Admin %s deleted announcement: %s (%s)", request.user, a, a.id)
             else:
                 a.expiration_date = timezone.localtime()
                 a.save()
                 messages.success(request, "Successfully expired announcement.")
+                logger.info("Admin %s expired announcement: %s (%s)", request.user, a, a.id)
         except Announcement.DoesNotExist:
             pass
 

--- a/intranet/apps/events/views.py
+++ b/intranet/apps/events/views.py
@@ -37,6 +37,7 @@ def events_view(request):
                 event.approved_by = request.user
                 event.save()
                 messages.success(request, "Approved event {}".format(event))
+                logger.info("Admin %s approved event: %s (%s)", request.user, event, event.id)
             else:
                 raise http.Http404
 
@@ -49,6 +50,7 @@ def events_view(request):
                 event.rejected_by = request.user
                 event.save()
                 messages.success(request, "Rejected event {}".format(event))
+                logger.info("Admin %s rejected event: %s (%s)", request.user, event, event.id)
             else:
                 raise http.Http404
 
@@ -176,6 +178,7 @@ def add_event_view(request):
             obj.approved = True
             obj.approved_by = request.user
             messages.success(request, "Because you are an administrator, this event was auto-approved.")
+            logger.info("Admin %s added event: %s (%s)", request.user, obj, obj.id)
             obj.created_hook(request)
 
             obj.save()
@@ -244,6 +247,7 @@ def modify_event_view(request, event_id):
             obj.description = safe_html(obj.description)
             obj.save()
             messages.success(request, "Successfully modified event.")
+            logger.info("Admin %s modified event: %s (%s)", request.user, obj, obj.id)
         else:
             messages.error(request, "Error modifying event.")
     else:
@@ -268,6 +272,7 @@ def delete_event_view(request, event_id):
     if request.method == "POST":
         event.delete()
         messages.success(request, "Successfully deleted event.")
+        logger.info("Admin %s deleted event: %s (%s)", request.user, event, event.id)
         return redirect("events")
     else:
         return render(request, "events/delete.html", {"event": event, "action": "delete"})


### PR DESCRIPTION
closes #660 and #661

## Proposed changes
- Log admin usernames and timestamps for actions in `events` and `announcements`.
- Logger messages formatted as: `Admin test_admin added event: Assembly (event id)`.

## Brief description of rationale
- To more easily trace the modifications done to events and announcements by admins (see #660, #661)