### PR TITLE
fix(vagrant): remove unnecessary VirtualBox GUI

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -62,7 +62,7 @@ Vagrant.configure("2") do |config|
     vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
     vb.name = "ion-vagrant"
     vb.memory = 2048 # the default of 512 gives us a OOM during setup.
-    vb.gui = true
+    vb.gui = false
   end
 
 


### PR DESCRIPTION
## Brief description of rationale
This has been repeatedly mentioned and no one got around to doing it. As far as I can tell, the VirtualBox GUI serves no purpose for the Ion development environment, so it seems best to just get rid of it.