### PR TITLE
test: update_counselors, delete_users, bus view, gen_schedule, EighthActivity statistics

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -208,6 +208,7 @@ intranet/apps/bus/migrations/0003_route_space.py
 intranet/apps/bus/migrations/0004_auto_20180117_1232.py
 intranet/apps/bus/migrations/__init__.py
 intranet/apps/dashboard/__init__.py
+intranet/apps/dashboard/tests.py
 intranet/apps/dashboard/views.py
 intranet/apps/dataimport/__init__.py
 intranet/apps/dataimport/apps.py

--- a/docs/sourcedoc/intranet.apps.dashboard.rst
+++ b/docs/sourcedoc/intranet.apps.dashboard.rst
@@ -4,6 +4,14 @@ intranet.apps.dashboard package
 Submodules
 ----------
 
+intranet.apps.dashboard.tests module
+------------------------------------
+
+.. automodule:: intranet.apps.dashboard.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 intranet.apps.dashboard.views module
 ------------------------------------
 

--- a/intranet/apps/announcements/tests.py
+++ b/intranet/apps/announcements/tests.py
@@ -4,13 +4,17 @@ from django.urls import reverse
 from ...test.ion_test import IonTestCase
 from ...utils.date import get_senior_graduation_year
 from ..users.models import Group
+from .models import AnnouncementRequest
 
 
 class AnnouncementTest(IonTestCase):
+
     """Tests for the announcements module."""
 
     def setUp(self):
-        self.user = get_user_model().objects.get_or_create(username="awilliam", graduation_year=get_senior_graduation_year() + 1)[0]
+        self.user = get_user_model().objects.get_or_create(
+            username="awilliam", graduation_year=get_senior_graduation_year() + 1, user_type="student"
+        )[0]
 
     def test_get_announcements(self):
         self.login()
@@ -45,8 +49,48 @@ class AnnouncementTest(IonTestCase):
         response = self.client.post(reverse("show_announcement"))
         self.assertEqual(response.status_code, 404)
 
-    def test_announcement_approval(self):
+    def test_announcement_approval_allowed_users(self):
+        """Tests to ensure that only allowed users can approve announcements."""
         teacher = get_user_model().objects.get_or_create(username="teacher", user_type="teacher", first_name="timmy", last_name="teacher")[0]
         counselor = get_user_model().objects.get_or_create(username="counselor", user_type="counselor", first_name="c", last_name="c")[0]
         user = get_user_model().objects.get_or_create(username="user", user_type="user", first_name="ursula", last_name="user")[0]
+        student = get_user_model().objects.get_or_create(username="3000student", user_type="student", first_name="s", last_name="tudent")[0]
         self.assertEqual(list(get_user_model().objects.get_approve_announcements_users_sorted()), [counselor, teacher, user])
