### PR TITLE
feat(eighth): redirect to info page near eighth period

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -3103,6 +3103,7 @@ intranet/templates/eighth/activity.html
 intranet/templates/eighth/edit_profile.html
 intranet/templates/eighth/email_students.html
 intranet/templates/eighth/empty_state.html
+intranet/templates/eighth/location.html
 intranet/templates/eighth/multi_signup.html
 intranet/templates/eighth/profile.html
 intranet/templates/eighth/profile_header.html

--- a/intranet/apps/auth/tests.py
+++ b/intranet/apps/auth/tests.py
@@ -61,7 +61,7 @@ class LoginViewTest(IonTestCase):
 
         activity = EighthActivity.objects.create(name="Test Activity 1")
 
-        with self.settings(ENABLE_PRE_EIGHTH_REDIRECT=True):
+        with self.settings(ENABLE_PRE_EIGHTH_CLOSE_SIGNUP_REDIRECT=True):
             block_25 = self.create_block_by_signup_datetime(now + deltas[25], block_letter="A")
             self.assertTrue(self.does_login_redirect_to(reverse("index")))
             EighthSignup.objects.create(user=user, scheduled_activity=EighthScheduledActivity.objects.create(block=block_25, activity=activity))

--- a/intranet/apps/eighth/urls.py
+++ b/intranet/apps/eighth/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     re_path(r"^/toggle_favorite$", signup.toggle_favorite_view, name="eighth_toggle_favorite"),
     re_path(r"^/absences$", attendance.eighth_absences_view, name="eighth_absences"),
     re_path(r"^/absences/(?P<user_id>\d+)$", attendance.eighth_absences_view, name="eighth_absences"),
+    re_path(r"^/glance$", signup.eighth_location, name="eighth_location"),
     # Teachers
     re_path(r"^/attendance$", attendance.teacher_choose_scheduled_activity_view, name="eighth_attendance_choose_scheduled_activity"),
     re_path(r"^/attendance/(?P<scheduled_activity_id>\d+)$", attendance.take_attendance_view, name="eighth_take_attendance"),

--- a/intranet/apps/eighth/views/signup.py
+++ b/intranet/apps/eighth/views/signup.py
@@ -6,6 +6,7 @@ from prometheus_client import Summary
 
 from django import http
 from django.conf import settings
+from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
@@ -363,6 +364,24 @@ def toggle_favorite_view(request):
         else:
             activity.favorites.add(request.user)
             return http.HttpResponse("Favorited activity.")
+
+
+@login_required
+def eighth_location(request):
+    blocks = EighthBlock.objects.get_blocks_today()
+    if blocks:
+        sch_acts = []
+        for b in blocks:
+            try:
+                act = request.user.eighthscheduledactivity_set.get(block=b)
+                sch_acts.append([b, act, ", ".join([r.name for r in act.get_true_rooms()]), ", ".join([s.name for s in act.get_true_sponsors()])])
+            except EighthScheduledActivity.DoesNotExist:
+                sch_acts.append([b, None])
+
+        return render(request, "eighth/location.html", context={"sch_acts": sch_acts})
+    else:
+        messages.error(request, "There are no eighth period blocks scheduled today.")
+        return redirect("index")
 
 
 @require_POST

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -42,7 +42,8 @@ NOMINATION_POSITION = ""
 ENABLE_WAITLIST = False  # WARNING: Enabling the waitlist causes severe performance issues
 ENABLE_BUS_APP = True
 ENABLE_BUS_DRIVER = True
-ENABLE_PRE_EIGHTH_REDIRECT = False
+ENABLE_PRE_EIGHTH_CLOSE_SIGNUP_REDIRECT = False
+ENABLE_PRE_EIGHTH_LOCATION_REDIRECT = True
 NOTIFY_ADMIN_EMAILS = None
 
 IOS_APP_CLIENT_IDS = []  # Attempting to OAuth to an application with one of these client IDs will result in a *special* error message

--- a/intranet/static/css/eighth.schedule.scss
+++ b/intranet/static/css/eighth.schedule.scss
@@ -300,3 +300,12 @@ tr.form-row {
     cursor: pointer;
     margin-left: 5px;
 }
+
+#quick-schedule {
+    .block-display {
+        display: inline-block;
+        margin: 10px;
+        padding: 10px;
+        border: 1px solid rgb(102, 102, 102);
+    }
+}

--- a/intranet/templates/eighth/location.html
+++ b/intranet/templates/eighth/location.html
@@ -1,0 +1,48 @@
+{% extends "page_with_nav.html" %}
+{% load phone_numbers %}
+{% load static %}
+{% load pipeline %}
+
+{% block title %}{{ block.super }} - Eighth Location{% endblock %}
+
+
+{% block css %}
+    {{ block.super }}
+    {% stylesheet 'eighth.schedule' %}
+{% endblock %}
+
+{% block js %}
+    {{ block.super }}
+{% endblock %}
+
+{% block head %}
+    {% if dark_mode_enabled %}
+        {% stylesheet 'dark/base' %}
+        {% stylesheet 'dark/nav' %}
+    {% endif %}
+{% endblock %}
+
+{% block main %}
+<div class="primary-content" id="quick-schedule">
+    <h2>Your upcoming eighth periods are:</h2>
+    <br>
+    {% for s in sch_acts %}
+    <h3>{{ s.0.block_letter }} Block ({{ s.0.date }})</h3>
+        <div class="block-display">
+            {% if s.1 is not None %}
+            <h4><a href="{% url 'eighth_activity' s.1.activity.id %}">{{ s.1.full_title }}</a></h4>
+            <h5><strong>Room(s):</strong> {{ s.2 }}</h5>
+            <h5><strong>Sponsor(s):</strong> {{ s.3 }}</h5>
+            <br>
+            <p><strong>Comments:</strong> {% if s.1.comments %}{{ s.1.comments }}{% else %}None{% endif %}</p>
+            <br>
+            <p>{{ s.1.activity.description }}</p>
+            {% else %}
+            <p>You are not signed up for any activity.</p>
+            {% endif %}
+        </div>
+        <br><br>
+    {% endfor %}
+    <a class="button" href="{% url 'index' %}">Return to Dashboard</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Proposed changes
- redirect to `/eighth/activity/location` starting 20 minutes before the first 8th block of a day and ending 20 minutes after that block's start time.
- `/eighth/activity/location` details the two upcoming 8th blocks, including title, location, sponsors, comments and descriptions

## Brief description of rationale
- avoid loading `/` or `/eighth` for students checking 8th period codes during peak times
