### PR TITLE
fix(bus): make bus status indicators visible in dark mode

### DIFF
--- a/intranet/static/css/dark/bus.scss
+++ b/intranet/static/css/dark/bus.scss
@@ -10,6 +10,10 @@ svg path.a[style*="stroke: black;"] {
     stroke: white !important;
 }
 
+h2.colored-header {
+    color: #0D0D0B;
+}
+
 @media (max-width: 550px) {
     .action-view.search-widget {
         &, .search-widget {

--- a/intranet/templates/bus/home.html
+++ b/intranet/templates/bus/home.html
@@ -33,7 +33,7 @@
     {% verbatim %}
     <script type="text/template" id="personal-status">
         <% if (route_name !== "Empty route") { %>
-            <h2 class="personal-status bordered-element <%= label_status_strings[status].color %>">
+            <h2 class="personal-status bordered-element colored-header <%= label_status_strings[status].color %>">
                 <i class="fas fa-regular fa-<%= label_status_strings[status].icon %>"></i>&nbsp;
                 <strong> <%= route_name %> </strong>
                 <%= label_status_strings[status].personal %>

--- a/intranet/templates/bus/morning.html
+++ b/intranet/templates/bus/morning.html
@@ -47,19 +47,19 @@
         {% endif %}
         <br>
         <div>
-            <h2 class="title green">
+            <h2 class="title green colored-header">
                 <i class="fas fa-regular fa-check"></i>
                 Arrived
             </h2>
             <div class="list" id="arrived"></div>
             <br>
-            <h2 class="title blue">
+            <h2 class="title blue colored-header">
                 <i class="fas fa-regular fa-clock"></i>
                 On Time
             </h2>
             <div class="list" id="ontime"></div>
             <br>
-            <h2 class="title red">
+            <h2 class="title red colored-header">
                 <i class="fas fa-regular fa-exclamation-circle"></i>
                 Delayed
             </h2>


### PR DESCRIPTION
## Proposed changes
- Change bus status text to improve visibility in dark mode
- (Partially) resolves #1453 

### Before

![image](https://user-images.githubusercontent.com/62958782/200440259-e61404f8-af0a-462d-a93d-503ef46eccb4.png)
![image](https://user-images.githubusercontent.com/62958782/200440716-ea4e3de3-e3ea-418f-868c-9bad2988cd77.png)

### After

![image](https://user-images.githubusercontent.com/62958782/200440136-a16f7617-8e62-42f0-8acd-9b51117702e5.png)
![image](https://user-images.githubusercontent.com/62958782/200445521-394f39f8-6934-4d4e-b0ca-d8996a0a72ca.png)

## Brief description of rationale
It is hard to read to the bus message when on dark mode