### PR TITLE
chore: changes to let lint checks pass

### DIFF
--- a/intranet/apps/eighth/views/admin/groups.py
+++ b/intranet/apps/eighth/views/admin/groups.py
@@ -606,6 +606,7 @@ eighth_admin_distribute_unsigned = eighth_admin_required(EighthAdminDistributeGr
 
 @eighth_admin_required
 def eighth_admin_distribute_action(request):
+    block = None
     if "users" in request.POST:
         activity_user_map = {}
         for item in request.POST:

--- a/intranet/apps/eighth/views/attendance.py
+++ b/intranet/apps/eighth/views/attendance.py
@@ -72,7 +72,7 @@ class EighthAttendanceSelectScheduledActivityWizard(SessionWizardView):
     def get_form_kwargs(self, step=None):
         kwargs = {}
         block = None
-
+        block_title = None
         if step == "block":
             show_all_blocks = "show_all_blocks" in self.request.GET or "block" in self.request.GET
             if show_all_blocks:

--- a/intranet/apps/users/views.py
+++ b/intranet/apps/users/views.py
@@ -121,6 +121,7 @@ def picture_view(request, user_id, year=None):
     """
     user = get_object_or_404(get_user_model(), id=user_id)
     default_image_path = os.path.join(settings.PROJECT_ROOT, "static/img/default_profile_pic.png")
+    image_buffer = None
 
     img = None
     if year is None:

--- a/intranet/utils/deletion.py
+++ b/intranet/utils/deletion.py
@@ -34,6 +34,7 @@ def set_historical_user(collector, field, sub_objs, using):
 
 
 def handle_eighth_sponsor_deletion(in_obj, eighth_sponsor):
+    original = None
     teststaff, _ = get_user_model().objects.get_or_create(id=7011)
     c = Collector(using="default")
     c.collect([in_obj])


### PR DESCRIPTION
## Proposed changes
- Declare variables as `None` in the problematic functions at the start, and assume they will be set later on so pylint doesn't complain


## Brief description of rationale
This makes linting checks pass (I think)