### PR TITLE
Add tests for seniors, search, error, sessionmgmt, signage apps, docstrings/typing hints

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -626,6 +626,7 @@ intranet/apps/signage/admin.py
 intranet/apps/signage/consumers.py
 intranet/apps/signage/models.py
 intranet/apps/signage/pages.py
+intranet/apps/signage/tests.py
 intranet/apps/signage/urls.py
 intranet/apps/signage/views.py
 intranet/apps/signage/migrations/0001_initial.py

--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -586,6 +586,7 @@ intranet/apps/schedule/migrations/0010_auto_20150806_1547.py
 intranet/apps/schedule/migrations/0011_day_comment.py
 intranet/apps/schedule/migrations/__init__.py
 intranet/apps/search/__init__.py
+intranet/apps/search/tests.py
 intranet/apps/search/urls.py
 intranet/apps/search/utils.py
 intranet/apps/search/views.py

--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -593,6 +593,7 @@ intranet/apps/seniors/__init__.py
 intranet/apps/seniors/admin.py
 intranet/apps/seniors/forms.py
 intranet/apps/seniors/models.py
+intranet/apps/seniors/tests.py
 intranet/apps/seniors/urls.py
 intranet/apps/seniors/views.py
 intranet/apps/seniors/management/__init__.py

--- a/docs/sourcedoc/intranet.apps.search.rst
+++ b/docs/sourcedoc/intranet.apps.search.rst
@@ -4,6 +4,14 @@ intranet.apps.search package
 Submodules
 ----------
 
+intranet.apps.search.tests module
+---------------------------------
+
+.. automodule:: intranet.apps.search.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 intranet.apps.search.urls module
 --------------------------------
 

--- a/docs/sourcedoc/intranet.apps.seniors.rst
+++ b/docs/sourcedoc/intranet.apps.seniors.rst
@@ -36,6 +36,14 @@ intranet.apps.seniors.models module
    :undoc-members:
    :show-inheritance:
 
+intranet.apps.seniors.tests module
+----------------------------------
+
+.. automodule:: intranet.apps.seniors.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 intranet.apps.seniors.urls module
 ---------------------------------
 

--- a/docs/sourcedoc/intranet.apps.signage.rst
+++ b/docs/sourcedoc/intranet.apps.signage.rst
@@ -44,6 +44,14 @@ intranet.apps.signage.pages module
    :undoc-members:
    :show-inheritance:
 
+intranet.apps.signage.tests module
+----------------------------------
+
+.. automodule:: intranet.apps.signage.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 intranet.apps.signage.urls module
 ---------------------------------
 

--- a/intranet/apps/error/tests.py
+++ b/intranet/apps/error/tests.py
@@ -1,3 +1,6 @@
+from django.test import Client
+from django.urls import reverse
+
 from ...test.ion_test import IonTestCase
 
 
@@ -12,3 +15,16 @@ class ErrorPageTest(IonTestCase):
         resp = self.client.get("/nonexistent")
         self.assertEqual(resp.status_code, 404)
         self.assertIn(b"The page you requested could not be found.", resp.content)
+
+    def test_503_page(self):
+        with self.settings(MAINTENANCE_MODE=True):
+            resp = self.client.get(reverse("login"))
+            self.assertEqual(resp.status_code, 503)
+            self.assertIn(b"This site is currently undergoing maintenance", resp.content)
+
+    def test_csrf_page(self):
+        csrf_client = Client(enforce_csrf_checks=True)
+
+        resp = csrf_client.post(reverse("login"), data={"sdlfkjsf": "sdlfjsdlfsd"})
+        self.assertEqual(resp.status_code, 403)
+        self.assertIn(b"If making a scripted request", resp.content)

