### PR TITLE
refactor(polls): style ranked choice for dark mode

### DIFF
--- a/intranet/static/css/dark/polls.scss
+++ b/intranet/static/css/dark/polls.scss
@@ -33,3 +33,17 @@
     }
 }
 
+.candidate-info {
+    color: #b7b7b7;
+    background-color: #2A2A28;
+}
+
+select {
+    color: #b7b7b7;
+    background-color: #2A2A28;
+    border: 1px solid #b7b7b7;
+}
+
+.expand-collapse-all:hover {
+    background-color: #6e6e6e;
+}

--- a/intranet/static/js/polls-vote.js
+++ b/intranet/static/js/polls-vote.js
@@ -42,7 +42,7 @@ $(function() {
         $("select[name=" + name +"]").not(this).find("option[value='" + value + "'][class='choice-option']").hide();
     });
 
-    $(".candidate-info ul li a").each(function() {
-        $(this).text($(this).text().replace("|", "—"));
+    $(".candidate-info ul li").each(function() {
+        $(this).html($(this).html().replace("|", "—"));
     });
 });


### PR DESCRIPTION
## Proposed changes
- Apply styling for dark mode in ranked choice voting
- Fix small bug where a pipe symbol ( | ) isn't converted to a dash ( - ) if the choice isn't a link
