### PR TITLE
Fix formtools

### DIFF
--- a/Ion.egg-info/requires.txt
+++ b/Ion.egg-info/requires.txt
@@ -18,7 +18,7 @@ django-cacheops==6.1
 django-cors-headers==3.13.0
 django-debug-toolbar==3.6.0
 django-extensions==3.2.0
-django-formtools==2.4
+django-formtools==2.3
 django-inline-svg==0.1.1
 django-maintenance-mode==0.16.3
 django-oauth-toolkit==2.1.0

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -18,7 +18,7 @@ django-cacheops==6.1
 django-cors-headers==3.13.0
 django-debug-toolbar==3.6.0
 django-extensions==3.2.0
-django-formtools==2.4
+django-formtools==2.3
 django-inline-svg==0.1.1
 django-maintenance-mode==0.16.3
 django-oauth-toolkit==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ django-cacheops==6.1
 django-cors-headers==3.13.0
 django-debug-toolbar==3.6.0
 django-extensions==3.2.0
-django-formtools==2.4
+django-formtools==2.3
 django-inline-svg==0.1.1
 django-maintenance-mode==0.16.3
 django-oauth-toolkit==2.1.0


### PR DESCRIPTION
## Proposed changes
- Fix `django-formtools` breaking `/eighth` for teachers
- Rollback to v2.3 after bump in https://github.com/tjcsl/ion/commit/e732f3bb27148068297ce8d56b93178db7ce85a2