### PR TITLE
fix(dashboard): limit time when senior graduation message is shown

### DIFF
--- a/intranet/apps/dashboard/views.py
+++ b/intranet/apps/dashboard/views.py
@@ -425,6 +425,8 @@ def dashboard_view(request, show_widgets=True, show_expired=False, ignore_dashbo
             "dash_warning": dash_warning,
             "show_widgets": show_widgets,
             "show_expired": show_expired,
+            "show_near_graduation_message": is_senior
+            and (timezone.now().date() + timedelta(days=settings.NEAR_GRADUATION_DAYS) >= get_senior_graduation_date().date()),
             "view_announcements_url": view_announcements_url,
             "dashboard_title": dashboard_title,
             "dashboard_header": dashboard_header,

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -746,6 +746,9 @@ SENIOR_GRADUATION_DATE = datetime.datetime(year=2000, month=6, day=18, hour=19)
 # July = 7
 YEAR_TURNOVER_MONTH = 7
 
+# The number of days out at which a user is deemed "near graduation".
+NEAR_GRADUATION_DAYS = 50
+
 # The hour on an eighth period day to lock teachers from
 # taking attendance (10PM)
 ATTENDANCE_LOCK_HOUR = 22

--- a/intranet/templates/dashboard/dashboard.html
+++ b/intranet/templates/dashboard/dashboard.html
@@ -170,7 +170,7 @@
             </div>
         {% endif %}
 
-        {% if is_senior %}
+        {% if show_near_graduation_message %}
             {% include "dashboard/senior_forwarding.html" %}
         {% endif %}
 


### PR DESCRIPTION
Currently, unless commented manually, the senior forwarding message on
the dashboard is rendered for all seniors, regardless of when it is
during the school year. We intend for the message to be only rendered
near the end of academic year.

This commit restricts the rendering of this message to
settings.NEAR_GRADUATION_DAYS (50).

## Proposed changes
- Restrict rendering of senior forwarding message to seniors NEAR_GRADUATION_DAYS out from graduation
- 
- 

## Brief description of rationale
The current code displays the message at all points during senior year.

NOTE: This has not been tested