+        self.assertNotIn(student, get_user_model().objects.get_approve_announcements_users_sorted())
+
+    def test_announcement_request(self):
+        """Tests the announcement request view."""
+        self.login()
+        response = self.client.get(reverse("request_announcement"))
+        self.assertEqual(response.status_code, 200)
+
+        teacher = get_user_model().objects.get_or_create(username="awilliam1", user_type="teacher", first_name="a", last_name="william")[0]
+
+        # Now, try to POST an announcement
+        response = self.client.post(
+            reverse("request_announcement"),
+            data={
+                "title": "This is a test!",
+                "author": "Sysadmins",
+                "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                "expiration_date": "3000-01-01 00:00:00",
+                "teachers_requested": str(teacher.id),
+                "notes": "Enter something here!",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)  # to "success" page
+
+        self.assertEqual(1, AnnouncementRequest.objects.count())
+
+        # See if that AnnouncementRequest appears
+        self.assertEqual(
+            AnnouncementRequest.objects.filter(
+                title="This is a test!",
+                author="Sysadmins",
+                content="Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                teachers_requested=teacher,
+                notes="Enter something here!",
+            ).count(),
+            1,
+        )

--- a/intranet/apps/bus/tests.py
+++ b/intranet/apps/bus/tests.py
@@ -1,4 +1,9 @@
+import datetime
+from unittest.mock import patch
+
+from django.conf import settings
 from django.urls import reverse
+from django.utils import timezone
 
 from ...test.ion_test import IonTestCase
 from .models import Route
@@ -10,7 +15,25 @@ class BusTest(IonTestCase):
     def test_bus(self):
         self.login()
 
-        self.assertEqual(self.client.get(reverse("bus")).status_code, 200)
+        # Test morning
+        morning_tz = timezone.make_aware(datetime.datetime(3000, 1, 1, hour=settings.BUS_PAGE_CHANGEOVER_HOUR - 1, minute=0, second=0))
+        with patch("django.utils.timezone.localtime", return_value=morning_tz) as m:
+            response = self.client.get(reverse("bus"))
+            self.assertEqual(response.status_code, 200)
+
+            self.assertTemplateUsed(response, template_name="bus/morning.html")
+
+        m.assert_called()
+
+        # Test afternoon
+        afternoon_tz = timezone.make_aware(datetime.datetime(3000, 1, 1, hour=settings.BUS_PAGE_CHANGEOVER_HOUR + 1, minute=0, second=0))
+        with patch("django.utils.timezone.localtime", return_value=afternoon_tz) as m:
+            response = self.client.get(reverse("bus"))
+            self.assertEqual(response.status_code, 200)
+
+            self.assertTemplateUsed(response, template_name="bus/home.html")
+
+        m.assert_called()
 
     def test_routes(self):
         route = Route.objects.get_or_create(route_name="JT-101", bus_number="JT-101")[0]

--- a/intranet/apps/dashboard/tests.py
+++ b/intranet/apps/dashboard/tests.py
@@ -1,0 +1,128 @@
+from datetime import date
+
+from django.contrib.auth import get_user_model
+
+from ...test.ion_test import IonTestCase
+from ...utils.date import get_senior_graduation_year
+from ..eighth.models import EighthActivity, EighthBlock, EighthScheduledActivity, EighthSignup, EighthSponsor
+from .views import gen_schedule, gen_sponsor_schedule
+
+
+class DashboardTest(IonTestCase):
+
+    """Test for dashboard module"""
+
+    def setUp(self) -> None:
+        self.user = get_user_model().objects.get_or_create(
+            username="awilliam", graduation_year=get_senior_graduation_year() + 1, user_type="student"
+        )[0]
+
+    def test_gen_schedule(self):
+        """Tests the gen_schedule method."""
+        self.make_admin()
+
+        schedule, no_signup_today = gen_schedule(self.user)
+
+        # There are no eighth blocks and no signups, so this should be None, False
+        self.assertIsNone(schedule)
+        self.assertFalse(no_signup_today)
+
+        # Add some blocks
+        today = date.today()
+        block1 = EighthBlock.objects.create(date=today, block_letter="A")
+        block2 = EighthBlock.objects.create(date=today, block_letter="B")
+
+        schedule, no_signup_today = gen_schedule(self.user)
+
+        # There are several eighth blocks but no signups, so this should be not None, then True
+        self.assertIsNotNone(schedule)
+        self.assertTrue(no_signup_today)
+
+        # Add an activity and schedule it
+        eighthactivity = EighthActivity.objects.create(name="Testing Ion", description="lol")
+        act_block1 = EighthScheduledActivity.objects.create(block=block1, activity=eighthactivity, capacity=10)
+        act_block2 = EighthScheduledActivity.objects.create(block=block2, activity=eighthactivity, capacity=10)
+
+        # Sign up this user for block1
+        EighthSignup.objects.create(user=self.user, scheduled_activity=act_block1)
+
+        schedule, no_signup_today = gen_schedule(self.user)
+
+        # There are several eighth blocks but no signups, so this should be not None, then True for block2
+        self.assertIsNotNone(schedule)
+        self.assertTrue(no_signup_today)
+
+        # The first item in `schedule` should be block1 and should be flagged "open"
+        self.assertEqual(block1, schedule[0]["block"])
+        self.assertEqual("Testing Ion", schedule[0]["current_signup"])
+        self.assertIn("open", schedule[0]["flags"])
+
+        # The second item in `schedule` should be block2 and should be flagged "warning" and "open"
+        self.assertEqual(block2, schedule[1]["block"])
+        self.assertIsNone(schedule[1]["current_signup"])
+        self.assertIn("warning", schedule[1]["flags"])
+        self.assertIn("open", schedule[1]["flags"])
+
+        # Lock block1 and it should show as locked
+        block1.locked = True
+        block1.save()
+
+        schedule, no_signup_today = gen_schedule(self.user)
+        self.assertIn("locked", schedule[0]["flags"])
+
+        # Sign up for block2, but then cancel the activity
+        signup = EighthSignup.objects.create(user=self.user, scheduled_activity=act_block2)
+        act_block2.cancel()
+
+        schedule, no_signup_today = gen_schedule(self.user)
+
+        # block2 should show as "warning", "cancelled", and "open"
+        for flag in ["warning", "cancelled", "open"]:
+            self.assertIn(flag, schedule[1]["flags"])
+
+        # Clean up: remove the blocks, signup, activity, etc.
+        block1.delete()
+        block2.delete()
+        signup.delete()
+        act_block2.delete()
+        act_block1.delete()
+
+    def test_gen_sponsor_schedule(self):
+        """Test cases for the gen_sponsor_schedule method."""
+        # Make the user a teacher, and make an EighthSponsor object
+        self.user.user_type = "teacher"
+        self.user.save()
+
+        sponsor = EighthSponsor.objects.create(first_name="a", last_name="William", user=self.user)
+
+        response = gen_sponsor_schedule(self.user)
+
+        # "sponsor_schedule" should be empty because there are no activities assigned to this sponsor
+        self.assertEqual(0, len(response["sponsor_schedule"]))
+
+        # Create two blocks and an activity, scheduled for both
+        today = date.today()
+        block1 = EighthBlock.objects.create(date=today, block_letter="A")
+        block2 = EighthBlock.objects.create(date=today, block_letter="B")
+        eighthactivity = EighthActivity.objects.create(name="Testing Ion", description="lol")
+        act_block1 = EighthScheduledActivity.objects.create(block=block1, activity=eighthactivity, capacity=10)
+        act_block2 = EighthScheduledActivity.objects.create(block=block2, activity=eighthactivity, capacity=10)
+
+        act_block1.sponsors.add(sponsor)
+        act_block2.sponsors.add(sponsor)
+
+        response = gen_sponsor_schedule(self.user)
+
+        # "sponsor_schedule" should have two activities because there are two activities assigned to this sponsor
+        self.assertEqual(2, len(response["sponsor_schedule"]))
+
+        # num_acts should be two
+        self.assertEqual(2, response["num_attendance_acts"])
+
+        # Lock block2, then no_attendance_today should be True
+        block2.locked = True
+        block2.save()
+
+        response = gen_sponsor_schedule(self.user)
+
+        self.assertTrue(response["num_attendance_acts"])

--- a/intranet/apps/dataimport/tests.py
+++ b/intranet/apps/dataimport/tests.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from io import StringIO
+from unittest.mock import mock_open, patch
 
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
@@ -95,3 +96,12 @@ class ImportStudentsTest(IonTestCase):
         # Now let's try using a set
         s = {"2021ttest5", "2021ttest6", "2021ttest7"}
         self.assertEqual("2021ttest8", import_students.find_next_available_username(None, "2021ttest", s))
+
+        # Test file input
+        file_contents = "Student ID\n11111\n55555"
+        with patch("intranet.apps.dataimport.management.commands.delete_users.open", mock_open(read_data=file_contents)) as m:
+            call_command("delete_users", filename="foo.csv", header="Student ID", run=True, confirm=True)
+
+        m.assert_called_with("foo.csv", "r")
+        with self.assertRaises(get_user_model().DoesNotExist):
+            get_user_model().objects.get(username="2021ttester")

--- a/intranet/apps/eighth/tests.py
+++ b/intranet/apps/eighth/tests.py
@@ -831,16 +831,16 @@ class EighthCommandsTest(IonTestCase):
         file_contents = "Student ID,Counselor\n12345,CounselorOne\n54321,CounselorTwo\n55555,CounselorOne"
 
         # Make some counselors
-        counselorone = get_user_model().objects.get_or_create(username="counselorone", last_name="CounselorOne", user_type="counselor")[0]
+        get_user_model().objects.get_or_create(username="counselorone", last_name="CounselorOne", user_type="counselor")
         counselortwo = get_user_model().objects.get_or_create(username="counselortwo", last_name="CounselorTwo", user_type="counselor")[0]
 
         # Make some users
-        userone = get_user_model().objects.get_or_create(username="2021ttest", student_id=12345, user_type="student", counselor=counselortwo)[0]
-        usertwo = get_user_model().objects.get_or_create(username="2021ttest2", student_id=54321, user_type="student", counselor=counselortwo)[0]
-        userthree = get_user_model().objects.get_or_create(username="2021ttester", student_id=55555, user_type="student")[0]
+        get_user_model().objects.get_or_create(username="2021ttest", student_id=12345, user_type="student", counselor=counselortwo)
+        get_user_model().objects.get_or_create(username="2021ttest2", student_id=54321, user_type="student", counselor=counselortwo)
+        get_user_model().objects.get_or_create(username="2021ttester", student_id=55555, user_type="student")
 
         # Run command
-        with patch("intranet.apps.eighth.management.commands.update_counselors.open", mock_open(read_data=file_contents)) as m:
+        with patch("intranet.apps.eighth.management.commands.update_counselors.open", mock_open(read_data=file_contents)):
             call_command("update_counselors", "foo.csv", "--run")
 
         self.assertEqual("counselorone", get_user_model().objects.get(username="2021ttest").counselor.username)


### PR DESCRIPTION
## Proposed changes
Adds unit tests for:

- `intranet.apps.eighth.management.commands.update_counselors`, a command to update students' counselors
- `intranet.apps.dataimport.management.commands.delete_users`, a command to delete users
- [`intranet.apps.bus.views.home`](https://github.com/tjcsl/ion/blob/master/intranet/apps/bus/views.py#L13), to test both `morning` and `afternoon` views no matter the time of day when these tests are ran
- `intranet.apps.dashboard.views.gen_schedule` and `intranet.apps.dashboard.views.gen_sponsor_schedule`
- Views to generate statistics for `EighthActivity`es (`intranet.apps.eighth.views.activities`).

## Brief description of rationale

Self explanatory.