### PR TITLE
refactor(bus): adjust warning text color for dark mode

### DIFF
--- a/intranet/static/css/dark/bus.scss
+++ b/intranet/static/css/dark/bus.scss
@@ -21,3 +21,8 @@ h2.colored-header {
         }
     }
 }
+
+.bus-announcement-alert {
+    color: #0D0D0B;
+    border: 3px solid #0D0D0B;
+}


### PR DESCRIPTION
Color was previously grey, making it hard to see on the red warning background.