### PR TITLE
fix(events): integration with dashboard, special event display

### DIFF
--- a/intranet/apps/events/views.py
+++ b/intranet/apps/events/views.py
@@ -184,9 +184,9 @@ def events_view(request):
     this_week = (delta, delta + timezone.timedelta(days=7))
     this_month = (this_week[1], this_week[1] + timezone.timedelta(days=31))
 
-    def has_attending_event(events):
+    def has_special_event(events):
         for event in events:
-            if event.show_attending or event.scheduled_activity or event.announcement:
+            if event.show_attending or event.scheduled_activity or event.announcement or event.show_on_dashboard:
                 return True
         return False
 
@@ -199,7 +199,7 @@ def events_view(request):
         events_categories.append(
             {"title": "Week and month",
              "events": viewable_events.filter(time__gte=this_week[0], time__lt=this_month[1]),
-             "has_attending_event": has_attending_event(viewable_events.filter(time__gte=this_week[0], time__lt=this_month[1])), }, )
+             "has_special_event": has_special_event(viewable_events.filter(time__gte=this_week[0], time__lt=this_month[1])), }, )
 
     if is_events_admin:
         unapproved_events = Event.objects.filter(approved=False, rejected=False).prefetch_related("groups")
@@ -218,7 +218,7 @@ def events_view(request):
         "num_events": num_events,
         "is_events_admin": is_events_admin,
         "show_attend": True,
-        "show_icon": True,
+        "show_icon": False,
         "show_all": show_all,
         "classic": classic,
     }

--- a/intranet/templates/dashboard/dashboard.html
+++ b/intranet/templates/dashboard/dashboard.html
@@ -184,7 +184,7 @@
                     {% include "announcements/announcement.html" %}
                 {% endwith %}
             {% elif item.dashboard_type == "event" %}
-                {% with event=item show_icon=True %}
+                {% with event=item show_date_icon=True %}
                     {% include "events/event.html" %}
                 {% endwith %}
             {% endif %}

--- a/intranet/templates/events/event.html
+++ b/intranet/templates/events/event.html
@@ -4,7 +4,7 @@
 
 <div class="event{% if hide_events and event.id in user_hidden_events %} hidden{% endif %}" data-id="{{ event.id }}">
     <h3>
-        {% if show_icon and event.show_attending or event.scheduled_activity or event.announcement or not event.approved %}
+        {% if show_icon or show_date_icon or not event.approved %}
             <i class="far fa-calendar-alt dashboard-item-icon" title="Event"></i>
         {% endif %}
 
@@ -42,7 +42,7 @@
             by {{ event.user.full_name_nick|escape }} &bull;
         {% endif %}
 
-        {% if event.show_attending or event.scheduled_activity or event.announcement %}
+        {% if show_date_icon %}
             {{ event.time|date:"l, F j, Y"}}
         {% endif %}
 
@@ -119,7 +119,7 @@
             {% endif %}
         {% endif %}
 
-        {% if event.show_attending %}
+        {% if event.show_attending and not not_show_attend_form %}
         <div class="bottom-row show-attend">
             <span class="signup-status">
                 People attending: {{ event.attending.count }}

--- a/intranet/templates/events/home.html
+++ b/intranet/templates/events/home.html
@@ -73,7 +73,7 @@
                 </a>
             {% endif %}
 
-            {% if is_events_admin and not show_all %}
+            {% if not show_all %}
                 <a href="?show_all=1" class="button">
                     Show All
                 </a>
@@ -98,7 +98,7 @@
                 </a>
             {% endif %}
 
-            {% if not show_all %}
+            {% if not show_all and not classic %}
                 &nbsp;
                 <a id="month-button" class="button" href="#">Month</a>
                 <a id="week-button" class="button" href="#">Week</a>
@@ -107,7 +107,7 @@
 
         </div>
         <div class="events-container">
-            {% if show_all or classic %}
+        {% if show_all or classic %}
             <div class="events-container">
                 {% for category in events %}
                     {% if category.events %}
@@ -115,7 +115,9 @@
                     {% endif %}
 
                     {% for event in category.events %}
-                        {% include "events/event.html" %}
+                        {% with show_date_icon=True %}
+                            {% include "events/event.html" %}
+                        {% endwith %}
                     {% endfor %}
                 {% endfor %}
             </div>
@@ -124,18 +126,26 @@
                 {% if category.title == "Awaiting Approval" and category.events %}
                     <h2 class="category">{{ category.title }}:</h2>
                     {% for event in category.events %}
-                        {% include "events/event.html" %}
+
+                        {% with show_date_icon=True %}
+                            {% include "events/event.html" %}
+                        {% endwith %}
+
                     {% endfor %}
-                {% elif category.title == "Week and month" and category.events and category.has_attending_event %}
+                {% elif category.title == "Week and month" and category.events and category.has_special_event %}
                     <h2 class="category">Special:</h2>
                     {% for event in category.events %}
-                        {% if event.show_attending or event.scheduled_activity or event.announcement %}
-                            {% include "events/event.html" %}
+                        {% if event.show_attending or event.scheduled_activity or event.announcement or event.show_on_dashboard %}
+
+                            {% with show_date_icon=True %}
+                                {% include "events/event.html" %}
+                            {% endwith %}
+
                         {% endif %}
                     {% endfor %}
                 {% endif %}
             {% endfor %}
-            {% endif %}
+        {% endif %}
 
             {% if num_events == 0 %}
                 There are no events to display at this time.
@@ -145,7 +155,7 @@
             <br />
         </div>
 
-        {% if not show_all or classic %}
+        {% if not show_all and not classic %}
             <div class="events-container" id="view-div"></div>
         {% endif %}
 

--- a/intranet/templates/events/month.html
+++ b/intranet/templates/events/month.html
@@ -29,9 +29,11 @@
                     <h2 class="schedule-date">{{ day.events_ctx.date|date:"D, N j" }}</h2>
                     {% if day.events_ctx.has_events %}
                         {% for event in day.events_ctx.events %}
-                            {% if not event.show_attending and not event.scheduled_activity and not event.announcement %}
+
+                            {% with not_show_attend_form=True %}
                                 {% include "events/event.html" %}
-                            {% endif %}
+                            {% endwith %}
+
                         {% endfor %}
                     {% else %}
                         <b>No events.</b>

--- a/intranet/templates/events/week.html
+++ b/intranet/templates/events/week.html
@@ -21,9 +21,11 @@
                     <h2 class="schedule-date">{{ day.events_ctx.date|date:"D, N j" }}</h2>
                     {% if day.events_ctx.has_events %}
                         {% for event in day.events_ctx.events %}
-                            {% if not event.show_attending and not event.scheduled_activity and not event.announcement %}
+
+                            {% with not_show_attend_form=True %}
                                 {% include "events/event.html" %}
-                            {% endif %}
+                            {% endwith %}
+
                         {% endfor %}
                     {% else %}
                         <b>No events.</b>


### PR DESCRIPTION
## Proposed changes
- Shows the full date & time and events calendar icon if the event is shown on the dashboard. 
- Adds events in the "special" section to calendar (events that have the option checked for show attending, scheduled activity, announcement or show on dashboard). Not previously implemented due to styling issues. 

## Brief description of rationale
- If the event is shown on the dashboard, it should include which day the event is on instead of only the time (on the calendar view, it only shows time). 
- Icon is shown to match formatting on dashboard and hidden in calendar to save space. 