### PR TITLE
style(nav): move absent icon to left on mobile

### DIFF
--- a/intranet/static/css/page_base.scss
+++ b/intranet/static/css/page_base.scss
@@ -23,6 +23,7 @@ body {
     background: $grey;
 }
 
+
 .badge-link {
     &,
     &:active,
@@ -289,6 +290,7 @@ h1 {
 .csl-apps .dropdown-menu a {
     font-size: 11pt;
     padding: 0;
+    line-height: 2.5em !important;
 
     &:hover {
         background-color: rgb(240, 240, 240);

--- a/intranet/static/css/responsive.core.scss
+++ b/intranet/static/css/responsive.core.scss
@@ -12,7 +12,7 @@ body.disable-scroll {
 
 @media (max-width: 700px) {
     .header .search input[type="text"] {
-        width: 150px;
+        width: 158px;
         font-size: 12px;
         padding-right: 3px;
     }
@@ -24,12 +24,17 @@ body.disable-scroll {
         position: fixed;
         left: 0;
         width: 100%;
-        height: auto;
         margin-top: 30px;
 
         .arrow {
             right: 148px;
         }
+    }
+
+    .badged-item {
+        position: absolute !important;
+        top: 9px;
+        left: 60px;
     }
 }
 
@@ -48,7 +53,7 @@ body.disable-scroll {
         .left > form.search {
             position: absolute;
             visibility: hidden;
-            left: 17.5%;
+            left: 14.5%;
             opacity: 0;
 
             body.mobile-nav-show & {
@@ -84,7 +89,8 @@ body.disable-scroll {
     }
     /* absence notification */
     ul.dropdown-menu.absence-notification .arrow {
-        right: 90px;
+        position: absolute;
+        left: 65px;
     }
     /* TODO: these proportions look off, and I can't figure out exactly why */
     .left .dropdown {

--- a/intranet/static/js/common.header.js
+++ b/intranet/static/js/common.header.js
@@ -92,7 +92,7 @@ $(function() {
     arrowPosition = function() {
         // Calculate dimensions to align arrow to icons/text in header
         $(".notifications .dropdown-menu .arrow").css("right", ($(".notifications").width() / 2) + "px");
-        $(".username .dropdown-menu .arrow, .csl-apps .dropdown-menu .arrow").css("right", ((($(".username .dropdown-item-wrapper").width()) / 2) + 5) + "px");
+        $(".username .dropdown-menu .arrow, .csl-apps .dropdown-menu .arrow").css("right", ((($(".username .dropdown-item-wrapper").width()) / 2)) + 1 + "px");
     }
 
     arrowPosition();


### PR DESCRIPTION
## Proposed changes
- Moves the eighth absences icon to the left of the header navbar on mobile

## Brief description of rationale
- #1379 introduced an apps icon to the navbar which would (if enabled) overlap with the absence icon