### PR TITLE
test(eighth): fix tests failing between 11-11:59pm

### DIFF
--- a/intranet/apps/eighth/tests/test_signup.py
+++ b/intranet/apps/eighth/tests/test_signup.py
@@ -313,7 +313,7 @@ class EighthSignupTest(EighthAbstractTest):
         user = self.make_admin()
         now = timezone.localtime()
         time_start = Time.objects.create(hour=now.time().hour, minute=now.time().minute)
-        time_end = Time.objects.create(hour=now.time().hour + 1, minute=now.time().minute)
+        time_end = Time.objects.create(hour=(now + timezone.timedelta(hours=1)).hour, minute=now.time().minute)
         block = Block.objects.create(name="8A", start=time_start, end=time_end, order=1)
         red_day = DayType.objects.create(name="red")
         red_day.blocks.add(block)


### PR DESCRIPTION
## Proposed changes
- Change `test_signup` to use `timedelta` 

## Brief description of rationale
- Tests fail between 11:00 and 11:59 pm because adding 1 to `now.time().hour` would have hour as 24
