### PR TITLE
fix(printing): fix disabled printers bug

### DIFF
--- a/intranet/apps/printing/views.py
+++ b/intranet/apps/printing/views.py
@@ -82,6 +82,7 @@ def get_printers() -> Dict[str, str]:
                         # And make sure we don't set an empty description
                         if description:
                             printers[last_name] = description
+                            last_name = None
 
         cache.set(key, printers, timeout=settings.CACHE_AGE["printers_list"])
         return printers


### PR DESCRIPTION
## Proposed changes
- Make sure a printer's name (referred to as description) is not overridden by other printers

## Brief description of rationale
Fixes a bug that affects #1603