--- a/intranet/apps/search/tests.py
+++ b/intranet/apps/search/tests.py
@@ -1,0 +1,191 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+
+from ...test.ion_test import IonTestCase
+from ...utils.date import get_senior_graduation_year
+from ..announcements.models import Announcement
+from ..eighth.models import EighthActivity
+from ..events.models import Event
+
+
+class SearchTestCase(IonTestCase):
+    def test_student_id_search(self):
+        """Tests searching by a student ID."""
+        self.login()
+        user = get_user_model().objects.get_or_create(
+            username=f"{get_senior_graduation_year()}awilliam", student_id=1234567, first_name="Angela", last_name="William"
+        )[0]
+        response = self.client.get(reverse("search"), data={"q": 1234567})
+        self.assertEqual(200, response.status_code)
+
+        # This should load the profile view.
+        self.assertIn("Angela William", str(response.content))
+        self.assertEqual(user, response.context["profile_user"])
+
+    def test_user_name_search(self):
+        """Tests searching by a user's name."""
+        self.login()
+
+        user = get_user_model().objects.get_or_create(
+            username=f"{get_senior_graduation_year()}hthere", student_id=1234567, first_name="Hello", last_name="There"
+        )[0]
+        response = self.client.get(reverse("search"), data={"q": "Hello There"}, follow=True)
+        self.assertEqual(200, response.status_code)
+
+        # This should load the profile view, since there are no other results.
+        self.assertIn("Hello There", str(response.content))
+        self.assertEqual(user, response.context["profile_user"])
+
+        # Add another user.
+        get_user_model().objects.get_or_create(
+            username=f"{get_senior_graduation_year()}hthere2", student_id=1234568, first_name="Henry", last_name="There"
+        )
+        response = self.client.get(reverse("search"), data={"q": "Hello There"}, follow=True)
+        self.assertEqual(200, response.status_code)
+
+        # This should load the profile view, since there are no other results.
+        self.assertIn("Hello There", str(response.content))
+        self.assertEqual(user, response.context["profile_user"])
+
+        response = self.client.get(reverse("search"), data={"q": "There"})
+        self.assertEqual(200, response.status_code)
+
+        # This should not load the profile view, since there is more than one result.
+        self.assertIn("Hello There", str(response.content))
+        self.assertIn("Henry There", str(response.content))
+
+    def test_grade_level_search(self):
+        self.login()
+        user = get_user_model().objects.get_or_create(
+            username=f"{get_senior_graduation_year()}hthere",
+            student_id=1234567,
+            first_name="Hello",
+            last_name="There",
+            graduation_year=get_senior_graduation_year(),
+            user_type="student",
+        )[0]
+        user2 = get_user_model().objects.get_or_create(
+            username=f"{get_senior_graduation_year()+1}hthere",
+            student_id=1234568,
+            first_name="Hello",
+            last_name="There",
+            graduation_year=get_senior_graduation_year() + 1,
+            user_type="student",
+        )[0]
+        user3 = get_user_model().objects.get_or_create(
+            username=f"{get_senior_graduation_year()}hhello",
+            student_id=1234569,
+            first_name="Hello",
+            last_name="Hello",
+            graduation_year=get_senior_graduation_year(),
+            user_type="student",
+        )[0]
+        response = self.client.get(reverse("search"), data={"q": "grade:12"})
+        self.assertEqual(200, response.status_code)
+        self.assertIn(user, response.context["search_results"])
+        self.assertIn(user3, response.context["search_results"])
+        self.assertNotIn(user2, response.context["search_results"])
+
+    def test_search_grad_year(self):
+        self.login()
+        user = get_user_model().objects.get_or_create(
+            username=f"{get_senior_graduation_year()}hthere",
+            student_id=1234567,
+            first_name="Hello",
+            last_name="There",
+            graduation_year=get_senior_graduation_year(),
+            user_type="student",
+        )[0]
+        user2 = get_user_model().objects.get_or_create(
+            username=f"{get_senior_graduation_year() + 1}hthere",
+            student_id=1234568,
+            first_name="Hello",
+            last_name="There",
+            graduation_year=get_senior_graduation_year() + 1,
+            user_type="student",
+        )[0]
+        user3 = get_user_model().objects.get_or_create(
+            username=f"{get_senior_graduation_year()}hhello",
+            student_id=1234569,
+            first_name="Hello",
+            last_name="Hello",
+            graduation_year=get_senior_graduation_year(),
+            user_type="student",
+        )[0]
+        user4 = get_user_model().objects.get_or_create(
+            username=f"{get_senior_graduation_year() + 2}hhello",
+            student_id=1234570,
+            first_name="Hello",
+            last_name="Hello",
+            graduation_year=get_senior_graduation_year() + 2,
+            user_type="student",
+        )[0]
+
+        response = self.client.get(reverse("search"), data={"q": f"gradyear>{get_senior_graduation_year() + 1}"})
+        self.assertEqual(200, response.status_code)
+        self.assertNotIn(user, response.context["search_results"])
+        self.assertNotIn(user3, response.context["search_results"])
+        self.assertIn(user4, response.context["search_results"])
+        self.assertIn(user2, response.context["search_results"])
+
+        response = self.client.get(reverse("search"), data={"q": f"gradyear={get_senior_graduation_year()}"})
+        self.assertEqual(200, response.status_code)
+        self.assertIn(user, response.context["search_results"])
+        self.assertIn(user3, response.context["search_results"])
+        self.assertNotIn(user4, response.context["search_results"])
+        self.assertNotIn(user2, response.context["search_results"])
+
+    def test_exact_name_search(self):
+        self.login()
+        get_user_model().objects.get_or_create(
+            username=f"{get_senior_graduation_year()}hthere",
+            student_id=1234567,
+            first_name="Hello",
+            last_name="Ther",
+            graduation_year=get_senior_graduation_year(),
+            user_type="student",
+        )
+        get_user_model().objects.get_or_create(
+            username=f"{get_senior_graduation_year() + 1}hthere",
+            student_id=1234568,
+            first_name="Hello",
+            last_name="There",
+            graduation_year=get_senior_graduation_year(),
+            user_type="student",
+        )
+
+        response = self.client.get(reverse("search"), data={"q": '"ther"'}, follow=True)
+        self.assertEqual(200, response.status_code)
+        self.assertIn("Hello Ther", str(response.content))
+        self.assertNotIn("Hello There", str(response.content))
+
+    def test_eighth_activity_search(self):
+        eighth_activity = EighthActivity.objects.create(name="sysadmins")
+
+        self.login()
+        response = self.client.get(reverse("search"), data={"q": "sysadmins"}, follow=True)
+        self.assertEqual(200, response.status_code)
+
+        self.assertIn("sysadmins", str(response.content))
+        self.assertIn(str(eighth_activity.id), str(response.content))
+
+    def test_do_announcements_search(self):
+        announcement = Announcement.objects.create(title="I'm testing Ion today", content="you might be slowed down sorry")
+
+        self.login()
+        response = self.client.get(reverse("search"), data={"q": "testing Ion"}, follow=True)
+        self.assertEqual(200, response.status_code)
+
+        self.assertIn("you might", str(response.content))
+        self.assertIn(announcement, response.context["announcements"])
+
+    def test_events_search(self):
+        event = Event.objects.create(title="Sysadmins Conscription", description="haha", location="200D", time=timezone.localtime())
+
+        self.login()
+        response = self.client.get(reverse("search"), data={"q": "Conscription"}, follow=True)
+        self.assertEqual(200, response.status_code)
+
+        self.assertIn("Sysadmins Conscription", str(response.content))
+        self.assertIn(event, response.context["events"])

