### PR TITLE
fix(bus): altering dimensions of bus.html tjcsl

### DIFF
--- a/intranet/templates/signage/pages/bus.html
+++ b/intranet/templates/signage/pages/bus.html
@@ -216,12 +216,12 @@
 
     .bus-announcement-container {
         position: absolute;
-        top: 55%;
-        right: 6%;
-        width: 50%;
+        top: 85%;
+        right: 3%;
+        width: 25%;
         padding: 20px !important;
 
-        font-size: 30px;
+        font-size: 20px;
         text-align: center;
         padding: 20px;
         display: inline-block;
@@ -251,9 +251,9 @@
     }
 
     #morning .bus-announcement-container {
-        top: 50%;
+        top: 80%;
         right: 3%;
-        width: 27%;
+        width: 25%;
     }
 
     #morning .bus-announcement-header {


### PR DESCRIPTION
## Proposed changes

Changed: 
` .bus-announcement-container {
        position: absolute;
        top: 55%;
        right: 6%;
        width: 50%;
        padding: 20px !important;
        font-size: 30px;`
To:

`        .bus-announcement-container {
            position: absolute;
            top: 85%;
            right: 3%;
            width: 25%;
            padding: 20px !important;
            font-size: 20px;`

Changed: 

`    #morning .bus-announcement-container {
        top: 50%;
        right: 3%;
        width: 27%;
    }`

To:

`        #morning .bus-announcement-container {
            top: 80%;
            right: 3%;
            width: 25%;
        }`



## Brief description of rationale

I reduced the font size, made the assignment buttons smaller, and moved the location of the assignment buttons from the center of the page toward the bottom so it wouldn't interfere with the bus images to the left.

Using the singular file -  just to show the changes in the two announcement buttons, but on the actual signage it will be different, here is the difference between before and after the edits:


Before:

![Originalimage](https://github.com/tjcsl/ion/assets/117781489/bd14192a-0a0c-46e5-980f-f0031f9e2394)


After:

![Updatedimage](https://github.com/tjcsl/ion/assets/117781489/abe67abf-e724-43ed-8207-77e2e88442d9)



