### PR TITLE
feat(printing): add rate limit to print job requests (closes tjcsl#662)

### DIFF
--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -646,7 +646,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         return self.has_admin_permission("eighth")
 
     @property
-    def has_print_permission(self) -> bool:
+    def is_printing_admin(self) -> bool:
         """Checks if user has the admin permission 'printing'.
 
         Returns:

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -215,7 +215,12 @@ FILE_UPLOAD_HANDLERS = ["django.core.files.uploadhandler.MemoryFileUploadHandler
 # The maximum number of pages in one document that can be
 # printed through the printing functionality (determined through pdfinfo)
 # even number preferred to allow for maximum utilization of duplex printing
-PRINTING_PAGES_LIMIT = 16
+PRINTING_PAGES_LIMIT_STUDENTS = 16
+PRINTING_PAGES_LIMIT_TEACHERS = 50
+
+# The rate limit for print job requests (2 requests every 5 minutes)
+PRINT_RATELIMIT_FREQUENCY = 2
+PRINT_RATELIMIT_MINUTES = 5
 
 # The maximum file upload and download size for files
 FILES_MAX_UPLOAD_SIZE = 200 * 1024 * 1024

--- a/intranet/templates/nav.html
+++ b/intranet/templates/nav.html
@@ -116,7 +116,7 @@
             </a>
         </li>
 
-        {% if is_tj_ip or request.user.has_print_permission %}
+        {% if is_tj_ip or request.user.is_printing_admin %}
             <li {% if nav_category == "printing" %}class="selected"{% endif %}>
                 <a href="{% url 'printing' %}">
                     <i class="nav-icon print-icon"></i>

--- a/intranet/templates/printing/print_form.html
+++ b/intranet/templates/printing/print_form.html
@@ -22,7 +22,14 @@
     <br>
     <b>The following restrictions apply:</b>
     <ul>
-        <li>Print jobs can have a maximum of {{ DJANGO_SETTINGS.PRINTING_PAGES_LIMIT }} pages.</li>
+        {% if user.is_teacher or user.is_printing_admin %}
+        <li>Print jobs can have a maximum of {{ DJANGO_SETTINGS.PRINTING_PAGES_LIMIT_TEACHERS }} pages.</li>
+        {% else %}
+        <li>Print jobs can have a maximum of {{ DJANGO_SETTINGS.PRINTING_PAGES_LIMIT_STUDENTS }} pages.</li>
+        {% endif %}
+        {% if not user.is_teacher and not user.is_printing_admin %}
+        <li>You may send up to {{ DJANGO_SETTINGS.PRINT_RATELIMIT_FREQUENCY}} print jobs every {{ DJANGO_SETTINGS.PRINT_RATELIMIT_MINUTES }} minutes.</li>
+        {% endif %}
         <li>If the printer doesn't appear to be working, do <b>NOT</b> keep attempting to print. Instead, contact the Student Systems Administrators with <a href="{% url 'send_feedback' %}">the Ion feedback form</a>.</li>
         <li>Please be mindful of other printing users.</li>
         <li>Do not print documents that use an excessive amount of ink (e.g. dark backgrounds).</li>


### PR DESCRIPTION
## Proposed changes
- Add a rate limit of 10 POST requests per minute to ion printing
- Fix some linting errors from previous contributors in the printing/views.py file so checks can pass

## Brief description of rationale
Blocks excessive printing by users to prevent abuse or overload of the printers