--- a/intranet/apps/seniors/tests.py
+++ b/intranet/apps/seniors/tests.py
@@ -1,0 +1,126 @@
+from unittest.mock import mock_open, patch
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.urls import reverse
+
+from ...test.ion_test import IonTestCase
+from ...utils.date import get_senior_graduation_year
+from .models import College, Senior
+
+
+class SeniorsTestCase(IonTestCase):
+
+    """Test cases for the seniors app."""
+
+    def test_seniors_home_view(self):
+        """Tests the seniors home view, listing seniors and their destinations."""
+        self.login()
+        response = self.client.get(reverse("seniors"))
+        self.assertEqual(200, response.status_code)
+
+        # Add a senior.
+        user = get_user_model().objects.get_or_create(
+            username=f"{get_senior_graduation_year()}awilliam", graduation_year=get_senior_graduation_year()
+        )[0]
+        senior = Senior.objects.get_or_create(user=user, major="Computer Science")[0]
+
+        response = self.client.get(reverse("seniors"))
+        self.assertEqual(200, response.status_code)
+        self.assertIn(senior, response.context["seniors"])
+
+        # Log in as the senior
+        self.login(f"{get_senior_graduation_year()}awilliam")
+
+        response = self.client.get(reverse("seniors"))
+        self.assertEqual(200, response.status_code)
+        self.assertIn(senior, response.context["seniors"])
+        self.assertTrue(response.context["is_senior"])
+        self.assertEqual(senior, response.context["own_senior"])
+
+        # Clean up
+        user.handle_delete()
+        user.delete()
+
+    def test_seniors_add_view(self):
+        """Tests the seniors_add_view, the view for seniors to enter their destination info."""
+        self.login()
+
+        # I am not a senior, so this should fail
+        response = self.client.get(reverse("seniors_add"), follow=True)
+        self.assertEqual(200, response.status_code)
+        self.assertIn("You are not a senior, so you cannot submit destination information.", list(map(str, list(response.context["messages"]))))
+
+        # Log in as a senior
+        user = get_user_model().objects.get_or_create(
+            username=f"{get_senior_graduation_year()}awilliam", graduation_year=get_senior_graduation_year()
+        )[0]
+        self.login(f"{get_senior_graduation_year()}awilliam")
+
+        response = self.client.get(reverse("seniors_add"))
+        self.assertEqual(200, response.status_code)
+        self.assertNotIn("You are not a senior, so you cannot submit destination information.", list(map(str, list(response.context["messages"]))))
+        self.assertIsNone(response.context["senior"])
+
+        # Add a college
+        college = College.objects.create(name="CSL University", ceeb=1234)
+
+        # Add destination info
+        response = self.client.post(
+            reverse("seniors_add"),
+            data={
+                "college": college.id,
+                "college_sure": True,
+                "major": "Computer Science",
+                "major_sure": False,
+            },
+            follow=True,
+        )
+        self.assertEqual(200, response.status_code)
+
+        # Verify everything was set
+        senior = Senior.objects.get(user=user)
+        self.assertEqual(college, senior.college)
+        self.assertTrue(senior.college_sure)
+        self.assertEqual("Computer Science", senior.major)
+        self.assertFalse(senior.major_sure)
+
+        # Edit to make the major_sure True
+        response = self.client.get(reverse("seniors_add"))
+        self.assertEqual(200, response.status_code)
+        self.assertNotIn("You are not a senior, so you cannot submit destination information.", list(map(str, list(response.context["messages"]))))
+        self.assertEqual(senior, response.context["senior"])
+
+        response = self.client.post(
+            reverse("seniors_add"),
+            data={
+                "college": college.id,
+                "college_sure": True,
+                "major": "Computer Science",
+                "major_sure": True,
+            },
+            follow=True,
+        )
+        self.assertEqual(200, response.status_code)
+
+        # Verify everything was set
+        senior = Senior.objects.get(user=user)
+        self.assertEqual(college, senior.college)
+        self.assertTrue(senior.college_sure)
+        self.assertEqual("Computer Science", senior.major)
+        self.assertTrue(senior.major_sure)
+
+
+class SeniorsCommandsTestCase(IonTestCase):
+
+    """Test cases for the commands to manage the seniors app."""
+
+    def test_import_colleges(self):
+        """Tests the import_colleges command."""
+        file_contents = "1234,Computer Systems Lab University,Alexandria,Virginia\n1235,Other University,Anytown,Virginia"
+        with patch("intranet.apps.seniors.management.commands.import_colleges.open", mock_open(read_data=file_contents)) as m:
+            call_command("import_colleges")
+
+        m.assert_called_with("ceeb.csv", "r")
+        self.assertEqual(1, College.objects.filter(ceeb=1234, name="Computer Systems Lab University - Alexandria, Virginia").count())
+        self.assertEqual(1, College.objects.filter(ceeb=1235, name="Other University - Anytown, Virginia").count())

