### PR TITLE
fix(events): show_all fix, mobile-friendly format

### DIFF
--- a/intranet/apps/events/tests.py
+++ b/intranet/apps/events/tests.py
@@ -22,7 +22,8 @@ class EventsTest(IonTestCase):
 
     def test_event_model(self):
         user = self.login()
-        event = self.create_random_event(user)
+        event = self.create_random_event(user, approved=True)
+        unapproved_event = self.create_random_event(user)
 
         # Check event properties
         self.assertTrue(event.is_this_year)
@@ -32,15 +33,15 @@ class EventsTest(IonTestCase):
         # Test creating/fetching EventUserMap
         self.assertFalse(EventUserMap.objects.exists())
         user_map = event.user_map
+
         # Test that EventUserMap was created
         self.assertTrue(EventUserMap.objects.filter(event=event).count(), 1)
         self.assertEqual(event.user_map, user_map)
 
         self.assertEqual(str(event.user_map), "UserMap: {}".format(event.title))
 
-        self.assertEqual("UNAPPROVED - {} - {}".format(event.title, event.time), str(event))
+        self.assertEqual("UNAPPROVED - {} - {}".format(unapproved_event.title, unapproved_event.time), str(unapproved_event))
 
-        event = self.create_random_event(user, approved=True)
         self.assertEqual("{} - {}".format(event.title, event.time), str(event))
 
         next_event = self.create_random_event(user, time=timezone.now() + timezone.timedelta(days=15))
@@ -63,7 +64,7 @@ class EventsTest(IonTestCase):
 
     def test_join_event(self):
         user = self.login()
-        event = self.create_random_event(user)
+        event = self.create_random_event(user, approved=True)
 
         # Test GET of valid event
         response = self.client.get(reverse("join_event", args=[event.id]))
@@ -99,7 +100,7 @@ class EventsTest(IonTestCase):
         # Test as a regular person
         user = self.login()
 
-        event = self.create_random_event(user)
+        event = self.create_random_event(user, approved=True)
 
         # Test with non-existent event
         response = self.client.get(reverse("event_roster", args=[9999]))

--- a/intranet/static/css/events.scss
+++ b/intranet/static/css/events.scss
@@ -23,6 +23,16 @@
     margin-top: -38px;
 }
 
+@media (max-width: 1080px) {
+    .button-container {
+      margin-top: auto;
+    }
+
+    .events-container > .event:nth-child(2) {
+        margin-top: 80px;
+    }
+}
+
 .event {
     background-color: white;
     -webkit-border-radius: 5px;

--- a/intranet/templates/events/event.html
+++ b/intranet/templates/events/event.html
@@ -123,11 +123,6 @@
         <div class="bottom-row show-attend">
             <span class="signup-status">
                 People attending: {{ event.attending.count }}
-
-                <a href="{% url 'event_roster' event.id %}" class="button small-button view-roster-button">
-                    View Roster
-                </a>
-
             </span>
 
             {% if request.user in event.attending.all %}

--- a/intranet/templates/events/home.html
+++ b/intranet/templates/events/home.html
@@ -73,7 +73,7 @@
                 </a>
             {% endif %}
 
-            {% if not show_all %}
+            {% if not show_all  and is_events_admin %}
                 <a href="?show_all=1" class="button">
                     Show All
                 </a>
@@ -99,7 +99,7 @@
             {% endif %}
 
             {% if not show_all and not classic %}
-                &nbsp;
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
                 <a id="month-button" class="button" href="#">Month</a>
                 <a id="week-button" class="button" href="#">Week</a>
                 &nbsp;
@@ -125,6 +125,7 @@
             {% for category in events %}
                 {% if category.title == "Awaiting Approval" and category.events %}
                     <h2 class="category">{{ category.title }}:</h2>
+
                     {% for event in category.events %}
 
                         {% with show_date_icon=True %}
@@ -132,8 +133,10 @@
                         {% endwith %}
 
                     {% endfor %}
+
                 {% elif category.title == "Week and month" and category.events and category.has_special_event %}
                     <h2 class="category">Special:</h2>
+
                     {% for event in category.events %}
                         {% if event.show_attending or event.scheduled_activity or event.announcement or event.show_on_dashboard %}
 
@@ -143,13 +146,10 @@
 
                         {% endif %}
                     {% endfor %}
+
                 {% endif %}
             {% endfor %}
         {% endif %}
-
-            {% if num_events == 0 %}
-                There are no events to display at this time.
-            {% endif %}
 
             <br />
             <br />

--- a/intranet/templates/events/join_event.html
+++ b/intranet/templates/events/join_event.html
@@ -61,7 +61,9 @@
         <br><br>
 
         <div class="events-container">
-            {% include "events/event.html" %}
+            {% with show_date_icon=True %}
+                {% include "events/event.html" %}
+            {% endwith %}
         </div>
     </div>
 {% endblock %}

--- a/intranet/templates/events/roster.html
+++ b/intranet/templates/events/roster.html
@@ -3,7 +3,7 @@
 {% load pipeline %}
 
 {% block title %}
-    {{ block.super }} - Event Roster
+    {{ block.super }} - Event Detail
 {% endblock %}
 
 {% block css %}
@@ -14,6 +14,7 @@
 
 {% block js %}
     {{ block.super }}
+    <script src="{% static 'js/events.js' %}"></script>
 {% endblock %}
 
 {% block head %}
@@ -29,7 +30,7 @@
     <div class="primary-content events">
 
         <div class="events-container">
-        {% with show_attend=1 %}
+        {% with show_attend=1 show_date_icon=True %}
             {% include "events/event.html" %}
         {% endwith %}
         </div>


### PR DESCRIPTION
## Proposed changes
- The show_all button is currently visible for all users, but only works for admins. Takes out the show_all button for non-admins. 
- More mobile-friendly format for events; the text is currently overlapping.
- Import JS to make attend button work on roster view. 
- Small content changes: remove "View Roster" button from the view roster page, remove redundant "no events" text. 