### PR TITLE
fix(dev): change ruby sass to npm sass to fix deprecation

### DIFF
--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -8,8 +8,11 @@ COPY requirements.txt .
 
 RUN apt-get -y update && \
     apt-get -y clean && \
-    apt-get -y install git python3 python3-pip python-is-python3 \
-    libpq-dev ruby-full rubygems libmagic1 && gem install sass && \
+    apt-get -y install git curl python3 python3-pip python-is-python3 \
+    libpq-dev ruby-full libmagic1 && \
+    curl -sL https://deb.nodesource.com/setup_18.x | bash && \
+    apt-get install nodejs && \
+    npm install -g sass && \
     pip3 install pipenv && \
     ln -s /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install krb5-user kinit && \


### PR DESCRIPTION
## Proposed changes

- Use npm sass instead of the now-deprecated rubygems sass

## Brief description of rationale

Rubygems sass breaks on workstations/FCPS wifi, and is deprecated