### PR TITLE
fix(eighth): remove birthday fields from profile edit page

### DIFF
--- a/intranet/apps/eighth/views/profile.py
+++ b/intranet/apps/eighth/views/profile.py
@@ -36,7 +36,6 @@ def edit_profile_view(request, user_id=None):
             counselor_id = user_form.cleaned_data["counselor_id"]
             if counselor_id:
                 counselor = get_user_model().objects.get(id=counselor_id)
-                user.properties.birthday = user_form.cleaned_data["birthday"]
                 user.counselor = counselor
             # user.properties.address = address_form.save()
             # user.properties.save()
@@ -45,9 +44,7 @@ def edit_profile_view(request, user_id=None):
         else:
             messages.error(request, "An error occurred updating the student profile.")
     else:
-        user_form = ProfileEditForm(
-            initial={"counselor_id": "" if not user.counselor else user.counselor.id, "birthday": user.properties.birthday}, instance=user
-        )
+        user_form = ProfileEditForm(initial={"counselor_id": "" if not user.counselor else user.counselor.id}, instance=user)
         # address_form = AddressForm(instance=user.properties.address)
 
     context = {"profile_user": user, "user_form": user_form, "address_form": address_form}


### PR DESCRIPTION
## Proposed changes
- Remove `user.properties.birthday` from `edit_profile_view`

## Brief description of rationale
`user.properties.birthday` was removed earlier (a378eeca9858d98de47d6711b73190952b302ef1); this form is causing a 500 in production:

    AttributeError: 'UserProperties' object has no attribute 'birthday'