### PR TITLE
style(eighth): remove roster button for non-admins

### DIFF
--- a/intranet/templates/eighth/signup.html
+++ b/intranet/templates/eighth/signup.html
@@ -291,14 +291,17 @@
                 <% if (!cancelled) {%>
                     <% if (!selected && !waitlisted) {%>
                         <% showingRosterButton = true %>
+                        <% if isEighthAdmin { %>
                         <a class="button" id="roster-button" data-endpoint="/eighth/roster/raw" href="/eighth/roster/<%= scheduled_activity_id %>">
                             View Roster
                         </a>
-                        <% if (waitlist_count > 0 && isEighthAdmin && waitlistEnabled) { %>
-                                <a class="button" id="roster-waitlist-button" data-endpoint="/eighth/roster/raw/waitlist">
-                                    View Waitlist
-                                </a>
+                            <% if (waitlist_count > 0 && waitlistEnabled) { %>
+                            <a class="button" id="roster-waitlist-button" data-endpoint="/eighth/roster/raw/waitlist">
+                                View Waitlist
+                            </a>
+                            <% } %>
                         <% } %>
+
                         <% if (roster.count < roster.capacity || both_blocks || isEighthAdmin) { %>
                         <button id="signup-button">
                             Sign Up


### PR DESCRIPTION
## Proposed changes
Non eighth admins are unable to see an 8th-period roster due to privacy issues, and the button is redundant, and users clicking it at scale creates unnecessary requests.


## Brief description of rationale
Hide button for non-admins