### PR TITLE
style(eighth): hide signup button for restricted activities

### DIFF
--- a/intranet/templates/eighth/signup.html
+++ b/intranet/templates/eighth/signup.html
@@ -302,7 +302,7 @@
                             </a>
                         <% } %>
 
-                        <% if (roster.count < roster.capacity || both_blocks || isEighthAdmin) { %>
+                        <% if (isEighthAdmin || !restricted_for_user && roster.count < roster.capacity || both_blocks) { %>
                         <button id="signup-button">
                             Sign Up
                         </button>
@@ -340,13 +340,15 @@
                 </div>
             </div>
             <% if (!showingRosterButton) { %>
-                <a class="button" id="roster-button" data-endpoint="/eighth/roster/raw" href="/eighth/roster/<%= scheduled_activity_id %>">
-                    View Roster
-                </a>
-                <% if (waitlist_count > 0 && isEighthAdmin && waitlistEnabled) { %>
-                        <a class="button" id="roster-waitlist-button" data-endpoint="/eighth/roster/raw/waitlist">
-                            View Waitlist
-                        </a>
+                <% if(isEighthAdmin) { %>
+                    <a class="button" id="roster-button" data-endpoint="/eighth/roster/raw" href="/eighth/roster/<%= scheduled_activity_id %>">
+                        View Roster
+                    </a>
+                <% } %>
+                <% if (waitlist_count > 0 && waitlistEnabled) { %>
+                    <a class="button" id="roster-waitlist-button" data-endpoint="/eighth/roster/raw/waitlist">
+                        View Waitlist
+                    </a>
                 <% } %>
                 <div id="signup-spinner-container">
                     <div id="signup-spinner"></div>


### PR DESCRIPTION
## Proposed changes
- Hides sign up button on restricted activities the user is not authorized to sign up for
- Hides view roster button when signed up for activity (#1385 only hid button when not signed up)

## Brief description of rationale
- Streamline UI (sign up button is hidden on full activities, so should also be hidden for restricted)
