### PR TITLE
feat(events): responsive mobile calendar

### DIFF
--- a/intranet/apps/events/models.py
+++ b/intranet/apps/events/models.py
@@ -210,6 +210,13 @@ class Event(models.Model):
         except EventUserMap.DoesNotExist:
             return EventUserMap.objects.create(event=self)
 
+    @property
+    def happened(self):
+        """Return whether an event has happened."""
+        if self.time <= timezone.localtime():
+            return True
+        return False
+
     def __str__(self):
         if not self.approved:
             return "UNAPPROVED - {} - {}".format(self.title, self.time)

--- a/intranet/static/css/events.scss
+++ b/intranet/static/css/events.scss
@@ -23,13 +23,58 @@
     margin-top: -38px;
 }
 
+.button-subcontainer {
+    display: inline-block;
+    margin-right: 5px;
+}
+
 @media (max-width: 1080px) {
     .button-container {
       margin-top: auto;
+      margin-bottom: 5px;
+    }
+    .arrow-container {
+        margin-bottom: -20px !important;
     }
 
     .events-container > .event:nth-child(2) {
-        margin-top: 80px;
+        margin-top: 43px;
+        @media (max-width: 387px) {
+            margin-top: 80px;
+        }
+    }
+
+    .week-only {
+        position: relative;
+        right: 8.5%;
+
+        & > tbody > tr > td {
+            display: block;
+            border-bottom: 1px solid lightgrey;
+            padding: 20px 0 !important;
+            width: 120%;
+
+            &:first-child {
+                border-top: 1px solid lightgrey;
+            }
+        }
+    }
+
+    .week-table {
+        min-width: auto !important;
+        width: 100% !important;
+    }
+
+    .month-table {
+        min-width: 1680px !important;
+    }
+
+    td.cell-filler {
+        width: 0 !important;
+    }
+
+    .schedule {
+        overflow-x: auto;
     }
 }
 

--- a/intranet/static/js/events.js
+++ b/intranet/static/js/events.js
@@ -8,3 +8,65 @@ $(function() {
         $("form[data-form-no-attend=" + eventid + "]").submit();
     });
 });
+
+function toggleTouchEvents(viewName) {
+    if(viewName === "month") {
+        $(window).off("touchstart");
+    }
+    else {
+        var initX = null,
+        initY = null,
+        listening = false;
+
+        $(window).on({
+            touchstart(e) {
+                initX = e.originalEvent.touches[0].clientX;
+                initY = e.originalEvent.touches[0].clientY;
+                listening = true;
+            },
+            touchend(e) {
+                listening = false;
+            },
+            /* eslint-disable complexity */
+            touchmove(e) {
+                if (!listening) {
+                    return;
+                }
+                var nowX = e.originalEvent.touches[0].clientX,
+                    nowY = e.originalEvent.touches[0].clientY;
+
+                if (Math.abs(nowY - initY) > 30) {
+                    listening = false;
+                    return;
+                }
+
+                var diffX = nowX - initX;
+                var nav, g, shown;
+
+                if (Math.abs(diffX) > 30) {
+                    nav = $(".main > .nav").eq(0);
+                    g = $(".nav-g");
+                    shown = nav.css("left").split(/[^\-\d]+/)[0] === "0";
+
+                    if (diffX > 0 && !shown) {
+                        nav.animate({
+                            left: "0"
+                        }, 200);
+                        g.addClass("close-l").fadeIn(200);
+                        $("body").addClass("disable-scroll").addClass("mobile-nav-show");
+                        $(".c-hamburger").addClass("is-active");
+                        listening = false;
+                    } else if (diffX < 0 && shown) {
+                        nav.animate({
+                            left: "-202px"
+                        }, 200);
+                        g.removeClass("close-l").fadeOut(200);
+                        $("body").removeClass("disable-scroll").removeClass("mobile-nav-show");
+                        $(".c-hamburger").removeClass("is-active");
+                        listening = false;
+                    }
+                }
+            }
+        });
+    }
+}

--- a/intranet/templates/events/event.html
+++ b/intranet/templates/events/event.html
@@ -83,17 +83,17 @@
         <div class="event-content" style="font-size:14px;">
             {{ event.description|safe }}
         </div>
+        {% if not event.happened %}
+            <form action="{% url 'join_event' event.id %}" method="post" data-form-no-attend="{{ event.id }}" name="no-attend-form-{{ event.id }}">
+                {% csrf_token %}
+                <input type="hidden" name="attending" value="false">
+            </form>
 
-        <form action="{% url 'join_event' event.id %}" method="post" data-form-no-attend="{{ event.id }}" name="no-attend-form-{{ event.id }}">
-            {% csrf_token %}
-            <input type="hidden" name="attending" value="false">
-        </form>
-
-        <form action="{% url 'join_event' event.id %}" method="post" data-form-attend="{{ event.id }}" name="attend-form-{{ event.id }}">
-            {% csrf_token %}
-            <input type="hidden" name="attending" value="true">
-        </form>
-
+            <form action="{% url 'join_event' event.id %}" method="post" data-form-attend="{{ event.id }}" name="attend-form-{{ event.id }}">
+                {% csrf_token %}
+                <input type="hidden" name="attending" value="true">
+            </form>
+        {% endif %}
         {% if is_events_admin %}
             {% if not event.approved %}
                 <form action="{% url 'events' %}" method="post" style="display:inline">
