### PR TITLE
chore(dashboard): refresh links

### DIFF
--- a/intranet/templates/dashboard/links.html
+++ b/intranet/templates/dashboard/links.html
@@ -11,39 +11,36 @@
       <tr>
         <td>
           <h5 class="link-heading">Organizations</h5>
+          <a href="https://sysadmins.tjhsst.edu/">tjCSL</a><br>
           <a href="https://tjsths.rschoolteams.com/">TJ Athletics</a><br>
           <a href="https://sga.tjhsst.edu">TJ SGA</a><br>
+          <a href="http://tjtoday.org/">tjToday</a><br>
 
           <h5 class="link-heading">Reporting an Issue</h5>
-          <a href="https://tjhsst.fcps.edu/about/tjhsst-honor-code">Academic Integrity</a><br>
+          <a href="mailto:sysadmins@tjhsst.edu">Report a Bug in the CSL</a><br>
           <a href="https://docs.google.com/forms/d/e/1FAIpQLSdtutcsGAdQU9lkSuHrMssKpH0uub7haC7L490Xd17jFJnhug/viewform">Submit an Integrity Violation</a><br>
           <a href="https://goo.gl/forms/HnhJoUkuD9lzdwX72">Submit a Safety Concern</a><br>
-          <a href="/uploads/StudentAdvocacyGuide2021.pdf">Student Advocacy</a><br>
-
-          <h5 class="link-heading">Student News</h5>
-          <a href="https://docs.google.com/forms/d/e/1FAIpQLSfNEd_tC9qjZF5bbVPg3k4XLu8qkxFswtMWSdEcBalsFUmcSg/viewform">Morning Announcements</a><br>
-          <a href="http://tjtoday.org/">tjToday</a><br>
 
           <h5 class="link-heading">Tutorials</h5>
           <a href="https://guides.tjhsst.edu/webmail/forwarding-email">TJ Email Forwarding</a><br>
+          <a href="https://guides.tjhsst.edu/research/mathematica">Mathematica</a><br>
           <a href="https://www.fcps.edu/resources/technology/bring-your-own-device-byod/bring-your-own-device-byod-configuration-guides">Wi-Fi FAQ</a><br>
         </td>
         <td>
-          <h5 class="link-heading">CSL</h5>
-          <a href="mailto:sysadmins@tjhsst.edu">Report a Bug in the CSL</a><br>
-          <a href="https://sysadmins.tjhsst.edu/">Student Sysadmins</a><br>
-          <a href="https://blog.tjhsst.edu/">tjCSL Blog</a>
-
-          <h5 class="link-heading">Resources</h5>
-          <a href="https://fcps.blackboard.com">Blackboard</a><br>
-          <a href="https://sites.google.com/fcpsschools.net/tjlibraryresources/home">Library Resources</a><br>
-          <a href="https://tjhsst.fcps.edu/events">Events</a><br>
-          <a href="https://tjhsst.fcps.edu/student-services/college-and-career-center">College/Career Center</a><br>
-          <a href="https://guides.tjhsst.edu/research/mathematica">Mathematica</a><br>
+          <h5 class="link-heading">TJ Resources</h5>
           <a href="https://webmail.tjhsst.edu/">Webmail</a><br>
+          <a href="https://lms.fcps.edu/">Schoology</a><br>
+          <a href="https://studyguides.sites.tjhsst.edu">SGA Study Guides</a><br>
+          <a href="https://docs.google.com/forms/d/e/1FAIpQLSfNEd_tC9qjZF5bbVPg3k4XLu8qkxFswtMWSdEcBalsFUmcSg/viewform">Submit TJTV Announcement</a><br>
+          <a href="https://sites.google.com/fcpsschools.net/tjlibraryresources/home">Library</a><br>
+
+          <h5 class="link-heading">FCPS Resources</h5>
+          <a href="https://tjhsst.fcps.edu/about/tjhsst-honor-code">Academic Integrity</a><br>
+          <a href="/uploads/StudentAdvocacyGuide2021.pdf">Student Advocacy</a><br>
           <a href="/uploads/PreArrangedAbsenceForm.pdf">Pre-Arranged Absence Form</a><br>
           <a href="https://tjhsst.fcps.edu/resources/challenge-success-tjhsst">Challenge Success</a><br>
-          <a href="https://studyguides.sites.tjhsst.edu">SGA Study Guides Site</a>
+          <a href="https://tjhsst.fcps.edu/student-services/college-and-career-center">College/Career Center</a><br>
+          <a href="https://tjhsst.fcps.edu/events">Events</a><br>
 
         </td>
       </tr>


### PR DESCRIPTION
closes #608

Because the current categories do not make sense and we don't need a link to blackboard anymore.