### PR TITLE
chore(misc): cleanup scav hunt link

### DIFF
--- a/intranet/templates/dashboard/links.html
+++ b/intranet/templates/dashboard/links.html
@@ -20,7 +20,6 @@
           <a href="mailto:sysadmins@tjhsst.edu">Report a Bug in the CSL</a><br>
           <a href="https://docs.google.com/forms/d/e/1FAIpQLSdtutcsGAdQU9lkSuHrMssKpH0uub7haC7L490Xd17jFJnhug/viewform">Submit an Integrity Violation</a><br>
           <a href="https://goo.gl/forms/HnhJoUkuD9lzdwX72">Submit a Safety Concern</a><br>
-          <a href="https://docs.google.com/document/d/1Z4Inyz8IJ30SAeTEgYRJtHtO7KDURm4P1oHc7GnO5DY/edit">Contact an Ion Agent</a><br>
 
           <h5 class="link-heading">Tutorials</h5>
           <a href="https://guides.tjhsst.edu/webmail/forwarding-email">TJ Email Forwarding</a><br>


### PR DESCRIPTION
## Proposed changes
- Remove `Contact an Ion Agent` link that was added for the 2023 homecoming scavenger hunt
