### PR TITLE
fix(eighth): fix disappearing name on take attendance view

### DIFF
--- a/intranet/static/css/page_base.scss
+++ b/intranet/static/css/page_base.scss
@@ -367,6 +367,10 @@ ul.dropdown-menu.absence-notification {
     margin: 0 3px;
 }
 
+.user-name-eighth {
+    margin: 0 3px;
+}
+
 .nav {
     width: 73px;
     border: 1px solid rgb(216, 216, 216);

--- a/intranet/templates/eighth/take_attendance.html
+++ b/intranet/templates/eighth/take_attendance.html
@@ -56,7 +56,7 @@
             var student_list = [];
             var mem_list = $('.bbcu-selector');
             for (var i = 0; i < mem_list.length; i++) {
-                var name = $(mem_list[i]).find(".user-name")[0].innerText.split(" ").slice(0, 2).join(" ");
+                var name = $(mem_list[i]).find(".user-name-eighth")[0].innerText.split(" ").slice(0, 2).join(" ");
                 var email = $(mem_list[i]).find(".id")[0].innerText + "@fcpsschools.net";
                 student_list.push([name, email]);
             }
@@ -309,7 +309,7 @@
                             {% for pass in passes %}
                             <tr class="bbcu-selector">
                                 <td class="user-link" data-user-id="{{ pass.user.id }}">
-                                    <a href="{% url 'user_profile' pass.user.id %}" class="user-name">
+                                    <a href="{% url 'user_profile' pass.user.id %}" class="user-name-eighth">
                                         {{ pass.user.last_name }}, {{ pass.user.first_name }}
                                     </a>
                                 </td>
@@ -418,7 +418,7 @@
                                             {% endif %}
                                     {% endif %}
                                     <td class="user-col user-link" data-user-id="{{ member.id }}">
-                                        <a class="user-name" href="{% url 'user_profile' member.id %}">
+                                        <a class="user-name-eighth" href="{% url 'user_profile' member.id %}">
                                             {{ member.name }}
                                         </a>
                                     </td>


### PR DESCRIPTION
Fixes #1048

## Proposed changes

Fix the "disappearing name" on the take attendance view

The issue, I believe, is with [this line](https://github.com/tjcsl/ion/blob/master/intranet/static/css/responsive.core.scss#L183); it is hiding anything with the class `user-name`. The user dropdown menu in the top right has shows your name with the class `user-name`. But, the table also uses the class `user-name` for the names of users, and thus those names disappear too.

## Brief description of rationale

Self explanatory