### PR TITLE
fix(signage): fix text containers overlapping bus spots in portrait mode (closes tjcsl#1680)

### DIFF
--- a/intranet/templates/signage/pages/bus.html
+++ b/intranet/templates/signage/pages/bus.html
@@ -123,6 +123,11 @@
         padding: 6px 10px;
         margin-bottom: 6px;
         margin-right: 6px;
+
+        {% if not sign.landscape %}
+        right: 1%;
+        padding: 12px !important;
+        {% endif %}
     }
 
     .logo {
@@ -233,6 +238,12 @@
         margin-bottom: 6px;
         margin-right: 6px;
         overflow: show;
+
+        {% if not sign.landscape %}
+        right: 1%;
+        padding: 12px !important;
+        {% endif %}
+
     }
 
     .bus-announcement-header {


### PR DESCRIPTION
## Proposed changes
- Change `padding `and `left` dynamically if `sign.landscape` is not true

## Brief description of rationale
Prevents the containers from overlapping with the bus spots

before:
<img width="400" alt="before" src="https://github.com/tjcsl/ion/assets/74752581/7793c9ee-af8e-46e4-9cc4-45d255be6aa0">
after:
<img width="400" alt="after" src="https://github.com/tjcsl/ion/assets/74752581/4c4dab5a-c1b1-4e5d-a932-5047f893d2a4">
