### PR TITLE
refactor(emerg): styling + fix FCPS status, CSL linebreaks breaking

### DIFF
--- a/intranet/static/css/dashboard.scss
+++ b/intranet/static/css/dashboard.scss
@@ -25,9 +25,9 @@
 
 .announcement {
     background-color: white;
-    -webkit-border-radius: 5px;
-    -moz-border-radius: 5px;
-    border-radius: 5px;
+    -webkit--radius: 5px;
+    -moz--radius: 5px;
+    -radius: 5px;
     border: 1px solid rgb(216, 216, 216);
     padding: 6px 10px;
     margin-bottom: 6px;
@@ -229,13 +229,13 @@ div[data-placeholder]:not(:focus):not([data-div-placeholder-content]):before {
 
 .dash-warning {
     width: auto;
-    background-color: yellow;
-    border: 1px solid rgb(210, 208, 66);
+    background-color: #fce624;
+    border: 1px solid #fce624;
     padding: 10px;
     border-radius: 4px;
-    text-align: center;
     margin-bottom: 10px;
     position: relative;
+    bottom: 5px;
     max-height: 100vh;
     transition: max-height 0.2s ease-in-out;
 
@@ -257,7 +257,7 @@ div[data-placeholder]:not(:focus):not([data-div-placeholder-content]):before {
             background-image: linear-gradient(
                             to bottom,
                             rgba(255, 255, 255, 0),
-                            yellow 90%
+                            #fae26b 90%
             );
             width: 100%;
             height: 4em;
@@ -266,6 +266,19 @@ div[data-placeholder]:not(:focus):not([data-div-placeholder-content]):before {
 
     ul {
         text-align: left;
+    }
+
+    h3 {
+        text-align: center;
+        color: #d10202;
+        a {
+            color: red;
+        }
+    }
+
+    hr {
+        border: none;
+        border-top: 1px solid grey;
     }
 }
 

--- a/intranet/static/css/emerg.scss
+++ b/intranet/static/css/emerg.scss
@@ -47,16 +47,16 @@ body.has-login-warning {
 
 .dash-warning,
 .login-warning {
-    color: #484848;
-    background-color: yellow;
-    border: 1px solid #d2d042;
+    color: #303030;
+    background-color: #fce624;
+    border: 1px solid #fce624;
     padding: 10px;
     border-radius: 4px;
-    text-align: center;
     transition: max-height 0.2s ease-in-out;
+    text-align: left;
 
     &.collapsed {
-        max-height: 50px !important;
+        max-height: 90px !important;
         overflow: hidden;
 
         &::after {
@@ -69,11 +69,27 @@ body.has-login-warning {
             background-image: linear-gradient(
                             to bottom,
                             rgba(255, 255, 255, 0),
-                            yellow 90%
+                            #fce624 90%
             );
             width: 100%;
             height: 4em;
         }
+    }
+
+    &::-webkit-scrollbar {
+        width: 7px;
+    }
+
+    &::-webkit-scrollbar-track {
+        background: #d6d6d6;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: #888;
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+        background: #555;
     }
 
     ul {
@@ -82,5 +98,19 @@ body.has-login-warning {
 
     &:hover {
         cursor: pointer;
+    }
+
+
+    h3 {
+        text-align: center;
+        color: #d10202;
+        a {
+            color: red;
+        }
+    }
+
+    hr {
+        border: none;
+        border-top: 1px solid grey;
     }
 }

--- a/intranet/utils/helpers.py
+++ b/intranet/utils/helpers.py
@@ -158,8 +158,8 @@ def get_fcps_emerg(request):
     """Return FCPS emergency information."""
     try:
         emerg = get_emerg()
-    except Exception:
-        logger.info("Unable to fetch FCPS emergency info")
+    except Exception as e:
+        logger.info("Unable to fetch FCPS emergency info: %s", e)
         emerg = {"status": False}
 
     if emerg["status"] or ("show_emerg" in request.GET):

--- a/intranet/utils/html.py
+++ b/intranet/utils/html.py
@@ -73,3 +73,7 @@ def safe_fcps_emerg_html(text: str, base_url: str) -> str:
         return attrs
 
     return bleach.linkify(bleach.clean(text, strip=True, tags=tags, attributes=att, css_sanitizer=css_sanitizer), [translate_link_attr])
+
+
+def get_domain_name(url):
+    return "https://" + urllib.parse.urlparse(url).netloc


### PR DESCRIPTION
## Proposed changes
- Fix FCPS emergency status text not displaying (the title will display, but the body text won't)
- Allow dispaying multiple lines from the CSL status page - currently only one line of a status announcement will be shown
- A few styling changes, adds link to FCPS/CSL status page in title of status announcement

