### PR TITLE
fix(announcements): fix teacher approval message

### DIFF
--- a/intranet/templates/announcements/approve.html
+++ b/intranet/templates/announcements/approve.html
@@ -121,7 +121,7 @@
             </ul>
             <br>
         {% else %}
-            <p>{{ user.full_name }} ({{ user }}) submitted an Intranet announcement, and has asked for you to approve its posting. All Intranet announcements must first be approved by a teacher or faculty sponsor before they can be posted. The details of this announcement are included below.</p>
+            <p><a href="{% url 'user_profile' req.user.id %}">{{ req.user.full_name }} ({{ req.user }})</a> submitted an Intranet announcement, and has asked for you to approve its posting. All Intranet announcements must first be approved by a teacher or faculty sponsor before they can be posted. The details of this announcement are included below.</p>
             <p>You may edit the fields below if you would like to change what was submitted. Please note that pressing the 'Approve' button below will not automatically post the announcement; it places the announcement in a queue for submission by an administrator.</p>
         {% endif %}
         </td>


### PR DESCRIPTION
Message used to say that the teacher submitted the announcement, when it should say the student.
For example, assume Bob requests an announcement for Mr. Joe to approve. The message currently reads:
"Mr. Joe submitted an Intranet announcement, and has asked for you to approve its posting."
It should read:
"Bob submitted an Intranet announcement, and has asked for you to approve its posting."

