### PR TITLE
fix(eighth): correct stats dates

### DIFF
--- a/intranet/static/js/eighth/statistics.js
+++ b/intranet/static/js/eighth/statistics.js
@@ -22,14 +22,14 @@ $(document).ready(function() {
             datasets: [{
                 label: "A Block",
                 backgroundColor: "rgba(200,100,100,0.5)",
-                data: $.map(parsedData, function(v) {
-                    return "A" in v[1] ? v[1].A : null;
+                data: parsedData.filter((v) => "A" in v[1]).map((v) => {
+                    return {x: v[0]._i, y: v[1].A};
                 })
             }, {
                 label: "B Block",
                 backgroundColor: "rgba(100,100,200,0.5)",
-                data: $.map(parsedData, function(v) {
-                    return "B" in v[1] ? v[1].B : null;
+                data: parsedData.filter((v) => "B" in v[1]).map((v) =>  {
+                    return {x: v[0]._i, y: v[1].B};
                 })
             }]
         };


### PR DESCRIPTION
## Proposed changes
- Make stats correct based on actual eighth period dates

## Brief description of rationale
- current stats are wrong
- See activity 3261
- dates should be given within the data object in Chart.js, otherwise it goes chronologically. If num data entries is less than labels then it won't fill properly, although even if they are the same length the content is still wrong.