--- a/intranet/apps/sessionmgmt/tests.py
+++ b/intranet/apps/sessionmgmt/tests.py
@@ -1,3 +1,19 @@
-from django.test import TestCase  # pylint: disable=unused-import # noqa
+from django.urls import reverse
 
-# Create your tests here.
+from ...test.ion_test import IonTestCase
+
+
+class SessionMgmtTestCase(IonTestCase):
+    def test_index_view(self):
+        self.login()
+        response = self.client.get(reverse("sessionmgmt"))
+        self.assertEqual(200, response.status_code)
+
+    def test_global_logout_view(self):
+        self.login()
+        response = self.client.post(reverse("global_logout"), data={"global_logout": "GLOBAL_LOGOUT"}, follow=True)
+        self.assertEqual(200, response.status_code)
+
+        # A test to see if we're on the login page
+        self.assertIn("Login", str(response.content))
+        self.assertIn("js/login.js", str(response.content))

--- a/intranet/apps/signage/tests.py
+++ b/intranet/apps/signage/tests.py
@@ -1,0 +1,74 @@
+import datetime
+
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+from django.urls import reverse
+from django.utils import timezone
+
+from ...test.ion_test import IonTestCase
+from ...utils import helpers
+from ..eighth.models import EighthBlock
+from .models import Sign
+from .views import check_internal_ip
+
+
+class SignageTestCase(IonTestCase):
+    def test_check_internal_ip(self):
+        with self.settings(INTERNAL_IPS=helpers.GlobList(["165.45.34.0/24"])):  # arbitrary
+            factory = RequestFactory()
+            request = factory.get("/signage/display/cs-nobel/", REMOTE_ADDR="165.45.34.120")
+            request.user = AnonymousUser()
+            response = check_internal_ip(request)
+
+            self.assertIsNone(response)
+
+            request = factory.get("/signage/display/cs-nobel/", REMOTE_ADDR="165.45.36.120")
+            request.user = AnonymousUser()
+            response = check_internal_ip(request)
+
+            self.assertIsNotNone(response)
+
+    def test_signage_display(self):
+        self.login()
+
+        response = self.client.get(reverse("signage_display", kwargs={"display_id": "nobel"}))
+        self.assertEqual(404, response.status_code)
+
+        sign = Sign.objects.create(name="Nobel Commons", display="nobel")
+
+        response = self.client.get(reverse("signage_display", kwargs={"display_id": "nobel"}))
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(sign, response.context["sign"])
+
+    def test_eighth(self):
+        self.login()
+
+        response = self.client.get(reverse("eighth"))
+        self.assertEqual(404, response.status_code)  # There is no eighth period block scheduled.
+
+        block_a = EighthBlock.objects.create(date=datetime.date.today() + datetime.timedelta(days=1), block_letter="A")
+        block_b = EighthBlock.objects.create(date=datetime.date.today() + datetime.timedelta(days=1), block_letter="B")
+
+        response = self.client.get(reverse("eighth"))
+        self.assertEqual(200, response.status_code)
+
+        self.assertEqual(block_a, response.context["active_block"])
+        self.assertEqual(block_b, response.context["next_block"])
+
+    def test_prometheus_metrics(self):
+        user = self.login()
+        user.is_superuser = True
+        user.save()
+
+        response = self.client.get(reverse("prometheus_metrics"))
+        self.assertEqual(200, response.status_code)
+
+        Sign.objects.create(name="Nobel Commons", display="nobel", latest_heartbeat_time=timezone.localtime())
+        Sign.objects.create(name="Curie Commons", display="curie", latest_heartbeat_time=timezone.localtime() - datetime.timedelta(days=50))
+
+        response = self.client.get(reverse("prometheus_metrics"))
+        self.assertEqual(200, response.status_code)
+        self.assertIn('intranet_signage_sign_is_online{display="nobel"} 1', response.content.decode("UTF-8"))
+        self.assertIn('intranet_signage_sign_is_online{display="curie"} 0', response.content.decode("UTF-8"))
+
+        self.assertIn("intranet_signage_num_signs_online 1", response.content.decode("UTF-8"))

