### PR TITLE
chore(error): add status page link to error pages

### DIFF
--- a/intranet/templates/error/500.html
+++ b/intranet/templates/error/500.html
@@ -6,6 +6,12 @@
 
 
 {% block description %}
-    There was an error processing your request.<br>
-    Click <a href="#" id="feedbackLink">here</a> to send feedback to the <a href="mailto:intranet@tjhsst.edu">Intranet Development Team.</a>
+    <p>
+        There was an error processing your request.
+    </p>
+    <p>
+        If this message continues to appear, please contact the
+        <a href="mailto:intranet@tjhsst.edu">Intranet Development Team</a> or check the
+        <a href="https://status.tjhsst.edu">CSL status page</a>.
+    </p>
 {% endblock %}

--- a/intranet/templates/error/503.html
+++ b/intranet/templates/error/503.html
@@ -5,6 +5,9 @@
 {% endblock %}
 
 {% block description %}
-    This site is currently undergoing maintenance. Try again in a few minutes.
-    <script>setTimeout(function() { location = ""+location; }, 10000);</script>
+    <p>
+        This site is currently undergoing maintenance. Try again in a few minutes.
+        <script>setTimeout(function() { location = ""+location; }, 10000);</script>
+    </p>
+    <p>For updates, monitor the <a href="https://status.tjhsst.edu">CSL status page</a>.</p>
 {% endblock %}

--- a/intranet/templates/error/static/500.html
+++ b/intranet/templates/error/static/500.html
@@ -85,8 +85,12 @@
                 <div class="logo"></div>
                 <h1>Internal Server Error - HTTP 500</h1>
                 <p>
-                    There was an error processing your request.<br>
-                    If this message continues to appear, please contact the <a href="mailto:intranet@tjhsst.edu">Intranet Development Team.
+                    There was an error processing your request.
+                </p>
+                <p>
+                    If this message continues to appear, please contact the
+                    <a href="mailto:intranet@tjhsst.edu">Intranet Development Team</a> <br>
+                    or check the <a href="https://status.tjhsst.edu">CSL status page</a>.
                 </p>
             </div>
         </div>

--- a/intranet/templates/error/static/501.html
+++ b/intranet/templates/error/static/501.html
@@ -85,8 +85,11 @@
                 <div class="logo"></div>
                 <h1>Not Implemented - HTTP 501</h1>
                 <p>
-                    There was an error processing your request.<br>
-                    If this message continues to appear, please contact the <a href="mailto:intranet@tjhsst.edu">Intranet Development Team.
+                    There was an error processing your request.
+                </p>
+                <p>
+                    If this message continues to appear, please contact the
+                    <a href="mailto:intranet@tjhsst.edu">Intranet Development Team</a>.
                 </p>
             </div>
         </div>

--- a/intranet/templates/error/static/502.html
+++ b/intranet/templates/error/static/502.html
@@ -86,8 +86,12 @@
                 <!-- HTTP 502: Bad Gateway -->
                 <h1>Unable to contact an application server</h1>
                 <p>
-                    This error is likely temporary. Please wait a moment and try sending your request again.<br><br>
-                    If this message continues to appear, please contact the <a href="mailto:intranet@tjhsst.edu">Intranet Development Team.
+                    This error is likely temporary. Please wait a moment and try sending your request again.
+                </p>
+                <p>
+                    If this message continues to appear, please contact the
+                    <a href="mailto:intranet@tjhsst.edu">Intranet Development Team</a> or check the
+                    <a href="https://status.tjhsst.edu">CSL status page</a>.
                 </p>
             </div>
         </div>

--- a/intranet/templates/error/static/503.html
+++ b/intranet/templates/error/static/503.html
@@ -88,6 +88,7 @@
                     This site is currently undergoing maintenance. Try again in a few minutes.
                     <script>setTimeout(function() { location = ""+location; }, 10000);</script>
                 </p>
+                <p>For updates, monitor the <a href="https://status.tjhsst.edu">CSL status page</a>.</p>
             </div>
         </div>
     </div>

--- a/intranet/templates/error/static/504.html
+++ b/intranet/templates/error/static/504.html
@@ -86,8 +86,12 @@
                 <!-- HTTP 504: Gateway timeout -->
                 <h1>Connection to application server timed out</h1>
                 <p>
-                    This error is likely temporary. Please wait a moment and try sending your request again.<br><br>
-                    If this message continues to appear, please contact the <a href="mailto:intranet@tjhsst.edu">Intranet Development Team.
+                    This error is likely temporary. Please wait a moment and try sending your request again.
+                </p>
+                <p>
+                    If this message continues to appear, please contact the
+                    <a href="mailto:intranet@tjhsst.edu">Intranet Development Team</a> or check the
+                    <a href="https://status.tjhsst.edu">CSL status page</a>.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
## Proposed changes
- Add a link to the CSL status page ([status.tjhsst.edu](https://status.tjhsst.edu)) on the 5xx error pages.
- Fix some formatting/HTML on those pages.

## Brief description of rationale
The status page is probably a good idea to link to on these pages.