### PR TITLE
fix(events): make attend function work

### DIFF
--- a/Ion.egg-info/SOURCES.txt
+++ b/Ion.egg-info/SOURCES.txt
@@ -1006,6 +1006,7 @@ intranet/static/js/busdriver.js
 intranet/static/js/common.header.js
 intranet/static/js/common.js
 intranet/static/js/common.nav.js
+intranet/static/js/events.js
 intranet/static/js/features.js
 intranet/static/js/files.js
 intranet/static/js/hoco_ribbon.js

--- a/intranet/static/js/events.js
+++ b/intranet/static/js/events.js
@@ -1,0 +1,10 @@
+$(function() {
+    $(".attend-button").click(function() {
+        var eventid = $(this).attr("data-form-attend");
+        $("form[data-form-attend=" + eventid + "]").submit();
+    });
+    $(".no-attend-button").click(function() {
+        var eventid = $(this).attr("data-form-no-attend");
+        $("form[data-form-no-attend=" + eventid + "]").submit();
+    });
+});

--- a/intranet/templates/dashboard/dashboard.html
+++ b/intranet/templates/dashboard/dashboard.html
@@ -31,6 +31,7 @@
 
     <script src="{% static 'js/dashboard/eighth-widget.js' %}"></script>
     <script src="{% static 'js/schedule.js' %}"></script>
+    <script src="{% static 'js/events.js' %}"></script>
     <script src="{% static 'js/dashboard/common.js' %}"></script>
     <script src="{% static 'js/dashboard/announcements.js' %}"></script>
     <script src="{% static 'js/dashboard/events.js' %}"></script>

--- a/intranet/templates/events/event.html
+++ b/intranet/templates/events/event.html
@@ -75,17 +75,16 @@
         <div class="event-content">
             {{ event.description|safe }}
         </div>
-        {% if show_attend %}
-            <form action="{% url 'join_event' event.id %}" method="post" name="no-attend-form-{{ event.id }}">
+
+            <form action="{% url 'join_event' event.id %}" method="post" data-form-no-attend="{{ event.id }}" name="no-attend-form-{{ event.id }}">
                 {% csrf_token %}
                 <input type="hidden" name="attending" value="false">
             </form>
 
-            <form action="{% url 'join_event' event.id %}" method="post" name="attend-form-{{ event.id }}">
+            <form action="{% url 'join_event' event.id %}" method="post" data-form-attend="{{ event.id }}" name="attend-form-{{ event.id }}">
                 {% csrf_token %}
                 <input type="hidden" name="attending" value="true">
             </form>
-        {% endif %}
 
         {% if is_events_admin %}
             <table class="event-approve-table">
@@ -117,35 +116,35 @@
         {% endif %}
 
         {% if event.show_attending %}
-        <div class="bottom-row{% if show_attend %} show-attend{% endif %}">
+        <div class="bottom-row show-attend">
             <span class="signup-status">
                 People attending: {{ event.attending.count }}
-                {% if show_attend %}
+
                 <a href="{% url 'event_roster' event.id %}" class="button small-button view-roster-button">
                     View Roster
                 </a>
-                {% endif %}
+
             </span>
 
             {% if request.user in event.attending.all %}
                 <span class="attend-status">
                     You are <b style="color: green">attending</b> this event.
-                    {% if show_attend %}
-                        <a href="#" data-form-submit="no-attend-form-{{ event.id }}" class="button small-button no-attend-button">
+
+                        <a href="#" data-form-no-attend="{{ event.id }}" class="button small-button no-attend-button">
                             <i class="fas fa-times"></i>
                             Don't Attend
                         </a>
-                    {% endif %}
+
                 </span>
             {% else %}
                 <span class="attend-status">
                     You are <b style="color: red">not attending</b> this event.
-                    {% if show_attend %}
-                        <a href="#" data-form-submit="attend-form-{{ event.id }}" class="button small-button attend-button">
+
+                        <a href="#" data-form-attend="{{ event.id }}" class="button small-button attend-button">
                             <i class="fas fa-check"></i>
                             Attend
                         </a>
-                    {% endif %}
+
                 </span>
             {% endif %}
         </div>

--- a/intranet/templates/events/home.html
+++ b/intranet/templates/events/home.html
@@ -14,6 +14,7 @@
 
 {% block js %}
     {{ block.super }}
+    <script src="{% static 'js/events.js' %}"></script>
 {% endblock %}
 
 {% block head %}


### PR DESCRIPTION
## Proposed changes
- Makes the attend/don't attend event button work.
- The attend button is not part of the attend event form, but is a separate `a` element, which is why it does not work.
- Uses JavaScript to submit the attend form when the attend button is clicked, fixing the issue. 
- Also makes the attend button show up on the dashboard.

## Brief description of rationale
- Currently, the attend event button doesn't do anything when clicked.
- See, for example, https://ion.tjhsst.edu/events/784
- The button also doesn't currently show up on the dashboard. Allowing people to mark as attending from the announcement post increases visibility.
- In the future, might want to look into making the attend button `<input type="submit">` to eliminate need for JS. However, this could create formatting issues which is why I chose to keep it where it is for now. 