### PR TITLE
fix(eighth): add finance and comments field

### DIFF
--- a/intranet/apps/eighth/serializers.py
+++ b/intranet/apps/eighth/serializers.py
@@ -143,7 +143,9 @@ class EighthBlockDetailSerializer(serializers.Serializer):
             "administrative": scheduled_activity.get_administrative(),
             "presign": activity.presign,
             "sticky": scheduled_activity.get_sticky(),
+            "finance": "",  # TODO: refactor JS to remove this
             "title": scheduled_activity.title,
+            "comments": scheduled_activity.comments,  # TODO: refactor JS to remove this
             "display_text": "",
             # TODO: Remove together with other eighth waitlist functionality
             "waitlist_count": 0,


### PR DESCRIPTION
## Proposed changes
- Add the `finance` and `comments` field to `intranet/apps/eighth/serializers.py`

## Brief description of rationale
Without this fix (or a workaround), one cannot select an eighth activity on the signups view - the following error shows in the dev console.

![image](https://user-images.githubusercontent.com/3579871/92258512-f2932c00-eea4-11ea-9b12-590e373de08f.png)

Fixing a bug introduced in 297746388a856081f6821ac2e6f9edca112b4bc7 and ea97f5c0f4ac3b4d1fefb1da8dadc983a04159cc.