### PR TITLE
feat(printing): hide printers which are disabled on CUPS

### DIFF
--- a/intranet/apps/printing/views.py
+++ b/intranet/apps/printing/views.py
@@ -52,7 +52,7 @@ def get_printers() -> Dict[str, str]:
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
             return []
 
-        PRINTER_LINE_RE = re.compile(r"^printer\s+(\w+)", re.ASCII)
+        PRINTER_LINE_RE = re.compile(r"^printer\s+(\w+)\s+(?!disabled)", re.ASCII)
         DESCRIPTION_LINE_RE = re.compile(r"^\s+Description:\s+(.*)\s*$", re.ASCII)
 
         printers = {}


### PR DESCRIPTION
## Proposed changes
- Only add printers to Ion's printer list if the `lpstat` command output does not indicate they're disabled 

## Brief description of rationale

It is often helpful to hide printers from Ion by just disabling them in CUPS, as opposed to deleting them entirely