### PR TITLE
build(deps): update to django3

### DIFF
--- a/Ion.egg-info/requires.txt
+++ b/Ion.egg-info/requires.txt
@@ -11,7 +11,7 @@ channels-redis==3.2.0
 contextlib2==0.6.0.post1
 cryptography==3.4.7
 decorator==5.0.9
-Django==2.2.24
+Django==3.2.6
 django-cacheops==6.0
 django-cors-headers==3.7.0
 django-debug-toolbar==3.2.1

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -11,7 +11,7 @@ channels-redis==3.2.0
 contextlib2==0.6.0.post1
 cryptography==3.4.7
 decorator==5.0.9
-Django==2.2.24
+Django==3.2.6
 django-cacheops==6.0
 django-cors-headers==3.7.0
 django-debug-toolbar==3.2.1

--- a/intranet/apps/auth/__init__.py
+++ b/intranet/apps/auth/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "intranet.apps.auth.apps.AuthConfig"

--- a/intranet/routing.py
+++ b/intranet/routing.py
@@ -8,6 +8,7 @@ from channels.auth import AuthMiddlewareStack
 from channels.generic.websocket import WebsocketConsumer
 from channels.routing import ProtocolTypeRouter, URLRouter
 
+from django.core.asgi import get_asgi_application
 from django.urls import re_path
 
 from .apps.bus.consumers import BusConsumer
@@ -28,6 +29,7 @@ class WebsocketCloseConsumer(WebsocketConsumer):
 
 application = ProtocolTypeRouter(
     {
+        "http": get_asgi_application(),
         "websocket": AuthMiddlewareStack(
             URLRouter(
                 [
@@ -37,6 +39,6 @@ application = ProtocolTypeRouter(
                     re_path(r"^.*$", WebsocketCloseConsumer.as_asgi()),
                 ]
             )
-        )
+        ),
     }
 )

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,6 @@ python_files = tests.py test_*.py
 filterwarnings = error
 # Suppress an pysftp warning about not having any ssh known_hosts.
   ignore:Failed to load HostKeys:UserWarning:pysftp
+# Suppress a warning caused by third party libraries
+  ignore::django.utils.deprecation.RemovedInDjango40Warning
+  ignore::django.utils.deprecation.RemovedInDjango41Warning

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ channels-redis==3.2.0
 contextlib2==0.6.0.post1
 cryptography==3.4.7
 decorator==5.0.9
-Django==2.2.24
+Django==3.2.6
 django-cacheops==6.0
 django-cors-headers==3.7.0
 django-debug-toolbar==3.2.1


### PR DESCRIPTION
`django-prometheus`, `django-cacheops`, `django-debug-toolbar` and `django-oauth-toolkit` haven't updated to remove some depreciation, but that doesn't actually become an issue until django 4. Because of this however, we have to mute the depreciation warnings in pytest.

I went over the changelogs pretty thoroughly and I'd like to put this in this weekend, after deploying it to `ion-dev`, but please see if I've missed anything.

E: to be clear, still very much testing this
