### PR TITLE
fix(dev): use python 3.8

### DIFF
--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18 
+FROM python:3.8.19-alpine3.18
 
 ENV TZ America/New_York
 ENV C_FORCE_ROOT true
@@ -8,7 +8,7 @@ COPY requirements.txt .
 COPY requirements-dev.txt .
 
 RUN apk update && \
-    apk add bash git curl python3 python3-dev py3-pip build-base libpq-dev freetype-dev libffi-dev ruby-full libmagic krb5 kinit rsync nodejs npm tzdata libxml2-dev libxslt-dev && \
+    apk add bash git curl build-base libpq-dev freetype-dev libffi-dev ruby-full libmagic krb5 kinit rsync nodejs npm tzdata libxml2-dev libxslt-dev && \
     npm install -g sass && \
     ln -s /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     pip3 install -Ir requirements.txt && \


### PR DESCRIPTION
## Proposed changes
- Use `python:3.8.19-alpine3.18` as the base image
- Don't install Python 3.11

## Brief description of rationale
Python 3.8 better emulates production Ion at the moment, and this change can help catch bugs like 9afc0466a186016bc9f13e9534bb6205381840a1 before they hit production.