### PR TITLE
fix: let django handle SIGTERM

### DIFF
--- a/config/docker/entrypoint.sh
+++ b/config/docker/entrypoint.sh
@@ -12,6 +12,6 @@ export PYTHONUNBUFFERED=1  # Don't buffer Django output
 # Wrap the run command in a loop so that it restarts if it crashes, e.g. due to a syntax error
 while true
 do
-    python3 manage.py run 0.0.0.0:8080  # Custom run command that skips system checks for performance
+    exec python3 manage.py run 0.0.0.0:8080  # Custom run command that skips system checks for performance
     sleep 1
 done


### PR DESCRIPTION
## Proposed changes
- Let Django handle `SIGTERM` signals in the docker env

## Brief description of rationale
DB's are stateful, so it's important to let them clean up after themselves when killing a docker compose session. This way, django can control how to peacefully shutdown connections to the DB.

It also has the added benefit of decreasing shutdown times from **10.2s to 0.5s**.