### PR TITLE
refactor(schedule): add schedule to nav, change urls

### DIFF
--- a/intranet/apps/context_processors.py
+++ b/intranet/apps/context_processors.py
@@ -45,6 +45,7 @@ def nav_categorizer(request):
         (r"^/announcements", "dashboard"),
         (r"^/eighth/admin", "eighth_admin"),
         (r"^/eighth", "eighth"),
+        (r"^/schedule", "schedule"),
         (r"^/events", "events"),
         (r"^/files", "files"),
         (r"^/printing", "printing"),

--- a/intranet/apps/schedule/urls.py
+++ b/intranet/apps/schedule/urls.py
@@ -4,12 +4,12 @@ from . import views
 
 urlpatterns = [
     # Admin
-    re_path(r"^$", views.admin_home_view, name="schedule_admin"),
+    re_path(r"^$", views.calendar_view, name="calendar"),
+    re_path(r"^/admin", views.admin_home_view, name="schedule_admin"),
     re_path(r"^/view$", views.schedule_view, name="schedule"),
     re_path(r"^/embed$", views.schedule_embed, name="schedule_embed"),
     re_path(r"^/widget$", views.schedule_widget_view, name="schedule_widget"),
     re_path(r"^/daytype(?:/(?P<daytype_id>\d+))?$", views.admin_daytype_view, name="schedule_daytype"),
     re_path(r"^/add$", views.admin_add_view, name="schedule_add"),
     re_path(r"^/comment$", views.admin_comment_view, name="schedule_comment"),
-    re_path(r"^/calendar", views.calendar_view, name="calendar"),
 ]

--- a/intranet/templates/nav.html
+++ b/intranet/templates/nav.html
@@ -49,6 +49,13 @@
         </li>
         {% endcomment %}
         {% if not request.user.is_restricted %}
+        <li {% if nav_category == "schedule" %}class="selected"{% endif %}>
+            <a href="{% if request.user.is_schedule_admin and not request.user.is_student %}{% url 'schedule_admin' %}{% else %}{% url 'calendar' %}{% endif %}">
+                <i class="nav-icon bell-icon"></i>
+                Schedule
+            </a>
+        </li>
+
         <li {% if nav_category == "events" %}class="selected"{% endif %}>
             <a href="{% url 'events' %}">
                 <i class="nav-icon events-icon"></i>

--- a/intranet/templates/schedule/admin_home.html
+++ b/intranet/templates/schedule/admin_home.html
@@ -3,7 +3,7 @@
 {% load pipeline %}
 
 {% block title %}
-    {{ block.super }} - Schedule
+    {{ block.super }} - Schedule Admin
 {% endblock %}
 
 {% block js %}
@@ -236,6 +236,7 @@ $(function() {
         </form>
 
         <div class="schedule-methods">
+            <a href="{% url 'calendar' %}" class="button">Calendar</a> &nbsp;
             <form action="" method="post" onsubmit="return defaultFillWarning()" style="display: inline">
                 {% csrf_token %}
                 <input type="hidden" name="default_fill" value="1">

--- a/intranet/templates/schedule/calendar.html
+++ b/intranet/templates/schedule/calendar.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load pipeline %}
 {% block title %}
-    {{ block.super }} - Calendar
+    {{ block.super }} - Schedule
 {% endblock %}
 
 {% block js %}
@@ -68,8 +68,11 @@
 
 {% block main %}
     <div class="primary-content">
-        <h2>Calendar</h2>
+        <h2>Schedule</h2>
         <div class="button-container">
+            {% if request.user.is_schedule_admin %}
+            <a class="button" href="{% url 'schedule_admin' %}">Admin</a> &nbsp;
+            {% endif %}
             <a id="month-button" class="button" href="#">Month</a>
             <a id="week-button" class="button" href="#">Week</a>
         </div>


### PR DESCRIPTION
## Proposed changes
- Add schedule calendar to left navbar
- Change `/schedule` to go to the schedule calendar (used to go to the admin interface)

## Brief description of rationale
- Schedule is accessed a lot, adding to navbar makes it easier to locate
- The new URL syntax is more in line with other apps
