### PR TITLE
docs: add FAQ on accounts for incoming students

### DIFF
--- a/intranet/templates/docs/accounts.html
+++ b/intranet/templates/docs/accounts.html
@@ -43,8 +43,9 @@
     <br>
 
     <h3 class="block-center-heading" id="faq-students">Frequently Asked Questions - Students</h3>
-    <b>What has changed from previous years?</b>
-    <p>Starting this year, there is only one place to set your password for Ion &amp; other CSL services: <a href="https://resetter.tjhsst.edu">https://resetter.tjhsst.edu</a>. Changing your password on any TJ Windows computer <b>NO LONGER</b> allows you to log in to Ion &amp; other CSL services.</p>
+    <b>Why can I, an incoming freshman or froshmore, not reset my CSL password during the summer?</b>
+    <p>CSL accounts for incoming students do not become available until around a week before the start of the school year.</p>
+    <p>Until then, you will be unable to set your CSL password or access your CSL account.</p>
     <b>What is my TJ username? How is this different from my FCPS student ID?</b>
     <p>Your TJ username allows you to interact with CSL services.</p>
     <p>For TJ students, this is composed of your graduation year, first initial, first seven characters of your last names, and, if necessary, an additional numeric identifier. For example, if you graduate in 2023 and your name is John Doe, your TJ username is <i>2023jdoe</i>. If you graduate in 2023 and your name is Alice Longestlastnameintheworld, your TJ username is <i>2023alongest</i>.</p>


### PR DESCRIPTION
## Proposed changes
- add FAQ on when accounts are created for incoming students
- remove FAQ on account transition
- 

## Brief description of rationale
We need to add information to preempt questions from incoming students.