### PR TITLE
Add unit tests for emailfwd, lostfound, itemreg apps; cosmetic changes

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -466,6 +466,7 @@ intranet/apps/lostfound/admin.py
 intranet/apps/lostfound/apps.py
 intranet/apps/lostfound/forms.py
 intranet/apps/lostfound/models.py
+intranet/apps/lostfound/tests.py
 intranet/apps/lostfound/urls.py
 intranet/apps/lostfound/views.py
 intranet/apps/lostfound/migrations/0001_initial.py

--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -357,6 +357,7 @@ intranet/apps/emailfwd/migrations/__init__.py
 intranet/apps/emerg/__init__.py
 intranet/apps/emerg/api.py
 intranet/apps/emerg/tasks.py
+intranet/apps/emerg/tests.py
 intranet/apps/emerg/views.py
 intranet/apps/emerg/migrations/__init__.py
 intranet/apps/error/__init__.py

--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -445,6 +445,7 @@ intranet/apps/itemreg/admin.py
 intranet/apps/itemreg/apps.py
 intranet/apps/itemreg/forms.py
 intranet/apps/itemreg/models.py
+intranet/apps/itemreg/tests.py
 intranet/apps/itemreg/urls.py
 intranet/apps/itemreg/views.py
 intranet/apps/itemreg/migrations/0001_initial.py

--- a/docs/sourcedoc/intranet.apps.emerg.rst
+++ b/docs/sourcedoc/intranet.apps.emerg.rst
@@ -20,6 +20,14 @@ intranet.apps.emerg.tasks module
    :undoc-members:
    :show-inheritance:
 
+intranet.apps.emerg.tests module
+--------------------------------
+
+.. automodule:: intranet.apps.emerg.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 intranet.apps.emerg.views module
 --------------------------------
 

--- a/docs/sourcedoc/intranet.apps.itemreg.rst
+++ b/docs/sourcedoc/intranet.apps.itemreg.rst
@@ -44,6 +44,14 @@ intranet.apps.itemreg.models module
    :undoc-members:
    :show-inheritance:
 
+intranet.apps.itemreg.tests module
+----------------------------------
+
+.. automodule:: intranet.apps.itemreg.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 intranet.apps.itemreg.urls module
 ---------------------------------
 

--- a/docs/sourcedoc/intranet.apps.lostfound.rst
+++ b/docs/sourcedoc/intranet.apps.lostfound.rst
@@ -36,6 +36,14 @@ intranet.apps.lostfound.models module
    :undoc-members:
    :show-inheritance:
 
+intranet.apps.lostfound.tests module
+------------------------------------
+
+.. automodule:: intranet.apps.lostfound.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 intranet.apps.lostfound.urls module
 -----------------------------------
 

--- a/intranet/apps/emailfwd/tests.py
+++ b/intranet/apps/emailfwd/tests.py
@@ -3,13 +3,31 @@ from django.urls import reverse
 
 from ...test.ion_test import IonTestCase
 from ...utils.date import get_senior_graduation_year
+from .models import SeniorEmailForward
 
 
 class EmailFwdTest(IonTestCase):
     def test_email_fwd(self):
         """Email Forward sanity check."""
-        get_user_model().objects.get_or_create(username="awilliam", graduation_year=get_senior_graduation_year())
+        user = get_user_model().objects.get_or_create(username="awilliam", graduation_year=get_senior_graduation_year() - 1, user_type="student")[0]
         self.login()
+
+        response = self.client.get(reverse("senior_emailfwd"), follow=True)
+        self.assertIn("Only seniors can set their forwarding address.", list(map(str, list(response.context["messages"]))))
+
+        user.graduation_year = get_senior_graduation_year()
+        user.save()
 
         response = self.client.get(reverse("senior_emailfwd"))
         self.assertEqual(response.status_code, 200)
