### PR TITLE
refactor(dashboard): increase number of announcements displayed to 15

### DIFF
--- a/intranet/apps/dashboard/views.py
+++ b/intranet/apps/dashboard/views.py
@@ -276,7 +276,7 @@ def paginate_announcements_list(request, context, items):
     else:
         start_num = 0
 
-    display_num = 10
+    display_num = 15
     end_num = start_num + display_num
     prev_page = start_num - display_num
     more_items = (len(items) - start_num) > display_num


### PR DESCRIPTION
There has been an increasing amount
of announcements posted to Ion,
so increasing the number visible
at a time will help with navigating
all of them.

## Proposed changes
- 
- 
- 

## Brief description of rationale
