### PR TITLE
perf(auth): remove LOCAL

### DIFF
--- a/intranet/apps/auth/forms.py
+++ b/intranet/apps/auth/forms.py
@@ -32,7 +32,7 @@ class AuthenticateForm(AuthenticationForm):
         error_messages={"required": "Invalid password", "inactive": "Access disallowed."},
     )
 
-    trust_device = forms.BooleanField(required=False, label="Trust this device", label_suffix="")
+    trust_device = forms.BooleanField(required=False, initial=True, label="Remember me", label_suffix="")
 
     def is_valid(self):
         """Validates the username and password in the form."""

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -525,8 +525,7 @@ else:
     }
 
 CSL_REALM = "CSL.TJHSST.EDU"  # CSL Realm
-AD_REALM = "LOCAL.TJHSST.EDU"
-KINIT_TIMEOUT = 15  # seconds before pexpect timeouts
+KINIT_TIMEOUT = 10  # seconds before pexpect timeouts
 
 FCPS_STUDENT_ID_LENGTH = 7
 


### PR DESCRIPTION
## Proposed changes
- Removes the `LOCAL.TJHSST.EDU` realm from auth

## Brief description of rationale
- `LOCAL` is no longer used.
- If Kerberos authentication for the `CSL.TJHSST.EDU` realm fails, `LOCAL` is checked. However, since `LOCAL` doesn't exist, the request just hangs until the timeout (currently 15 sec, lowered to 10 sec in this PR) stops it. This is what is causing the really slow login for wrong passwords.
- This lowers the incorrect login loading time from around 20 seconds to 3 seconds.

Please monitor carefully when deploying! I tested this on dev but if anything breaks due to production's config, even though it's highly unlikely, we should be ready to revert.