+
+        # Now, test setting an email
+        response = self.client.post(reverse("senior_emailfwd"), data={"email": "nonexistent@tjhsst.edu"}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(1, SeniorEmailForward.objects.filter(user=user, email="nonexistent@tjhsst.edu").count())
+
+        # Test invalid email
+        response = self.client.post(reverse("senior_emailfwd"), data={"email": "nonexistenttjhsst.edu"}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(1, SeniorEmailForward.objects.filter(user=user, email="nonexistent@tjhsst.edu").count())
+        self.assertIn("Error adding forwarding address.", list(map(str, list(response.context["messages"]))))

--- a/intranet/apps/emerg/tests.py
+++ b/intranet/apps/emerg/tests.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch
+
+from ...test.ion_test import IonTestCase
+from .views import check_emerg, get_emerg, get_emerg_result, update_emerg_cache
+
+
+class EmergTestCase(IonTestCase):
+    def test_emerg(self):
+        with patch("intranet.apps.emerg.views.settings.EMERGENCY_MESSAGE", "test"):
+            self.assertEqual((True, "test"), check_emerg())
+
+        # I don't have a way to check the output, but at least I can call them
+        check_emerg()
+        get_emerg()
+        get_emerg_result()
+        update_emerg_cache()

--- a/intranet/apps/events/tests.py
+++ b/intranet/apps/events/tests.py
@@ -327,3 +327,35 @@ class EventsTest(IonTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode(), "Unhidden")
         self.assertFalse(user in user_map.users_hidden.all())
+
+    def test_approve_event(self):
+        event = Event.objects.create(title="Test Event", description="test", approved=False, time=timezone.localtime())
+        event2 = Event.objects.create(title="Test Event2", description="test", approved=False, time=timezone.localtime())
+
+        response = self.client.post(reverse("events"), data={"approve": event.id}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Event.objects.get(id=event.id).approved)
+
+        self.make_admin()
+
+        response = self.client.post(reverse("events"), data={"approve": event.id}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(Event.objects.get(id=event.id).approved)
+
+        self.assertFalse(Event.objects.get(id=event2.id).approved)
+
+    def test_reject_event(self):
+        event = Event.objects.create(title="Test Event", description="test", approved=False, time=timezone.localtime())
+        event2 = Event.objects.create(title="Test Event2", description="test", approved=False, time=timezone.localtime())
+
+        response = self.client.post(reverse("events"), data={"reject": event.id}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Event.objects.get(id=event.id).rejected)
+
+        self.make_admin()
+
+        response = self.client.post(reverse("events"), data={"reject": event.id}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(Event.objects.get(id=event.id).rejected)
+
+        self.assertFalse(Event.objects.get(id=event2.id).rejected)

--- a/intranet/apps/itemreg/tests.py
+++ b/intranet/apps/itemreg/tests.py
@@ -1,0 +1,145 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from ...test.ion_test import IonTestCase
+from ..groups.models import Group
+from .models import CalculatorRegistration, ComputerRegistration, PhoneRegistration
+
+
+class ItemRegTestCase(IonTestCase):
+
+    """Test cases for the itemreg app."""
+
+    def test_home_view(self):
+        """Tests for home_view"""
+        self.login("awilliam")
+        user = get_user_model().objects.get(username="awilliam")
+
+        # Just load the page.
+        response = self.client.get(reverse("itemreg"))
+        self.assertEqual(200, response.status_code)
+
+        # Add some items, then load the page.
+        phone = PhoneRegistration.objects.create(user=user, manufacturer="other", imei="351756051523999", description="A phone")
+        calc = CalculatorRegistration.objects.create(user=user, calc_type="ti84p", calc_serial="9999999", calc_id="999999")
+        comp = ComputerRegistration.objects.create(user=user, manufacturer="other", model="test", serial="999999999", screen_size=14)
+
+        response = self.client.get(reverse("itemreg"))
+        self.assertEqual(200, response.status_code)
+        self.assertIn(phone, response.context["phones"])
+        self.assertIn(calc, response.context["calculators"])
+        self.assertIn(comp, response.context["computers"])
+
+    def test_search_view(self):
+        """Tests for search_view, the view to search for registered items."""
+        self.login("awilliam")
+        user = get_user_model().objects.get_or_create(username="awilliam")[0]
+        user2 = get_user_model().objects.get_or_create(username="awilliam1")[0]
+
+        # awilliam should be denied
+        response = self.client.get(reverse("itemreg_search"))
+        self.assertEqual(404, response.status_code)
+
+        # Now, make awilliam part of the group
+        group = Group.objects.get_or_create(name="admin_itemreg")[0]
+        user.groups.add(group)
+        user.save()
+
+        # awilliam should now be able to load the search page
+        response = self.client.get(reverse("itemreg_search"))
+        self.assertEqual(200, response.status_code)
+
+        # Now, add some items belonging to user2 (awiliam1)
+        phone = PhoneRegistration.objects.create(user=user2, manufacturer="other", imei="351756051523999", description="A phone")
+        calc = CalculatorRegistration.objects.create(user=user2, calc_type="ti84p", calc_serial="9999999", calc_id="999999")
+        comp = ComputerRegistration.objects.create(user=user2, manufacturer="other", model="test", serial="999999999", screen_size=14)
+
+        # Search for all items in the database
+        response = self.client.get(reverse("itemreg_search"), data={"type": "all", "user": ""})
+        self.assertEqual(200, response.status_code)
+
+        self.assertIn(phone, response.context["results"]["phone"])
+        self.assertIn(calc, response.context["results"]["calculator"])
+        self.assertIn(comp, response.context["results"]["computer"])
+
+        # Search by user
+        response = self.client.get(reverse("itemreg_search"), data={"type": "all", "user": "awilliam1"})
+        self.assertEqual(200, response.status_code)
+
+        self.assertIn(phone, response.context["results"]["phone"])
+        self.assertIn(calc, response.context["results"]["calculator"])
+        self.assertIn(comp, response.context["results"]["computer"])
+
+        # Search by phone IMEI
+        response = self.client.get(reverse("itemreg_search"), data={"type": "phone", "imei": "351756051523999"})
+        self.assertEqual(200, response.status_code)
+
+        self.assertIn(phone, response.context["results"]["phone"])
+
+        # Search by calculator serial
+        response = self.client.get(reverse("itemreg_search"), data={"type": "calculator", "serial": "9999999"})
+        self.assertEqual(200, response.status_code)
+
+        self.assertIn(calc, response.context["results"]["calculator"])
+
+        # Search by computer serial
+        response = self.client.get(reverse("itemreg_search"), data={"type": "computer", "serial": "999999999"})
+        self.assertEqual(200, response.status_code)
+
+        self.assertIn(comp, response.context["results"]["computer"])
+
+    def test_register_view(self):
+        """Tests for register_view, the view to register items."""
+        self.login()
+
+        # Load the page.
+        for type in ["computer", "calculator", "phone"]:
+            response = self.client.get(reverse("itemreg_register", kwargs={"item_type": type}))
+            self.assertEqual(200, response.status_code)
+
+        # Register a phone.
+        response = self.client.post(
+            reverse("itemreg_register", kwargs={"item_type": "phone"}),
+            data={"manufacturer": "other", "imei": "123456789", "model": "test", "description": "haha"},
+            follow=True,
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, PhoneRegistration.objects.filter(imei="123456789").count())
+
+        # Register a computer.
+        response = self.client.post(
+            reverse("itemreg_register", kwargs={"item_type": "computer"}),
+            data={"manufacturer": "other", "serial": "1234567890", "model": "test", "description": "haha", "screen_size": 14},
+            follow=True,
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, ComputerRegistration.objects.filter(serial="1234567890").count())
+
+        # Register a calculator.
+        response = self.client.post(
+            reverse("itemreg_register", kwargs={"item_type": "calculator"}),
+            data={
+                "calc_type": "ti84p",
+                "calc_serial": "987654321",
+                "calc_id": "test",
+            },
+            follow=True,
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, CalculatorRegistration.objects.filter(calc_serial="987654321").count())
+
+    def test_register_delete_view(self):
+        """Test register_delete_view, the view to delete a registered item."""
+        self.login("awilliam")
+        user = get_user_model().objects.get(username="awilliam")
+        phone = PhoneRegistration.objects.create(user=user, manufacturer="other", imei="351756051523999", description="A phone")
+        calc = CalculatorRegistration.objects.create(user=user, calc_type="ti84p", calc_serial="9999999", calc_id="999999")
+        comp = ComputerRegistration.objects.create(user=user, manufacturer="other", model="test", serial="999999999", screen_size=14)
+
+        # Delete them
+        registration_types = {CalculatorRegistration: "calculator", PhoneRegistration: "phone", ComputerRegistration: "computer"}
+        for item in [phone, calc, comp]:
+            self.client.post(
+                reverse("itemreg_delete", kwargs={"item_type": registration_types[type(item)], "item_id": item.id}), data={"confirm": "confirm"}
+            )
+            self.assertEqual(0, type(item).objects.filter(id=item.id).count())

--- a/intranet/apps/itemreg/tests.py
+++ b/intranet/apps/itemreg/tests.py
@@ -93,8 +93,8 @@ class ItemRegTestCase(IonTestCase):
         self.login()
 
         # Load the page.
-        for type in ["computer", "calculator", "phone"]:
-            response = self.client.get(reverse("itemreg_register", kwargs={"item_type": type}))
+        for item_type in ["computer", "calculator", "phone"]:
+            response = self.client.get(reverse("itemreg_register", kwargs={"item_type": item_type}))
             self.assertEqual(200, response.status_code)
 
         # Register a phone.

--- a/intranet/apps/lostfound/tests.py
+++ b/intranet/apps/lostfound/tests.py
@@ -1,0 +1,161 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from ...test.ion_test import IonTestCase
+from .models import FoundItem, LostItem
+
+
+class LostFoundTestCase(IonTestCase):
+    def test_home_view(self):
+        response = self.client.get(reverse("lostfound"))
+        self.assertEqual(302, response.status_code)  # to login page
+
+        self.login()
+        response = self.client.get(reverse("lostfound"))
+        self.assertEqual(200, response.status_code)
+
+    def test_lostitem_add_view(self):
+        self.login()
+        response = self.client.get(reverse("lostitem_add"))
+        self.assertEqual(200, response.status_code)
+
+        # Add an item
+        response = self.client.post(
+            reverse("lostitem_add"), data={"title": "i lost my calculator", "description": "<p>Oh no</p>", "last_seen": "3000-01-01"}, follow=True
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, LostItem.objects.filter(title="i lost my calculator", description="<p>Oh no</p>", last_seen="3000-01-01").count())
+
+    def test_lostitem_modify_view(self):
+        self.login()
+        user2 = get_user_model().objects.get_or_create(username="awilliam1")[0]
+        item = LostItem.objects.create(user=user2, title="hellotest1", description="Hello", last_seen="3000-01-01")
+
+        # Attempts to modify that would result in a 404 because I am not awilliam1
+        response = self.client.get(reverse("lostitem_modify", kwargs={"item_id": item.id}))
+        self.assertEqual(404, response.status_code)
+
+        # Change the user to awilliam and try again
+        user = get_user_model().objects.get(username="awilliam")
+        item.user = user
+        item.save()
+        response = self.client.get(reverse("lostitem_modify", kwargs={"item_id": item.id}))
+        self.assertEqual(200, response.status_code)
+
+        # Attempt to modify it
+        response = self.client.post(
+            reverse("lostitem_modify", kwargs={"item_id": item.id}),
+            data={"title": "hellotest2", "description": "Hi there!", "last_seen": "3000-01-01"},
+            follow=True,
+        )
+        self.assertEqual(200, response.status_code)
+
+        self.assertEqual(1, LostItem.objects.filter(title="hellotest2", description="Hi there!").count())
+
+    def test_lostitem_delete_view(self):
+        self.login()
+        user2 = get_user_model().objects.get_or_create(username="awilliam1")[0]
+        item = LostItem.objects.create(user=user2, title="hellotest1", description="Hello", last_seen="3000-01-01")
+
+        # Attempts to modify that would result in a 404 because I am not awilliam1
+        response = self.client.get(reverse("lostitem_delete", kwargs={"item_id": item.id}))
+        self.assertEqual(404, response.status_code)
+
+        # Change the user to awilliam and try again
+        user = get_user_model().objects.get(username="awilliam")
+        item.user = user
+        item.save()
+        response = self.client.get(reverse("lostitem_delete", kwargs={"item_id": item.id}))
+        self.assertEqual(200, response.status_code)
+
+        response = self.client.post(reverse("lostitem_delete", kwargs={"item_id": item.id}), data={"mark_retrieved": True}, follow=True)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, LostItem.objects.filter(title="hellotest1", found=True).count())
+
+        response = self.client.post(reverse("lostitem_delete", kwargs={"item_id": item.id}), data={"full_delete": True}, follow=True)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(0, LostItem.objects.filter(title="hellotest1").count())
+
+    def test_lostitem_view(self):
+        self.login()
+        item = LostItem.objects.create(
+            user=get_user_model().objects.get(username="awilliam"), title="hellotest1", description="Hello", last_seen="3000-01-01"
+        )
+
+        response = self.client.get(reverse("lostitem_view", kwargs={"item_id": item.id}))
+        self.assertEqual(200, response.status_code)
+
+    def test_founditem_add_view(self):
+        self.login()
+        response = self.client.get(reverse("founditem_add"))
+        self.assertEqual(200, response.status_code)
+
+        # Add an item
+        response = self.client.post(
+            reverse("founditem_add"),
+            data={"title": "i found this calculator", "description": "<p>Free calculator</p>", "found": "3000-01-01"},
+            follow=True,
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            1, FoundItem.objects.filter(title="i found this calculator", description="<p>Free calculator</p>", found="3000-01-01").count()
+        )
+
+    def test_founditem_modify_view(self):
+        self.login()
+        user2 = get_user_model().objects.get_or_create(username="awilliam1")[0]
+        item = FoundItem.objects.create(user=user2, title="hellotest1", description="Hello", found="3000-01-01")
+
+        # Attempts to modify that would result in a 404 because I am not awilliam1
+        response = self.client.get(reverse("founditem_modify", kwargs={"item_id": item.id}))
+        self.assertEqual(404, response.status_code)
+
+        # Change the user to awilliam and try again
+        user = get_user_model().objects.get(username="awilliam")
+        item.user = user
+        item.save()
+        response = self.client.get(reverse("founditem_modify", kwargs={"item_id": item.id}))
+        self.assertEqual(200, response.status_code)
+
+        # Attempt to modify it
+        response = self.client.post(
+            reverse("founditem_modify", kwargs={"item_id": item.id}),
+            data={"title": "hellotest2", "description": "Hi there!", "found": "3000-01-01"},
+            follow=True,
+        )
+        self.assertEqual(200, response.status_code)
+
+        self.assertEqual(1, FoundItem.objects.filter(title="hellotest2", description="Hi there!").count())
+
+    def test_founditem_delete_view(self):
+        self.login()
+        user2 = get_user_model().objects.get_or_create(username="awilliam1")[0]
+        item = FoundItem.objects.create(user=user2, title="hellotest1", description="Hello", found="3000-01-01")
+
+        # Attempts to modify that would result in a 404 because I am not awilliam1
+        response = self.client.get(reverse("founditem_delete", kwargs={"item_id": item.id}))
+        self.assertEqual(404, response.status_code)
+
+        # Change the user to awilliam and try again
+        user = get_user_model().objects.get(username="awilliam")
+        item.user = user
+        item.save()
+        response = self.client.get(reverse("founditem_delete", kwargs={"item_id": item.id}))
+        self.assertEqual(200, response.status_code)
+
+        response = self.client.post(reverse("founditem_delete", kwargs={"item_id": item.id}), data={"mark_retrieved": True}, follow=True)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, FoundItem.objects.filter(title="hellotest1", retrieved=True).count())
+
+        response = self.client.post(reverse("founditem_delete", kwargs={"item_id": item.id}), data={"full_delete": True}, follow=True)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(0, FoundItem.objects.filter(title="hellotest1").count())
+
+    def test_founditem_view(self):
+        self.login()
+        item = FoundItem.objects.create(
+            user=get_user_model().objects.get(username="awilliam"), title="hellotest1", description="Hello", found="3000-01-01"
+        )
+
+        response = self.client.get(reverse("founditem_view", kwargs={"item_id": item.id}))
+        self.assertEqual(200, response.status_code)

--- a/intranet/apps/lostfound/views.py
+++ b/intranet/apps/lostfound/views.py
@@ -65,10 +65,11 @@ def lostitem_add_view(request):
 @login_required
 @deny_restricted
 def lostitem_modify_view(request, item_id=None):
-    """Modify a lostitem.
+    """
+    Modify a LostItem.
 
-    id: lostitem id
-
+    Args:
+        item_id: LostItem ID
     """
     lostitem = get_object_or_404(LostItem, id=item_id)
     if lostitem.user != request.user and not request.user.has_admin_permission("all"):
@@ -95,10 +96,11 @@ def lostitem_modify_view(request, item_id=None):
 @login_required
 @deny_restricted
 def lostitem_delete_view(request, item_id):
-    """Delete a lostitem.
+    """
+    Delete a LostItem.
 
-    id: lostitem id
-
+    Args:
+        item_id: LostItem id
     """
     lostitem = get_object_or_404(LostItem, id=item_id)
     if lostitem.user != request.user and not request.user.has_admin_permission("all"):
@@ -121,10 +123,11 @@ def lostitem_delete_view(request, item_id):
 @login_required
 @deny_restricted
 def lostitem_view(request, item_id):
-    """View a lostitem.
+    """
+    View a LostItem.
 
-    id: lostitem id
-
+    Args:
+        item_id: LostItem id
     """
     lostitem = get_object_or_404(LostItem, id=item_id)
     return render(request, "lostfound/item_view.html", {"item": lostitem, "type": "lost"})
@@ -154,10 +157,11 @@ def founditem_add_view(request):
 @login_required
 @deny_restricted
 def founditem_modify_view(request, item_id=None):
-    """Modify a founditem.
+    """
+    Modify a FoundItem.
 
-    id: founditem id
-
+    Args:
+        item_id: FoundItem id
     """
     founditem = get_object_or_404(FoundItem, id=item_id)
     if founditem.user != request.user and not request.user.has_admin_permission("all"):
@@ -184,10 +188,11 @@ def founditem_modify_view(request, item_id=None):
 @login_required
 @deny_restricted
 def founditem_delete_view(request, item_id):
-    """Delete a founditem.
+    """
+    Delete a FoundItem.
 
-    id: founditem id
-
+    Args:
+        item_id: FoundItem id
     """
     founditem = get_object_or_404(FoundItem, id=item_id)
     if founditem.user != request.user and not request.user.has_admin_permission("all"):
@@ -210,10 +215,11 @@ def founditem_delete_view(request, item_id):
 @login_required
 @deny_restricted
 def founditem_view(request, item_id):
-    """View a founditem.
+    """
+    View a FoundItem.
 
-    id: founditem id
-
+    Args:
+        item_id: FoundItem id
     """
     founditem = get_object_or_404(FoundItem, id=item_id)
     return render(request, "lostfound/item_view.html", {"item": founditem, "type": "found"})

--- a/intranet/templates/events/add_modify.html
+++ b/intranet/templates/events/add_modify.html
@@ -73,7 +73,7 @@
     <table>
     {% csrf_token %}
     <tr><td colspan="2">
-        {% if action == "add" %}
+        {% if action == "add" or action == "request" %}
             <p>
                 {% if is_events_admin %}
                     You can directly post an event to Intranet using this form.
@@ -89,7 +89,7 @@
     </td></tr>
     {{ form.as_table }}
     <tr><td>&nbsp;</td><td>
-        <input type="submit" style="width: 150px">
+        <input type="submit" style="width: 150px" value="{{ action|title }} Event">
         {% if id %}
             <a href="{% url 'delete_event' id %}" class="button delete-button">Delete</a>
         {% endif %}


### PR DESCRIPTION
## Proposed changes
- Adds unit tests for these apps
  - `emailfwd`
  - `lostfound`
  - `itemreg`
- Cosmetic changes
  - Event request app
    - fix showing the header when requesting events
    - Change "submit query" text to something a little more user friendly