### PR TITLE
style(cslapps): added client secret warning for oauth

### DIFF
--- a/intranet/templates/oauth2_provider/application_detail.html
+++ b/intranet/templates/oauth2_provider/application_detail.html
@@ -25,11 +25,6 @@
             </li>
 
             <li>
-                <p><b>{% trans "Client secret" %}</b></p>
-                <input class="input-block-level" type="text" value="{{ application.client_secret }}" readonly>
-            </li>
-
-            <li>
                 <p><b>{% trans "Client type" %}</b></p>
                 <p>{{ application.client_type }}</p>
             </li>

--- a/intranet/templates/oauth2_provider/application_form.html
+++ b/intranet/templates/oauth2_provider/application_form.html
@@ -65,7 +65,9 @@
             </h3>
 
             {% block app-form-description %}
-            <p>For more information on how to use Ion OAuth, click <a target="_blank" href="https://guides.tjhsst.edu/ion/using-ion-oauth">here</a>.</p>
+            <p>For more information on how to use Ion OAuth, click <a target="_blank" href="https://guides.tjhsst.edu/ion/using-ion-oauth">here</a>.
+            <br>Copy the "Client Secret" now, you won't be able to see it later.
+            </p>
             {% endblock %}
 
             {% csrf_token %}


### PR DESCRIPTION
## Proposed changes
Add explicit help text showing that the client's secret is hashed and hide it after it's made.

