### PR TITLE
docs: update docs site theme and info

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -54,7 +54,6 @@ docs/rtd-requirements.txt
 docs/_ext/djangodocs.py
 docs/_static/custom.css
 docs/_templates/relations.html
-docs/administration/index.rst
 docs/architecture/index.rst
 docs/developing/eighth-models.rst
 docs/developing/howto.rst

--- a/docs/administration/index.rst
+++ b/docs/administration/index.rst
@@ -1,9 +1,0 @@
-**************
-Administration
-**************
-
-Running manage.py
-=================
-
-Note that when running `./manage.py` in production you must first export `PRODUCTION=TRUE`.
-Otherwise you will not be able to connect to the database.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,7 +143,7 @@ html_theme_options = {
     # such as "amelia" or "cosmo".
     #
     # Note that this is served off CDN, so won't be available offline.
-    "bootswatch_theme": "",
+    "bootswatch_theme": "pulse",
     "bootstrap_version": "3",
 }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,6 @@ Contents
     architecture/index
     developing/index
     sourcedoc/modules
-    administration/index
 
 Setup
 -----


### PR DESCRIPTION
closes #718

## Brief description of rationale
It's really ugly and not fun to look at now. Also, the administration docs were for the old deployment model. I elected to remove instead of replacing those because information on managing the production deployment doesn't need to be public.