### PR TITLE
Character rendering + Pylint fix

### DIFF
--- a/intranet/apps/eighth/forms/admin/scheduling.py
+++ b/intranet/apps/eighth/forms/admin/scheduling.py
@@ -50,3 +50,12 @@ class ScheduledActivityForm(forms.ModelForm):
             "comments": forms.Textarea(attrs={"rows": 2, "cols": 30}),
             "admin_comments": forms.Textarea(attrs={"rows": 2, "cols": 30}),
         }
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        cleaned_data["title"] = cleaned_data["title"].replace("\\", "/")
+        cleaned_data["comments"] = cleaned_data["comments"].replace("\\", "/")
+        cleaned_data["admin_comments"] = cleaned_data["admin_comments"].replace("\\", "/")
+
+        return cleaned_data

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -478,9 +478,7 @@ class User(AbstractBaseUser, PermissionsMixin):
             if self.user_type == "teacher":
                 current_grade = 12
             else:
-                current_grade = int(self.grade)
-                if current_grade > 12:
-                    current_grade = 12
+                current_grade = min(int(self.grade), 12)
             for i in reversed(range(9, current_grade + 1)):
                 data = None
                 if self.photos.filter(grade_number=i).exists():


### PR DESCRIPTION
## Proposed changes
- Replace backslashes with forward slashes in `title`, `comments` and `admin_comments` fields.
- Make minor formatting changes to align with new pylint standards

## Brief description of rationale
This issue was reported by 8PO. Essentially, JSON does a really bad job of handling backslashes with any sort of variability in format. There is no case in entering titles or comments where a backslash is needed -- forward slashes work just as well -- so we can just replace the backslashes.

For pylint, it was complaining about not using `with` to open files in `files.views` and not using `min()` in users.models.