### PR TITLE
fix(ci): update mirrors before installing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@
                 },
                 {
                     "name": "install Kerberos",
-                    "run": "sudo apt install -y krb5-user"
+                    "run": "sudo apt update\nsudo apt install -y krb5-user\n"
                 },
                 {
                     "name": "Run tests (Fork)",

--- a/ci/spec.yml
+++ b/ci/spec.yml
@@ -192,11 +192,14 @@ jobs:
           echo "PGPASSFILE=$PGPASSFILE" >> $GITHUB_ENV
           echo 127.0.0.1:5432:postgres:postgres:postgres >$PGPASSFILE
           chmod 600 $PGPASSFILE
+
       - name: Create database
         run: psql -U postgres -h 127.0.0.1 -c 'create database ion'
 
       - name: install Kerberos
-        run: sudo apt install -y krb5-user
+        run: |
+          sudo apt update
+          sudo apt install -y krb5-user
 
       # Tests
       - name: Run tests (Fork)


### PR DESCRIPTION
Hopefully this fixes the CI.

I couldn't add the link to the fix in the commit description (`validate-commit messages` line-too-long >:()
so I'll add it here:
https://github.com/actions/runner-images/issues/6486#issuecomment-1294714467
(credit to Krishnan for finding it)