### PR TITLE
fix(dev): remove unneeded pipenv commands

### DIFF
--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -10,7 +10,6 @@ COPY requirements-dev.txt .
 RUN apk update && \
     apk add bash git curl python3 python3-dev py3-pip build-base libpq-dev freetype-dev libffi-dev ruby-full libmagic krb5 kinit rsync nodejs npm tzdata && \
     npm install -g sass && \
-    pip3 install pipenv && \
     ln -s /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     pip3 install -Ir requirements.txt && \
     pip3 install -Ir requirements-dev.txt && \

--- a/config/docker/docker-compose.yml
+++ b/config/docker/docker-compose.yml
@@ -56,7 +56,7 @@ services:
         "/bin/sh",
         "-c",
         "git config --global --add safe.directory /ion && \
-         pipenv run celery --app intranet worker -l info --without-gossip --without-mingle --without-heartbeat -Ofair"
+         celery --app intranet worker -l info --without-gossip --without-mingle --without-heartbeat -Ofair"
       ]
     depends_on:
       - application
@@ -73,7 +73,7 @@ services:
         "/bin/sh",
         "-c",
         "git config --global --add safe.directory /ion && \
-         pipenv run celery --app intranet beat -l info"
+         celery --app intranet beat -l info"
       ]
     depends_on:
       - application

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -118,7 +118,7 @@ EMERGENCY_MESSAGE = None  # type: str
 # In production, Nginx filters requests that are not in this list. If this is
 # not done, a notification gets sent whenever someone messes with
 # the HTTP Host header.
-ALLOWED_HOSTS = ["ion.tjhsst.edu", "198.38.18.250", "localhost", "127.0.0.1"]
+ALLOWED_HOSTS = ["ion.tjhsst.edu", "198.38.18.250", "localhost", ".local", "127.0.0.1"]
 
 PRODUCTION = os.getenv("PRODUCTION", "").upper() == "TRUE"
 IN_CI = any(os.getenv(key, "").upper() == "TRUE" for key in ["TRAVIS", "GITHUB_ACTIONS"])


### PR DESCRIPTION
## Proposed changes
- pipenv isn't needed to run celery and celerybeat
- Also small change to allow `.local` in ALLOWED_HOSTS
