### PR TITLE
fix(hoco): move TJ logo down on vertical signages

### DIFF
--- a/intranet/static/css/signage.base.scss
+++ b/intranet/static/css/signage.base.scss
@@ -184,4 +184,8 @@ section.signage-section {
         width: 100%;
         height: calc(95vh - 20px);
     }
+
+    .signage-section.signage-home .tjlogo {
+        margin-top: 350px;
+    }
 }


### PR DESCRIPTION
## Proposed changes
- Move TJ logo further down on vertical signages
- Fix hoco scores added in #1454 from overlapping with the TJ logo on vertical signages

![image](https://user-images.githubusercontent.com/62958782/200472061-531436a3-6933-4be3-b2bb-bc97ed69ed07.png)

## Brief description of rationale
 - Fixes a bug
 - Looks better