### PR TITLE
feat(polls): fix poll visibility

### DIFF
--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -970,6 +970,15 @@ class User(AbstractBaseUser, PermissionsMixin):
         now = timezone.localtime()
         return Poll.objects.visible_to_user(self).filter(start_time__lt=now, end_time__gt=now).exclude(question__answer__user=self).exists()
 
+    def should_see_polls(self) -> bool:
+        """
+
+        Returns whether the user should have the Polls icon visible
+
+        """
+        now = timezone.localtime()
+        return Poll.objects.visible_to_user(self).filter(start_time__lt=now, end_time__gt=now).exists() or self.has_admin_permission("polls")
+
     def signed_up_today(self) -> bool:
         """If the user is a student, returns whether they are signed up for an activity during
         all eighth period blocks that are scheduled today. Otherwise, returns ``True``.

--- a/intranet/templates/nav.html
+++ b/intranet/templates/nav.html
@@ -85,6 +85,7 @@
         </li>
         {% endcomment %}
 
+        {% if request.user.should_see_polls %}
         <li {% if nav_category == "polls" %}class="selected"{% endif %}>
             <a href="{% url 'polls' %}">
                 <div class="nav-alert-container">
@@ -96,6 +97,7 @@
                 Polls
             </a>
         </li>
+        {% endif %}
 
         <li {% if nav_category == "files" %}class="selected"{% endif %}>
             <a href="{% url 'files' %}">


### PR DESCRIPTION
## Proposed changes
- Add function "should_see_polls" for User model
- Use it in a template tag in nav.html 

## Brief description of rationale
The function should_see_polls returns true if there are any active polls visible to the user or if the user has admin permissions to polls in which case the polls icon should always be available. This function is used in a template tag in nav.html to only show the polls icon when necessary for the user.