### PR TITLE
fix(eighth): fix bbcu-link for firefox browser

### DIFF
--- a/intranet/templates/eighth/take_attendance.html
+++ b/intranet/templates/eighth/take_attendance.html
@@ -56,8 +56,8 @@
             var student_list = [];
             var mem_list = $('.bbcu-selector');
             for (var i = 0; i < mem_list.length; i++) {
-                var name = $(mem_list[i]).find(".user-name")[0].outerText.split(" ").slice(0, 2).join(" ");
-                var email = $(mem_list[i]).find(".id")[0].outerText + "@fcpsschools.net";
+                var name = $(mem_list[i]).find(".user-name")[0].innerText.split(" ").slice(0, 2).join(" ");
+                var email = $(mem_list[i]).find(".id")[0].innerText + "@fcpsschools.net";
                 student_list.push([name, email]);
             }
             var bbcu_script = $("#bbcu_script")[0].value;


### PR DESCRIPTION
## Proposed changes
- Change `outerText` to `innerText` in JavaScript

## Brief description of rationale
- Apparently `outerText` is Chrome specific. I've now tested `innerText` in Chrome, Firefox, Edge, Safari and Opera. I also can't find any incompatibility reports in other browsers.
