### PR TITLE
feat(auth): switch to PAM

### DIFF
--- a/Ion.egg-info/PKG-INFO
+++ b/Ion.egg-info/PKG-INFO
@@ -62,11 +62,13 @@ Requires-Dist: pyrankvote==2.0.5
 Requires-Dist: pysftp==0.2.9
 Requires-Dist: python-dateutil==2.8.2
 Requires-Dist: python-magic==0.4.27
+Requires-Dist: python-pam==2.0.2
 Requires-Dist: reportlab==3.6.13
 Requires-Dist: requests==2.31.0
 Requires-Dist: requests-oauthlib==1.3.1
 Requires-Dist: sentry-sdk==1.15.0
 Requires-Dist: setuptools-git==1.2
+Requires-Dist: six==1.16.0
 Requires-Dist: Sphinx==5.2.3
 Requires-Dist: sphinx-bootstrap-theme==0.8.1
 Requires-Dist: tblib==1.7.0

--- a/Ion.egg-info/requires.txt
+++ b/Ion.egg-info/requires.txt
@@ -47,11 +47,13 @@ pyrankvote==2.0.5
 pysftp==0.2.9
 python-dateutil==2.8.2
 python-magic==0.4.27
+python-pam==2.0.2
 reportlab==3.6.13
 requests==2.31.0
 requests-oauthlib==1.3.1
 sentry-sdk==1.15.0
 setuptools-git==1.2
+six==1.16.0
 Sphinx==5.2.3
 sphinx-bootstrap-theme==0.8.1
 tblib==1.7.0

--- a/intranet/apps/auth/helpers.py
+++ b/intranet/apps/auth/helpers.py
@@ -43,5 +43,6 @@ def change_password(form_data):
     except pexpect.TIMEOUT:
         return {"unable_to_set": True, "errors": errors}
     if exitstatus == 0:
+        logging.debug("Password changed for %s", form_data["username"])
         return {"unable_to_set": False}
     return {"unable_to_set": True}

--- a/intranet/apps/auth/tests.py
+++ b/intranet/apps/auth/tests.py
@@ -49,10 +49,9 @@ class LoginViewTest(IonTestCase):
         self.assertTrue(self.does_login_redirect_to(reverse("index")))
 
     def test_login(self):
-        """Just test Kerberos login, but not really because Kerberos isn't accessible from here..."""
+        """Just test PAM login, but not really because PAM isn't accessible from here..."""
 
-        with self.settings(KINIT_TIMEOUT=1):
-            response = self.client.post(reverse("login"), data={"username": "awilliam", "password": "dankmemes123"})
+        response = self.client.post(reverse("login"), data={"username": "awilliam", "password": "dankmemes123"})
         self.assertEqual(200, response.status_code)
 
     def test_logout_view(self):

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -390,12 +390,17 @@ LIST_OF_INDEPENDENT_CSS = [
 for name in LIST_OF_INDEPENDENT_CSS:
     PIPELINE["STYLESHEETS"].update(helpers.single_css_map(name))
 
-AUTHENTICATION_BACKENDS = (
-    "django.contrib.auth.backends.ModelBackend",
+AUTHENTICATION_BACKENDS = [
+    "intranet.apps.auth.backends.PamAuthenticationBackend",
     "intranet.apps.auth.backends.MasterPasswordAuthenticationBackend",
-    "intranet.apps.auth.backends.KerberosAuthenticationBackend",
     "oauth2_provider.backends.OAuth2Backend",
-)
+    "django.contrib.auth.backends.ModelBackend",
+]
+
+# The Alpine dev env doesn't work well with PAM
+if not PRODUCTION:
+    AUTHENTICATION_BACKENDS.remove("intranet.apps.auth.backends.PamAuthenticationBackend")
+
 # Default to Argon2, see https://docs.djangoproject.com/en/dev/topics/auth/passwords/#argon2-usage
 PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.Argon2PasswordHasher",
@@ -571,7 +576,7 @@ else:
     }
 
 CSL_REALM = "CSL.TJHSST.EDU"  # CSL Realm
-KINIT_TIMEOUT = 10  # seconds before pexpect timeouts
+KINIT_TIMEOUT = 15  # seconds before pexpect timeouts
 
 FCPS_STUDENT_ID_LENGTH = 7
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,11 +47,13 @@ pyrankvote==2.0.5
 pysftp==0.2.9
 python-dateutil==2.8.2
 python-magic==0.4.27
+python-pam==2.0.2
 reportlab==3.6.13
 requests==2.31.0
 requests-oauthlib==1.3.1
 sentry-sdk==1.15.0
 setuptools-git==1.2
+six==1.16.0
 Sphinx==5.2.3
 sphinx-bootstrap-theme==0.8.1
 tblib==1.7.0


### PR DESCRIPTION
## Proposed changes
- Simpler than the somewhat hacky Kerberos implementation
- Respects PAM and SSSD settings
- Useful when Kerberos is down (like earlier today) because SSSD cache will be used 
