### PR TITLE
Fix depends_on attributes in docker compose

### DIFF
--- a/config/docker/docker-compose.yml
+++ b/config/docker/docker-compose.yml
@@ -59,7 +59,7 @@ services:
          celery --app intranet worker -l info --without-gossip --without-mingle --without-heartbeat -Ofair"
       ]
     depends_on:
-      - intranet_django
+      - django
     volumes:
       - ../../:/ion:z
 
@@ -76,7 +76,7 @@ services:
          celery --app intranet beat -l info"
       ]
     depends_on:
-      - intranet_django
+      - django
     volumes:
       - ../../:/ion:z
 


### PR DESCRIPTION
## Proposed changes
- Use the service name (`django`) instead of the container name (`intranet_django`) in `depends_on` attributes

## Brief description of rationale
Before:
```
service "celery" depends on undefined service "intranet_django": invalid compose project
```

After:
```
[+] Building 0.3s (11/11) FINISHED
```

This bug was introduced in f041203106924e162483a570b8d5c450026253be (PR #1658).