### PR TITLE
chore(docs): fix CODEOWNERS file syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
-*   @alanzhu0
-*   @NotFish232
+*   @alanzhu0 @NotFish232
 
 intranet/ @tjcsl/intranet-admins 
 docs/ @tjcsl/intranet-admins 


### PR DESCRIPTION
## Proposed changes
- Move code owners to the same line

## Brief description of rationale
According to the [GitHub docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax),

> If you want to match two or more code owners with the same pattern, all the code owners must be on the same line. If the code owners are not on the same line, the pattern matches only the last mentioned code owner.