### PR TITLE
fix(dev): running docker as sudo

### DIFF
--- a/config/docker/docker-compose.yml
+++ b/config/docker/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     image: application
     networks:
     - intranet_net
-    entrypoint: ["/bin/sh", "-c" , "chmod +x config/docker/entrypoint.sh && config/docker/entrypoint.sh"]
+    entrypoint: ["/bin/sh", "-c" , "git config --global --add safe.directory /ion && chmod +x config/docker/entrypoint.sh && config/docker/entrypoint.sh"]
     ports:
     - 8080:8080
     build:
@@ -46,7 +46,7 @@ services:
     image: application
     networks:
     - intranet_net
-    command: pipenv run celery --app intranet worker -l info --without-gossip --without-mingle --without-heartbeat -Ofair
+    entrypoint: ["/bin/sh", "-c" , "git config --global --add safe.directory /ion && pipenv run celery --app intranet worker -l info --without-gossip --without-mingle --without-heartbeat -Ofair"]
     depends_on:
     - application
     volumes:
@@ -57,7 +57,7 @@ services:
     image: application
     networks:
     - intranet_net
-    command: pipenv run celery --app intranet beat -l info
+    entrypoint: ["/bin/sh", "-c" , "git config --global --add safe.directory /ion && pipenv run celery --app intranet beat -l info"]
     depends_on:
     - application
     volumes:


### PR DESCRIPTION
## Proposed changes
- Makes Git trust the root Ion directory for all containers.

## Brief description of rationale
- The Docker daemon needs root privileges, requiring the use of `sudo` or adding the user to the `docker` group. 
- When running Docker as `sudo` and the directory containing Ion's source code is owned by another user, Git will not run because the directory is not trusted.
