### PR TITLE
chore(eighth): replace text instances of 48 hour presign with 2 day

### DIFF
--- a/intranet/apps/eighth/models.py
+++ b/intranet/apps/eighth/models.py
@@ -191,7 +191,7 @@ class EighthActivity(AbstractBaseEighthModel):
             Use scheduled_activity.get_true_rooms()
         default_capacity (int): The default capacity, which overrides the sum of the default rooms when
             scheduling the activity. By default, this has a null value and is ignored.
-        presign (bool): If True, the activity can only be signed up for within 48 hours of the day that
+        presign (bool): If True, the activity can only be signed up for within 2 days of the day that
             the activity is scheduled.
         one_a_day (bool): If True, a student can only sign up for one instance of this activity per day.
         both_blocks (bool): If True, a signup for an EighthScheduledActivity during an A or B block will
@@ -978,7 +978,7 @@ class EighthScheduledActivity(AbstractBaseEighthModel):
     def is_too_early_to_signup(self, now: Optional[datetime.datetime] = None) -> (bool, datetime):
         """Returns whether it is too early to sign up for the activity
         if it is a presign.
-        This contains the 48 hour presign logic.
+        This contains the 2 day pre-signup logic.
         Args:
             now: A datetime object to use for the check instead of the current time.
         Returns:

--- a/intranet/apps/eighth/tests/test_signup.py
+++ b/intranet/apps/eighth/tests/test_signup.py
@@ -109,7 +109,7 @@ class EighthSignupTest(EighthAbstractTest):
         schactA.capacity = 1
         schactA.save()
 
-        # Add user to an activity with 48 hour presign before 48 hours (this should fail)
+        # Add user to an activity with 2 day presign before 2 days (this should fail)
         activity.presign = True
         activity.save()
 

--- a/intranet/templates/eighth/activity.html
+++ b/intranet/templates/eighth/activity.html
@@ -84,7 +84,7 @@
         <span class="badge" title="This activity is administrative.">Administrative</span>
     {% endif %}
     {% if activity.presign %}
-        <span class="badge yellow" title="You may only sign up for this activity 48 hours in advance.">48-hr Presign</span>
+        <span class="badge yellow" title="You may only sign up for this activity 2 days in advance.">2 day Pre-signup</span>
     {% endif %}
 
     {% if not activity.is_active %}

--- a/intranet/templates/eighth/admin/schedule_activity.html
+++ b/intranet/templates/eighth/admin/schedule_activity.html
@@ -129,7 +129,7 @@
                     <span class="badge" title="This activity is administrative.">Administrative</span>
                 {% endif %}
                 {% if activity.presign %}
-                    <span class="badge yellow" title="You may only sign up for this activity 48 hours in advance.">48-hr Presign</span>
+                    <span class="badge yellow" title="You may only sign up for this activity 2 days in advance.">2 day Pre-signup</span>
                 {% endif %}
 
                 {% if not activity.is_active %}

--- a/intranet/templates/eighth/multi_signup.html
+++ b/intranet/templates/eighth/multi_signup.html
@@ -145,7 +145,7 @@
                 <% } %>
 
                 <% if (presign) { %>
-                    <span class="badge yellow">48-hr</span>
+                    <span class="badge yellow">2 day Pre-signup</span>
                 <% } %>
 
                 <%  if (finance) { %>
@@ -218,7 +218,7 @@
         <% } %>
 
         <% if (presign) { %>
-            <span class="badge yellow clickable" data-append-search="is:p" title="You may only sign up for this activity 48 hours in advance.">48-hr Presign</span>
+            <span class="badge yellow clickable" data-append-search="is:p" title="You may only sign up for this activity 2 days in advance.">2 day Pre-signup</span>
         <% } %>
 
         <% scheduled_activity_id = this.model.attributes.scheduled_activity.id %>

--- a/intranet/templates/eighth/profile_signup.html
+++ b/intranet/templates/eighth/profile_signup.html
@@ -145,7 +145,7 @@
                 <% } %>
 
                 <% if (presign) { %>
-                    <span class="badge yellow">48-hr</span>
+                    <span class="badge yellow">2 day Pre-signup</span>
                 <% } %>
 
                 <%  if (finance && finance !== "") { %>
@@ -213,7 +213,7 @@
         <% } %>
 
         <% if (presign) { %>
-            <span class="badge yellow clickable" data-append-search="is:p" title="You may only sign up for this activity 48 hours in advance.">48-hr Presign</span>
+            <span class="badge yellow clickable" data-append-search="is:p" title="You may only sign up for this activity 2 days in advance.">2 day Pre-signup</span>
         <% } %>
 
         <% scheduled_activity_id = this.model.attributes.scheduled_activity.id %>

--- a/intranet/templates/signage/pages/eighth.html
+++ b/intranet/templates/signage/pages/eighth.html
@@ -385,7 +385,7 @@
                 <% } %>
 
                 <% if (presign) { %>
-                    <span class="badge yellow" title="You may only sign up for this activity 48 hours in advance.">48-hr</span>
+                    <span class="badge yellow" title="You may only sign up for this activity 2 days in advance.">2 day Pre-signup</span>
                 <% } %>
 
                 <% if (finance) { %>
@@ -455,7 +455,7 @@
         <% } %>
 
         <% if (presign) { %>
-            <span class="badge yellow clickable" data-append-search="is:p" title="You may only sign up for this activity 48 hours in advance.">48-hr Presign</span>
+            <span class="badge yellow clickable" data-append-search="is:p" title="You may only sign up for this activity 2 days in advance.">2 day Pre-signup</span>
         <% } %>
 
         <% scheduled_activity_id = this.model.attributes.scheduled_activity.id %>


### PR DESCRIPTION
Closes #1577

## Proposed changes
- Replaced all 48 hour presign text instances in Ion with the 2 day text 

## Brief description of rationale
- Consistency in text across the codebase