### PR TITLE
fix(events): fix home template

### DIFF
--- a/intranet/templates/events/event.html
+++ b/intranet/templates/events/event.html
@@ -39,7 +39,7 @@
                     <a href="{% url 'event' event.id %}" title="Event permalink">
                         <i class="fas fa-share-square"></i>
                     </a>
-                {% if events_admin %}
+                {% if is_events_admin %}
                     <a href="{% url 'modify_event' event.id %}">
                         <i class="event-icon fas fa-pencil-alt"></i>
                     </a>


### PR DESCRIPTION
## Brief description of rationale
The edit button doesn't actually show up because context passes `is_events_admin` and this was looking for `events_admin`.