@@ -122,27 +122,48 @@
         {% if event.show_attending and not not_show_attend_form %}
         <div class="bottom-row show-attend">
             <span class="signup-status">
-                People attending: {{ event.attending.count }}
+                People
+                {% if event.happened %}
+                    attended:
+                {% else %}
+                    attending:
+                {% endif %}
+                {{ event.attending.count }}
             </span>
-
             {% if request.user in event.attending.all %}
                 <span class="attend-status">
-                    You are <b style="color: green">attending</b> this event.
+                    You
+                    {% if event.happened %}
+                        attended
+                    {% else %}
+                        <b style="color: green"> are attending </b>
+                    {% endif %}
+                    this event.
 
+                    {% if not event.happened %}
                         <a href="#" data-form-no-attend="{{ event.id }}" class="button small-button no-attend-button">
                             <i class="fas fa-times"></i>
                             Don't Attend
                         </a>
+                    {% endif %}
 
                 </span>
             {% else %}
                 <span class="attend-status">
-                    You are <b style="color: red">not attending</b> this event.
+                    You
+                    {% if event.happened %}
+                        did not attend
+                    {% else %}
+                        <b style="color: red"> are not attending </b>
+                    {% endif %}
+                    this event.
 
+                    {% if not event.happened %}
                         <a href="#" data-form-attend="{{ event.id }}" class="button small-button attend-button">
                             <i class="fas fa-check"></i>
                             Attend
                         </a>
+                    {% endif %}
 
                 </span>
             {% endif %}

--- a/intranet/templates/events/home.html
+++ b/intranet/templates/events/home.html
@@ -17,12 +17,13 @@
         function setView(view_name){
             if(view_name == "month") {
                 $("#view-div").html(`{% include "events/month.html" %}`);
-                $("#{{ week_data.today }}").attr("class", "today");
             }
             else {
-                $("#view-div").html(`{% include "events/week.html" %}`);
-                $("#{{ week_data.today }}").attr("class", "today");
+                $("#view-div").html(`{% include "events/week.html"  %}`);
             }
+
+            toggleTouchEvents(view_name);
+            $("#{{ week_data.today }}").attr("class", "today");
         }
 
         $(document).ready(function() {
@@ -46,6 +47,16 @@
     {{ block.super }}
     {% stylesheet 'dashboard' %}
     {% stylesheet 'events' %}
+
+    {% if is_events_admin %}
+    <style>
+        @media (max-width: 1080px) {
+            .events-container > .event:nth-child(2) {
+                margin-top: 80px !important;
+            }
+        }
+    </style>
+    {% endif %}
 {% endblock %}
 
 {% block head %}
@@ -61,6 +72,7 @@
     <div class="primary-content events">
         <h2>Events</h2>
         <div class="button-container">
+            <div class="button-subcontainer">
 
             {% if not classic %}
                 <a href="?classic=1" class="button">
@@ -98,11 +110,13 @@
                 </a>
             {% endif %}
 
+            </div>
+
             {% if not show_all and not classic %}
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                <a id="month-button" class="button" href="#">Month</a>
-                <a id="week-button" class="button" href="#">Week</a>
-                &nbsp;
+                <div class="button-subcontainer">
+                    <a id="month-button" class="button" href="#">Month</a>
+                    <a id="week-button" class="button" href="#">Week</a>
+                </div>
             {% endif %}
 
         </div>

--- a/intranet/templates/events/month.html
+++ b/intranet/templates/events/month.html
@@ -2,8 +2,9 @@
 
 <table class="arrow-container week-table" style="border-spacing:0;">
     <tr>
-    <td></td><td></td>
-    <td>
+    <td class="cell-filler"></td>
+    <td class="cell-filler"></td>
+    <td class="date-nav">
         <a href="?date={{ month_data.last_month }}&view=month" class="button chevron schedule-left" title="Previous Month" id="left-button">
             <i class="fas fa-chevron-left"></i>
         </a>
@@ -14,10 +15,11 @@
             <i class="fas fa-chevron-right"></i>
         </a>
     </td>
-    <td></td><td></td>
+    <td class="cell-filler"></td>
+    <td class="cell-filler"></td>
     </tr>
 </table>
-<br />
+<br /><br />
 <div class="schedule" data-prev-date="{{ month_data.last_month }}" data-next-date="{{ month_data.next_month }}" data-date="{{ week_data.today }}">
     {% for week in month_data.weeks %}
     <table class="month-table">

--- a/intranet/templates/events/week.html
+++ b/intranet/templates/events/week.html
@@ -11,8 +11,9 @@
         <i class="fas fa-chevron-right"></i>
     </a>
 </div>
+
 <div class="schedule" data-prev-date="{{ week_data.last_week }}" data-next-date="{{ week_data.next_week }}" data-date="{{ week_data.today }}">
-    <table class="week-table">
+    <table class="week-table week-only">
         <tbody>
         <tr>
             {% for day in week_data.days %}


### PR DESCRIPTION
## Proposed changes
 Mobile friendly calendar: 
- For week view, days are shown vertically
- For month view, table has a scrolling overflow
- Page width fills the screen
- Disables the sidebar from appearing each time you swipe left when in month view

## Brief description of rationale
- Calendar was hard to navigate on mobile devices

Builds off the previous events fix, PR #1315 . 