### PR TITLE
style(welcome): center the dashboard icon

### DIFF
--- a/intranet/static/css/welcome.scss
+++ b/intranet/static/css/welcome.scss
@@ -18,11 +18,6 @@ body {
     overflow-y: auto;
 }
 
-#welcome-container button i.fas,
-#welcome-container a.button i.fas {
-    margin-left: 8px;
-}
-
 #welcome {
     width: 90%;
     max-width: 800px;
@@ -32,12 +27,20 @@ body {
     border-radius: 5px;
 }
 
-#welcome > div:not(#ion-welcome) {
-    margin: 15px;
-}
-
-#welcome > div#ion-welcome {
-    margin: 15px 0;
+#welcome > div {
+    &:not(#ion-welcome) {
+        margin: 15px;
+    }
+    &#ion-welcome {
+        margin: 15px 0;
+    }
+    &:not(#step-3) {
+        button, a.button {
+            i.fas {
+                margin-left: 8px;
+            }
+        }
+    }
 }
 
 #ion-welcome {


### PR DESCRIPTION
## Proposed changes
- Don't apply `margin-left: 8px;` to the dashboard icon
- Consolidate some scss

## Brief description of rationale
The dashboard icon is too far right due to a CSS property that adds margins to the left of icons. This property was intended for icons placed to the right of text, and therefore should not apply here.

Before and after:
![image](https://github.com/tjcsl/ion/assets/62958782/afa43cff-12a9-4c67-b110-a4affac2ac75)
![image](https://github.com/tjcsl/ion/assets/62958782/7373851e-1121-420c-9226-665382127efb)
