### PR TITLE
fix(dev): don't buffer Django output

### DIFF
--- a/config/docker/entrypoint.sh
+++ b/config/docker/entrypoint.sh
@@ -7,6 +7,7 @@ fi
 
 sass --watch intranet/static/css:intranet/collected_static/css &  # Automatically compile modified scss files
 
+export PYTHONUNBUFFERED=1  # Don't buffer Django output
 
 # Wrap the run command in a loop so that it restarts if it crashes, e.g. due to a syntax error
 while true


### PR DESCRIPTION
## Proposed changes
- Set the `PYTHONUNBUFFERED` environment variable in `entrypoint.sh`

## Brief description of rationale
Previously, print statements without `flush=True` would not be displayed until a server restart. This change unbuffers `stdout` and `stderr` from Django's development server to allow for easier debugging with print statements.