### PR TITLE
style(search): change all alumni to graduate in search results

### DIFF
--- a/intranet/templates/search/search_results.html
+++ b/intranet/templates/search/search_results.html
@@ -72,7 +72,7 @@
                     {% endif %}
                     <td>
                         {% if user.grade and not user.is_teacher %}
-                            {% if user.grade_number == 13 %}
+                            {% if user.grade_number >= 13 %}
                                 Graduate
                             {% else %}
                                 Grade {{ user.grade_number }}


### PR DESCRIPTION
## Proposed changes
The search results should display all graduates as graduates and not "Grade 1X"