### PR TITLE
docs: Fix outdated README.rst hyperlink

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Intranet 3
 *Version 3.0.0*
 
 Intranet3 (Ion) is the next-generation Intranet platform for `TJHSST 
-<https://www.tjhsst.edu/>`_. Using Python, Django, Redis, Postgres, and many other technologies, Ion was developed from the ground up to be simple, well-documented, and extensible.
+<https://tjhsst.fcps.edu/>`_. Using Python, Django, Redis, Postgres, and many other technologies, Ion was developed from the ground up to be simple, well-documented, and extensible.
 
 Documentation (in RestructuredText format) is available inside the "docs" folder or at https://tjcsl.github.io/ion publicly on the web.
 


### PR DESCRIPTION
## Proposed changes
- Changed from https://www.tjhsst.edu to https://tjhsst.fcps.edu

## Brief description of rationale
Old url gave a redirect notice
![Redirect Notice to https://tjhsst.fcps.edu](https://github.com/tjcsl/ion/assets/110117391/847cc9ca-6e58-4a1c-9eaa-6f7aa7b8102b)
