### PR TITLE
fix(dev): fix docker env breaking on latest alpine version

### DIFF
--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.18 
 
 ENV TZ America/New_York
 ENV C_FORCE_ROOT true


### PR DESCRIPTION
## Proposed changes
- Specify version of alpine instead of using latest
- Fix error where `ERROR: unable to select packages: kinit (no such package): required by: world[kinit]`

- New alpine docker image has a fix to make it work but in the future it is better to specify a static version in case new versions break.