### PR TITLE
feat(schedule): responsive mobile calendar

### DIFF
--- a/intranet/static/css/schedule.scss
+++ b/intranet/static/css/schedule.scss
@@ -1,6 +1,7 @@
 .bellschedule-table {
     margin: 0;
     width: 100%;
+    font-size: 16px;
 
     tr {
         th {
@@ -45,7 +46,7 @@
     font-size: 16px;
 }
 
-.week-table {
+.week-table, .month-table {
     border-collapse: separate;
     border-spacing: 30px;
     margin: 0;
@@ -141,5 +142,79 @@ tr.schedule-block.current {
 
     .far, .fas, .fab {
         color: black;
+    }
+}
+
+.primary-content {
+    position: relative;
+    top: 5px;
+
+    h2 {
+        left: 5px;
+    }
+}
+
+.arrow-container {
+    text-align:center;
+}
+
+.week-month-title {
+    font-size: 16px;
+    position: relative;
+    top: 3px;
+}
+
+.button-container {
+    float: right;
+    margin-top: -38px;
+}
+
+.month-table {
+    border-spacing: 0;
+
+    & > tbody > tr > td {
+        padding: 20px;
+        border: 1px solid lightgrey;
+    }
+}
+
+@media (max-width: 1080px) {
+    .arrow-container {
+        margin-top: 20px;
+        margin-bottom: -20px !important;
+    }
+
+    .week-only {
+        position: relative;
+        right: 8.5%;
+    }
+
+    .week-table {
+        min-width: auto !important;
+        width: 100% !important;
+
+        & > tbody > tr > td {
+            display: block;
+            border-bottom: 1px solid lightgrey;
+            padding: 20px 0 !important;
+            width: 120%;
+
+            &:first-child {
+                border-top: 1px solid lightgrey;
+            }
+        }
+    }
+
+    .month-table {
+        min-width: 1680px !important;
+    }
+
+
+    .schedule-container {
+        overflow-x: auto;
+    }
+
+    .schedule:first-child {
+        margin-top: 20px;
     }
 }

--- a/intranet/static/js/schedule.js
+++ b/intranet/static/js/schedule.js
@@ -195,3 +195,61 @@ $(function() {
     displayPeriod();
     setInterval(displayPeriod, 10000);
 });
+
+function toggleTouchEvents(view_name) {
+    if(view_name == "month") $(window).off("touchstart");
+    else {
+        var initX = null,
+        initY = null,
+        listening = false;
+
+        $(window).on({
+            "touchstart": function(e) {
+                initX = e.originalEvent.touches[0].clientX;
+                initY = e.originalEvent.touches[0].clientY;
+                listening = true;
+            },
+            "touchend": function(e) {
+                listening = false;
+            },
+            "touchmove": function(e) {
+                if (!listening) return;
+
+                var nowX = e.originalEvent.touches[0].clientX,
+                    nowY = e.originalEvent.touches[0].clientY;
+
+                if (Math.abs(nowY - initY) > 30) {
+                    listening = false;
+                    return;
+                }
+
+                var diffX = nowX - initX;
+                var nav, g, shown;
+
+                if (Math.abs(diffX) > 30) {
+                    nav = $(".main > .nav").eq(0);
+                    g = $(".nav-g");
+                    shown = nav.css("left").split(/[^\-\d]+/)[0] === "0";
+
+                    if (diffX > 0 && !shown) {
+                        nav.animate({
+                            left: "0"
+                        }, 200);
+                        g.addClass("close-l").fadeIn(200);
+                        $("body").addClass("disable-scroll").addClass("mobile-nav-show");
+                        $(".c-hamburger").addClass("is-active");
+                        listening = false;
+                    } else if (diffX < 0 && shown) {
+                        nav.animate({
+                            left: "-202px"
+                        }, 200);
+                        g.removeClass("close-l").fadeOut(200);
+                        $("body").removeClass("disable-scroll").removeClass("mobile-nav-show");
+                        $(".c-hamburger").removeClass("is-active");
+                        listening = false;
+                    }
+                }
+            }
+        });
+    }
+}

--- a/intranet/templates/schedule/calendar.html
+++ b/intranet/templates/schedule/calendar.html
@@ -14,12 +14,11 @@
     <script>
         var view = "{{ view }}";
         function setView(view_name){
-            if(view_name == "month") {
-                $("#view-div").html(`{% include "schedule/month.html" %}`);
-            }
-            else {
-                $("#view-div").html(`{% include "schedule/week.html" %}`);
-            }
+            if(view_name == "month") $("#view-div").html(`{% include "schedule/month.html" %}`);
+            else                     $("#view-div").html(`{% include "schedule/week.html" %}`);
+
+            toggleTouchEvents(view_name);
+            $("#{{ day.sched_ctx.date }}").attr("class", "today");
         }
         $(document).ready(function() {
             setView(view);
@@ -68,10 +67,12 @@
 {% endblock %}
 
 {% block main %}
-    <div class="change-view">
-        <a id="week-button" class="button" href="#">Week</a>
-        <a id="month-button" class="button" href="#">Month</a>
-    </div>
-    <div class="primary-content" id="view-div">
+    <div class="primary-content">
+        <h2>Calendar</h2>
+        <div class="button-container">
+            <a id="month-button" class="button" href="#">Month</a>
+            <a id="week-button" class="button" href="#">Week</a>
+        </div>
+        <div id="view-div"></div>
     </div>
 {% endblock %}

--- a/intranet/templates/schedule/month.html
+++ b/intranet/templates/schedule/month.html
@@ -1,37 +1,63 @@
 {% load static %}
-<div class="month-container">
-    <a href="?date={{ month_data.last_month }}&view=month" title="Previous Month"><button><i class="fas fa-chevron-left"></i></button></a><span class="month-name">{{ month_data.current_month }}</span><a href="?date={{ month_data.next_month }}&view=month" title="Next Month"><button><i class="fas fa-chevron-right"></i></button></a>
-</div>
-<div class="schedule-container">
-{% for week in month_data.weeks %}
-<div class="schedule" data-endpoint="{% url 'calendar' %}" data-prev-date="{{ month_data.last_month }}" data-next-date="{{ month_data.next_month }}" data-date="{{ week.today }}">
-            <table class="week-table">
-        <tr>
-    {% for day in week.days %}
-    <td {% if week.today == day.sched_ctx.date_today %}class="today"{% endif %}>
-            <h2 class="schedule-date">{{ day.sched_ctx.date|date:"D, N j" }}</h2>
-        {% if day.sched_ctx.dayobj %}
-        <h2 class="day-name {{ day.sched_ctx.dayobj.day_type.class_name }}">{{ day.sched_ctx.dayobj.day_type.name|safe }}{% if day.sched_ctx.comment %} {{ day.sched_ctx.comment }}{% endif %}</h2>
-            <table class="bellschedule-table" data-date="{{ day.sched_ctx.date|date:'Y-m-d' }}">
-            {% for block in day.sched_ctx.blocks %}
-                <tr class="schedule-block" data-block-name="{{ block.name|safe }}" data-block-start="{{ block.start.str_12_hr }}" data-block-end="{{ block.end.str_12_hr }}" data-block-order="{{ block.order }}">
-                    <th class="block">{{ block.name|safe }}:</th>
-                    <td class="times">{{ block.start.str_12_hr }} - {{ block.end.str_12_hr }}</td>
-                </tr>
-            {% endfor %}
-            </table>
-        {% else %}
-            {% if day.sched_ctx.is_weekday %}
-                <h3 class="day-name">No schedule available</h3>
-            {% else %}
-                <h3 class="day-name">No school</h3>
-            {% endif %}
-        {% endif %}
-    </td>
-    {% endfor %}
-    </tr>
+<div class="arrow-container week-table" style="border-spacing:0;">
+    {% if not hide_arrows %}
+        <a href="?date={{ month_data.last_month }}&view=month" class="button chevron schedule-left" title="Previous Month" id="left-button">
+            <i class="fas fa-chevron-left"></i>
+        </a>
+        &nbsp;
+    {% endif %}
 
-</table>
+    <b class="week-month-title">{{ month_data.current_month }}</b>
+
+    {% if not hide_arrows %}
+        &nbsp;
+        <a href="?date={{ month_data.next_month }}&view=month" class="button chevron schedule-right" title="Next Month" id="right-button">
+            <i class="fas fa-chevron-right"></i>
+        </a>
+    {% endif %}
 </div>
-{% endfor %}
+<br />
+<div class="schedule-container">
+    {% for week in month_data.weeks %}
+    <div class="schedule" data-endpoint="{% url 'calendar' %}" data-prev-date="{{ month_data.last_month }}"
+        data-next-date="{{ month_data.next_month }}" data-date="{{ week.today }}">
+        <table class="month-table">
+            <tr>
+                {% for day in week.days %}
+                <td id="{{ day.sched_ctx.date }}">
+                    <h2 class="schedule-date">{{ day.sched_ctx.date|date:"D, N j" }}</h2>
+
+                    {% if day.sched_ctx.dayobj %}
+                    <h2 class="day-name {{ day.sched_ctx.dayobj.day_type.class_name }}">{{ day.sched_ctx.dayobj.day_type.name|safe }}
+                        {% if day.sched_ctx.comment %}
+                            {{ day.sched_ctx.comment }}
+                        {% endif %}
+                    </h2>
+                    <table class="bellschedule-table" data-date="{{ day.sched_ctx.date|date:'Y-m-d' }}">
+                        {% for block in day.sched_ctx.blocks %}
+                        <tr class="schedule-block" data-block-name="{{ block.name|safe }}"
+                            data-block-start="{{ block.start.str_12_hr }}"
+                            data-block-end="{{ block.end.str_12_hr }}"
+                            data-block-order="{{ block.order }}">
+
+                            <th class="block">{{ block.name|safe }}:</th>
+                            <td class="times">{{ block.start.str_12_hr }} - {{ block.end.str_12_hr }}</td>
+                        </tr>
+                        {% endfor %}
+                    </table>
+
+                    {% else %}
+                        {% if day.sched_ctx.is_weekday %}
+                            <h3 class="day-name">No schedule available</h3>
+                        {% else %}
+                            <h3 class="day-name">No school</h3>
+                        {% endif %}
+                    {% endif %}
+                </td>
+                {% endfor %}
+            </tr>
+
+        </table>
+    </div>
+    {% endfor %}
 </div>

--- a/intranet/templates/schedule/week.html
+++ b/intranet/templates/schedule/week.html
@@ -1,34 +1,59 @@
 {% load static %}
 
-<div class="schedule" data-endpoint="{% url 'calendar' %}" data-prev-date="{{ week_data.last_week }}" data-next-date="{{ week_data.next_week }}" data-date="{{ week_data.today }}">
+<div class="arrow-container week-table" style="border-spacing:0;">
+    {% if not hide_arrows %}
+        <a href="?date={{ week_data.last_week }}" class="button chevron schedule-left" title="Previous Week" id="left-button">
+            <i class="fas fa-chevron-left"></i>
+        </a>
+        &nbsp;
+    {% endif %}
 
-            <table class="week-table">
+    <b class="week-month-title">Week of {{ week_data.days.0.sched_ctx.date|date:"N j" }}</b>
+
+    {% if not hide_arrows %}
+    &nbsp;
+    <a href="?date={{ week_data.next_week }}" class="button chevron schedule-right" title="Next Week" id="right-button">
+        <i class="fas fa-chevron-right"></i>
+    </a>
+    {% endif %}
+</div>
+
+    <table class="week-table week-only">
         <tr>
-            <td{% if not hide_arrows %} class="chevron"><a href="?date={{ week_data.last_week }}" class="chevron schedule-left" title="Previous Week"><i class="fas fa-chevron-left"></i></a>{% else %}>{% endif %}</td>
-    {% for day in week_data.days %}
-    <td {% if today == day.sched_ctx.date_today %}class="today"{% endif %}>
-            <h2 class="schedule-date">{{ day.sched_ctx.date|date:"D, N j" }}</h2>
-        {% if day.sched_ctx.dayobj %}
-        <h2 class="day-name {{ day.sched_ctx.dayobj.day_type.class_name }}">{{ day.sched_ctx.dayobj.day_type.name|safe }}{% if day.sched_ctx.comment %} {{ day.sched_ctx.comment }}{% endif %}</h2>
-            <table class="bellschedule-table" data-date="{{ day.sched_ctx.date|date:'Y-m-d' }}">
-            {% for block in day.sched_ctx.blocks %}
-                <tr class="schedule-block" data-block-name="{{ block.name|safe }}" data-block-start="{{ block.start.str_12_hr }}" data-block-end="{{ block.end.str_12_hr }}" data-block-order="{{ block.order }}">
-                    <th class="block">{{ block.name|safe }}:</th>
-                    <td class="times">{{ block.start.str_12_hr }} - {{ block.end.str_12_hr }}</td>
-                </tr>
-            {% endfor %}
-            </table>
-        {% else %}
-            {% if day.sched_ctx.is_weekday %}
-                <h3 class="day-name">No schedule available</h3>
-            {% else %}
-                <h3 class="day-name">No school</h3>
-            {% endif %}
-        {% endif %}
-    </td>
-    {% endfor %}
-    <td{% if not hide_arrows %} class="chevron"><a href="?date={{ week_data.next_week }}" class="chevron schedule-right" title="Next Week"><i class="fas fa-chevron-right"></i></a>{% else %}>{% endif %}</td>
-    </tr>
+            {% for day in week_data.days %}
+            <td id="{{ day.sched_ctx.date }}">
+                <h2 class="schedule-date">{{ day.sched_ctx.date|date:"D, N j" }}</h2>
 
-</table>
+                {% if day.sched_ctx.dayobj %}
+                <h2 class="day-name {{ day.sched_ctx.dayobj.day_type.class_name }}">
+                    {{ day.sched_ctx.dayobj.day_type.name|safe }}
+
+                    {% if day.sched_ctx.comment %}
+                        {{ day.sched_ctx.comment }}
+                    {% endif %}
+                </h2>
+
+                <table class="bellschedule-table" data-date="{{ day.sched_ctx.date|date:'Y-m-d' }}">
+                    {% for block in day.sched_ctx.blocks %}
+                    <tr class="schedule-block" data-block-name="{{ block.name|safe }}"
+                        data-block-start="{{ block.start.str_12_hr }}"
+                        data-block-end="{{ block.end.str_12_hr }}"
+                        data-block-order="{{ block.order }}">
+
+                        <th class="block">{{ block.name|safe }}:</th>
+                        <td class="times">{{ block.start.str_12_hr }} - {{ block.end.str_12_hr }}</td>
+                    </tr>
+                    {% endfor %}
+                </table>
+
+                {% else %}
+                    {% if day.sched_ctx.is_weekday %}
+                        <h3 class="day-name">No schedule available</h3>
+                    {% else %}
+                        <h3 class="day-name">No school</h3>
+                    {% endif %}
+                {% endif %}
+            </td>
+            {% endfor %}
+    </table>
 </div>


### PR DESCRIPTION
## Proposed changes
 Mobile friendly calendar: 
- For week view, days are shown vertically
- For month view, table has a scrolling overflow
- Page width fills the screen
- Disables the sidebar from appearing each time you swipe left when in month view
Also adds borders in the month view for desktop and mobile

## Brief description of rationale
- Calendar was hard to navigate on mobile devices
