### PR TITLE
fix: unhashable type error with importlib_metadata

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 names==0.3.0
 whitenoise==6.6.0
 pre-commit==3.5.0
+importlib_metadata==8.4.0


### PR DESCRIPTION
[importlib_metadata](https://importlib-metadata.readthedocs.io/en/latest/history.html) v8.5.0 (released 9/11/24) throws a `TypeError unhashable type: 'types.SimpleNamespace'` when running the app ([see](https://stackoverflow.com/questions/78977665/django-autoreload-raises-typeerror-unhashable-type-types-simplenamespace)). This PR downgrades `importlib_metadata` to v8.4.0.