### PR TITLE
fix(templates): clean up hoco ribbon

### DIFF
--- a/intranet/templates/special/hoco_ribbon.html
+++ b/intranet/templates/special/hoco_ribbon.html
@@ -20,7 +20,7 @@
 
       <div class="ribbon-3">
         <span class="inner">
-          <span class="fadeLeft"><a href="https://homecoming.tjhsst.edu/" target="_blank" rel="noopener noreferrer">https://homecoming.tjhsst.edu/</a></span>
+          <span class="fadeLeft"><a href="https://homecoming.tjhsst.edu/" target="_blank" rel="noopener noreferrer">homecoming.tjhsst.edu</a></span>
         </span>
       </div>
 


### PR DESCRIPTION
## Proposed changes
- Removes the `https://` prefix and the trailing slash from the URL to `homecoming.tjhsst.edu` in the homecoming "ribbon", as shown below

![image](https://user-images.githubusercontent.com/3579871/113653750-6c221100-9664-11eb-961b-9a422b81a509.png)

## Brief description of rationale
It looks better