### PR TITLE
fix: remove temp fix for importlib_metadata type error

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,3 @@
 names==0.3.0
 whitenoise==6.6.0
 pre-commit==3.5.0
-importlib_metadata==8.4.0


### PR DESCRIPTION
The TypeError mentioned in [1718](https://github.com/tjcsl/ion/pull/1718) has been resolved with `zipp` v3.20.2. This PR removes our temporary fix.