### PR TITLE
feat(hoco): add hoco scores to Ion dashboard and signage homepage

### DIFF
--- a/intranet/apps/signage/views.py
+++ b/intranet/apps/signage/views.py
@@ -8,6 +8,7 @@ from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
 
+from ...utils.date import get_senior_graduation_year
 from ...utils.serialization import safe_json
 from ..eighth.models import EighthBlock
 from ..eighth.serializers import EighthBlockDetailSerializer
@@ -53,6 +54,7 @@ def signage_display(request, display_id: str) -> HttpResponse:
     context["sign"] = sign
     context["page_args"] = (sign, request)
     context["end_switch_page_time"] = end_of_day - datetime.timedelta(minutes=sign.day_end_switch_minutes)
+    context["senior_graduation_year"] = get_senior_graduation_year()
     return render(request, "signage/base.html", context)
 
 

--- a/intranet/static/css/hoco_ribbon.scss
+++ b/intranet/static/css/hoco_ribbon.scss
@@ -274,3 +274,74 @@
         }
     }
 }
+
+#hoco-scores {
+    display: none;
+    margin: 15px auto;
+    width: 580px;
+    text-align: center;
+
+    .box {
+        display: inline-block;
+        position: relative;
+        background-color: #003468;
+        color: white;
+        padding: 15px 15px 20px;
+        margin: 5px;
+        width: 100px;
+        height: 80px;
+        overflow: hidden;
+
+        .class {
+            font-size: 1.5em;
+        }
+
+        .score {
+            font-size: 2em;
+        }
+    }
+}
+
+@media screen and (max-width: 1170px) {
+    .center-wrapper {
+        margin-top: 40px;
+    }
+    #hoco-scores {
+        width: 284px;
+        zoom: 0.85;
+        left: calc(50% - 142px);
+    }
+}
+
+.corner-ribbon {
+    width: 95px;
+    background: #e43;
+    position: absolute;
+    top: 5px;
+    left: -30px;
+    text-align: center;
+    line-height: 25px;
+    letter-spacing: 1px;
+    color: #f0f0f0;
+    transform: rotate(-45deg);
+    -webkit-transform: rotate(-45deg);
+
+    &.gold {
+        background-color: #C98910;
+    }
+
+    &.silver {
+        background-color: #A8A8A8;
+    }
+
+    &.bronze {
+        background-color: #965A38;
+    }
+}
+
+@media screen and (max-height: 900px) {
+    .center {
+        top: 440px;
+    }
+}
+

--- a/intranet/templates/signage/base.html
+++ b/intranet/templates/signage/base.html
@@ -68,6 +68,9 @@
                         {% endwith %}
                     </div>
                 </div>
+                {% if show_homecoming %}
+                {% include "special/hoco_scores.html" %}
+                {% endif %}
             </section>
             {% for page in sign.pages.order_properly %}
             <section class="signage-section signage-page page{% if page.iframe %} iframe{% else %} server{% endif %} {{ page.strip_links | yesno:"strip-links," }}" id="{{ page.pk }}">

--- a/intranet/templates/special/hoco_ribbon.html
+++ b/intranet/templates/special/hoco_ribbon.html
@@ -3,33 +3,61 @@
 {% load cacheops %}
 {% load pipeline %}
 {% stylesheet 'hoco_ribbon' %}
-    <div class="ribbon">
-      <div class="medallion"></div>
+<script src="{% static 'js/hoco_scores.js' %}"></script>
+<div class="ribbon">
+    <div class="medallion"></div>
 
-      <div class="ribbon-1">
+    <div class="ribbon-1">
         <span class="inner">
           <span class="fadeLeft">It's</span>
         </span>
-      </div>
+    </div>
 
-      <div class="ribbon-2">
+    <div class="ribbon-2">
         <span class="inner">
           <span class="fadeRight">Homecoming!</span>
         </span>
-      </div>
+    </div>
 
-      <div class="ribbon-3">
+    <div class="ribbon-3">
         <span class="inner">
-          <span class="fadeLeft"><a href="https://homecoming.tjhsst.edu/" target="_blank" rel="noopener noreferrer">homecoming.tjhsst.edu</a></span>
+          <span class="fadeLeft"><a href="https://homecoming.tjhsst.edu/" target="_blank"
+                                    rel="noopener noreferrer">homecoming.tjhsst.edu</a></span>
         </span>
-      </div>
+    </div>
 
-      <div class="ball fadeIn">
+    <div class="ball fadeIn">
         <span class="ball-text">
           <strong>Gooooo</strong>
           Colonials!
         </span>
-      </div>
     </div>
-    <br>
-    <script src="{% static 'js/hoco_ribbon.js' %}"></script>
+</div>
+<div id="hoco-scores">
+    <div class="box">
+        <div class="class">{{ senior_graduation_year }}</div>
+        <div class="corner-ribbon"></div>
+        <div class="score" id="score-senior">0</div>
+        points
+    </div>
+    <div class="box">
+        <div class="class">{{ senior_graduation_year|add:"1" }}</div>
+        <div class="corner-ribbon"></div>
+        <div class="score" id="score-junior">0</div>
+        points
+    </div>
+    <div class="box">
+        <div class="class">{{ senior_graduation_year|add:"2" }}</div>
+        <div class="corner-ribbon"></div>
+        <div class="score" id="score-sophomore">0</div>
+        points
+    </div>
+    <div class="box">
+        <div class="class">{{ senior_graduation_year|add:"3" }}</div>
+        <div class="corner-ribbon"></div>
+        <div class="score" id="score-freshman">0</div>
+        points
+    </div>
+</div>
+<br>
+<script src="{% static 'js/hoco_ribbon.js' %}"></script>


### PR DESCRIPTION
## Proposed changes
- Adds homecoming scores (currently only on login page) to Ion dashboard and Signage homepage
- Resolves #1412 

![image](https://user-images.githubusercontent.com/62958782/200437223-230cfd2b-99c9-4872-babd-e4dbead3e35c.png)
![image](https://user-images.githubusercontent.com/62958782/200437282-f68d918f-b8dd-4247-9608-fa4b6aa1bf9e.png)


## Brief description of rationale
It is somewhat inconvenient to have to visit [the homecoming site](https://homecoming.tjhsst.edu) or log out from Ion in order to view hoco scores