### PR TITLE
fix(scripts): fix scope regex to match convention commit specification

### DIFF
--- a/scripts/validate-commit-messages.py
+++ b/scripts/validate-commit-messages.py
@@ -51,7 +51,7 @@ def main():
 
         if (
             re.search(
-                r"^(build|chore|ci|docs|feat|fix|perf|refactor|style|test)(\([a-z]+\))?: .*$",
+                r"^(build|chore|ci|docs|feat|fix|perf|refactor|style|test)(\([^()\n]+\))?: .*$",
                 lines[0],
             )
             is None


### PR DESCRIPTION
The conventional commit grammar allows the scope to be any utf-8 characters, except for newlines and parenthesis (see [here](https://github.com/conventional-commits/parser#the-grammar)).
Currently, we only accept the lowercase English alphabet.