### PR TITLE
fix(eighth): handle students always in-person better

### DIFF
--- a/intranet/apps/eighth/Hybrid-README.rst
+++ b/intranet/apps/eighth/Hybrid-README.rst
@@ -9,7 +9,7 @@ The motivation behind these changes was:
 2) Keep these changes as seperate as possible so that they can be reverted
 3) Not break ``eighth``
 
-First, this document assumes that all students have been sorted into three groups named ``virtual``, ``in-person (a-k)`` and ``in-person (l-z)``, that these groups are always correct and that each student is in only one group. It is on 8PO and/or the main office to ensure that these groups are accurate, not us. These groups NEED to be created for the code to work with ENABLE_HYBRID_EIGHTH set to True.
+First, this document assumes that all students have been sorted into four groups named ``virtual``, ``in-person (a-k)``, ``in-person (l-z)`` and ``in-person``, that these groups are always correct and that each student is in only one group. It is on 8PO and/or the main office to ensure that these groups are accurate, not us. These groups NEED to be created for the code to work with ENABLE_HYBRID_EIGHTH set to True.
 
 ###########
 Conventions
@@ -19,6 +19,7 @@ Block Names --> ``* - Virt``, ``* - P1``, ``* - P2`` where the * is the block le
 * ``virtual`` will always sign up for the ``* - Virt`` blocks
 * ``in-person (a-k)`` will sign up for ``* - P1`` blocks if they are present, else they will sign up for ``* - Virt`` blocks
 * ``in-person (l-z)`` will sign up for ``* - P2`` blocks if they are present, else they will sign up for ``* - Virt`` blocks
+* ``in-person`` will always sign up for the ``* - P1`` or ``* - P2`` blocks
 
 Most of the work is done in either the block creation process or the activity scheduling process. However, there is other work done to hide extra blocks for students, to ensure teachers remember to take attendance and to clean up some naming. There is a setting called ``ENABLE_HYBRID_EIGHTH`` which is used extensively to enable these changes. When this is ``False``, Ion should behave like normal. However, be careful when setting this to ``False`` because the hybrid blocks won't display correctly. Nothing will break per se, but it won't be very user friendly. Specifics are below.
 

--- a/intranet/apps/eighth/views/admin/blocks.py
+++ b/intranet/apps/eighth/views/admin/blocks.py
@@ -131,11 +131,11 @@ def perform_hybrid_block_signup(fmtdate, celery_logger):
                     except Exception:
                         failed_users.add(user)
 
-        # sticky `in-person (a-k)` for `* - Virt`
+        # sticky `in-person (a-k)` and `in-person` for `* - Virt`
         virtual_blocks = {b for b in blocks if "Virt" in b.block_letter}
         for b in virtual_blocks:
             sch_act = EighthScheduledActivity.objects.create(block=b, activity=sticky_act, attendance_taken=True)
-            for g in [Group.objects.get(name="in-person (a-k)")]:
+            for g in [Group.objects.get(name="in-person (a-k)"), Group.objects.get(name="in-person")]:
                 for user in g.user_set.all():
                     try:
                         sch_act.add_user(user, request=None, force=True, no_after_deadline=True)
@@ -159,11 +159,11 @@ def perform_hybrid_block_signup(fmtdate, celery_logger):
                     except Exception:
                         failed_users.add(user)
 
-        # sticky `in-person (l-z)` for `* - Virt`
+        # sticky `in-person (l-z)` and `in-person` for `* - Virt`
         virtual_blocks = {b for b in blocks if "Virt" in b.block_letter}
         for b in virtual_blocks:
             sch_act = EighthScheduledActivity.objects.create(block=b, activity=sticky_act, attendance_taken=True)
-            for g in [Group.objects.get(name="in-person (l-z)")]:
+            for g in [Group.objects.get(name="in-person (l-z)"), Group.objects.get(name="in-person")]:
                 for user in g.user_set.all():
                     try:
                         sch_act.add_user(user, request=None, force=True, no_after_deadline=True)


### PR DESCRIPTION
## Proposed changes
- Create a fourth group to handle those always in-person

## Brief description of rationale
Although block creation works fine as is, the few people who are in both `in-person (a-k)` and `in-person (l-z)` get put in both Virtual and In-Person blocks when 8PO goes to sticky into something like SEL. I already made the group changes in production.