### PR TITLE
fix(events): catch all errors

### DIFF
--- a/intranet/apps/events/tasks.py
+++ b/intranet/apps/events/tasks.py
@@ -84,5 +84,5 @@ def pull_sports_schedules(month=None) -> None:
                 open_to="everyone",
                 time=time,
             )
-        except [ValueError, AssertionError]:
-            pass
+        except (ValueError, AssertionError) as e:
+            print(e)


### PR DESCRIPTION
## Brief description of rationale
python3 throws a weird syntax error when using a list over a tuple and excluding the `as e`, so I fixed that.