### PR TITLE
fix(events): fix events admin load timeout

### DIFF
--- a/intranet/apps/events/admin.py
+++ b/intranet/apps/events/admin.py
@@ -2,4 +2,10 @@ from django.contrib import admin
 
 from .models import Event, Link
 
-admin.site.register([Event, Link])
+
+class EventAdmin(admin.ModelAdmin):
+    raw_id_fields = ("scheduled_activity", "announcement")
+
+
+admin.site.register(Event, EventAdmin)
+admin.site.register(Link)


### PR DESCRIPTION
## Proposed changes
- Change `Event.scheduled_activity` and `Event.announcement` fields to raw_id in Django Admin

## Brief description of rationale
Having these fields (especially `scheduled_activity`) as normal dropdowns causes a page load timeout, since Django Admin queries for every row in their respective models when creating or editing events.