### PR TITLE
fix(eighth): use get_true_rooms when filtering

### DIFF
--- a/intranet/apps/eighth/views/admin/rooms.py
+++ b/intranet/apps/eighth/views/admin/rooms.py
@@ -254,7 +254,10 @@ def room_utilization_action(request, start_id, end_id):
         sched_acts = sorted(sched_acts, key=lambda x: ("{}".format(x.block), "{}".format(x.get_true_rooms())))
 
         if show_all_rooms or show_available_for_eighth:
-            unused = rooms.exclude(Q(eighthscheduledactivity__in=sched_acts) | Q(eighthactivity__eighthscheduledactivity__in=sched_acts))
+            used_rooms_ids = []
+            for s in sched_acts:
+                used_rooms_ids.extend([r.id for r in s.get_true_rooms()])
+            unused = rooms.exclude(id__in=used_rooms_ids)
             for room in unused:
                 sched_acts.append({"room": room, "empty": True})
 


### PR DESCRIPTION
## Brief description of rationale
When using the Room Utilization function in the Eighth Admin dashboard, the logic filters out all room associated with an activity, not just those in use on that particular day. For instance, if Sysadmins was usually held in Room 1 and the Sysadmins `EighthActivity` had Room 1 listed, but then the activity had been overridden to happen in Room 2 at the `ScheduledEighthActivity` level, Room 1 wouldn't show up as open. 