### PR TITLE
Add values_list("token, "expires") to reduce CSL Apps load time (Closes Issue #1663)

### DIFF
--- a/intranet/apps/cslapps/views.py
+++ b/intranet/apps/cslapps/views.py
@@ -26,7 +26,7 @@ def redirect_to_app(request):
                         return response
                     return redirect(app.url)
                 else:
-                    last_token = AccessToken.objects.filter(user=request.user, application=app.oauth_application).order_by("-expires").first()
+                    last_token = AccessToken.objects.filter(user=request.user, application=app.oauth_application).order_by("-expires").values_list("token", "expires").first()
                     if last_token and last_token.is_valid():
                         return redirect(app.url)
                     return redirect(app.auth_url)


### PR DESCRIPTION
## Proposed changes
- Add `values_list("token, "expires")` in between `.order_by("-expires")` and `.first()`

## Brief description of rationale
Instead of retrieving all of the fields from the AccessToken object (which leads to slower load times), only retrieve necessary fields to filter the most recent Token. In turn, this will improve the load time of CSL apps.

#1663 