### PR TITLE
chore(docs): simplify CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,1 @@
-*   @alanzhu0
-*   @NotFish232
-
-intranet/ @tjcsl/intranet-admins 
-docs/ @tjcsl/intranet-admins 
-signage/ @tjcsl/intranet-admins
-.pylintrc @tjcsl/intranet-admins
+*   @tjcsl/intranet-admins


### PR DESCRIPTION
## Proposed changes
- Make @tjcsl/intranet-admins the sole code owner

## Brief description of rationale
GitHub Teams now support auto-assigning members for review. So, making the team code owner is simpler/more convenient.

This replaces #1634.