--- a/intranet/test/ion_test.py
+++ b/intranet/test/ion_test.py
@@ -15,6 +15,15 @@ class IonTestCase(TestCase):
         super().tearDownClass()
 
     def login(self, username: str = "awilliam") -> User:
+        """
+        Log the test client in as the given user.
+
+        Args:
+            username: the username to log in as
+
+        Return:
+            the ``User`` object corresponding to ``username``
+        """
         # We need to add the user to the db before trying to login as them.
         user = get_user_model().objects.get_or_create(username=username)[0]
         with self.settings(MASTER_PASSWORD="pbkdf2_sha256$24000$qp64pooaIEAc$j5wiTlyYzcMu08dVaMRus8Kyfvn5ZfaJ/Rn+Z/fH2Bw="):
@@ -22,6 +31,16 @@ class IonTestCase(TestCase):
         return user
 
     def make_admin(self, username: str = "awilliam") -> User:
+        """
+        Log in the test client as the given user, and make that
+        user an admin (i.e. give it the admin_all group).
+
+        Args:
+            username: the username to log in as and make an admin
+
+        Return:
+            the ``User`` object corresponding to ``username``
+        """
         user = self.login(username=username)
         # Make user an eighth admin
         group = Group.objects.get_or_create(name="admin_all")[0]


### PR DESCRIPTION
## Proposed changes
- Add unit tests for these apps
  - `seniors`
  - `search`
  - `error`
  - `sessionmgmt`
  - `signage`
- Add docstrings/typing hints to `ion_test.py` and `intranet.apps.signage.views`