### PR TITLE
fix(eighth): change times for eighth_location to be shown

### DIFF
--- a/intranet/apps/auth/views.py
+++ b/intranet/apps/auth/views.py
@@ -200,11 +200,13 @@ class LoginView(View):
                     today_8 = Day.objects.today().day_type.blocks.filter(name__contains="8")
                     if today_8:
                         first_start_time = time(today_8[0].start.hour, today_8[0].start.minute)
+                        last_start_time = time(today_8.last().start.hour, today_8.last().start.minute)
                         first_start_date = datetime.combine(now.today(), first_start_time)
+                        last_start_date = datetime.combine(now.today(), last_start_time)
                         if (
-                            first_start_date - timedelta(minutes=20)
+                            first_start_date - timedelta(minutes=30)
                             < datetime.combine(now.today(), now.time())
-                            < first_start_date + timedelta(minutes=20)
+                            < last_start_date + timedelta(minutes=20)
                         ):
                             default_next_page = "eighth_location"
                 except AttributeError:


### PR DESCRIPTION
Basically changes the show time for `eighth_location` from within 20 minutes of the first block start time to 30 minutes before first block start through 20 minutes after last block start.

Forgot to PR this last week, sorry.
