### PR TITLE
feat: fix club announcements for 15+ announcements

### DIFF
--- a/intranet/apps/dashboard/views.py
+++ b/intranet/apps/dashboard/views.py
@@ -369,12 +369,8 @@ def paginate_announcements_list_raw(
     prev_page = items.previous_page_number() if items.has_previous() else 0
     next_page = items.next_page_number() if more_items else 0
 
-    # limit to 15 to prevent extreme slowdowns for large amounts
-    # of club announcements
-    club_items = visible_club_items[:15]
-
     return RawPaginationData(
-        club_items=club_items,
+        club_items=visible_club_items,
         items=items,
         page_num=page_num,
         prev_page=prev_page,

--- a/intranet/static/css/dashboard.scss
+++ b/intranet/static/css/dashboard.scss
@@ -419,3 +419,7 @@ div[data-placeholder]:not(:focus):not([data-div-placeholder-content]):before {
     padding-right: 432px;
   }
 }
+
+.hidden-club-announcements {
+  display: none;
+}

--- a/intranet/static/js/dashboard/announcements.js
+++ b/intranet/static/js/dashboard/announcements.js
@@ -154,10 +154,12 @@ function announcementToggle() {
                 announcement.remove();
                 const numAnnouncementsSpan = $(".num-club-announcements");
                 const numAnnouncements = numAnnouncementsSpan.text().match(/\d+/);
-                // 15 is the cap, and prevent clicking on the button too fast
-                if(numAnnouncements != 15 && !announcement.hasClass("announcement-read")) {
+                if(!announcement.hasClass("announcement-read")) {
                   numAnnouncementsSpan.text(numAnnouncements - 1);
                   announcement.addClass("announcement-read");
+                  let newAnnouncement = $(".hidden-club-announcements").first();
+                  newAnnouncement.toggleClass("hidden-club-announcements");
+                  newAnnouncement.fadeIn(350);
                 }
                 $(".club-announcements:has(.club-announcements-content:not(:has(.announcement)))").slideUp(350);
             }, 450);

--- a/intranet/templates/dashboard/dashboard.html
+++ b/intranet/templates/dashboard/dashboard.html
@@ -217,20 +217,17 @@
             <div class="club-announcements">
                 <h3 class="club-announcements-header">
                     <i class="fas fa-users"></i>&nbsp;
-                    <!-- This only goes up to 15 items. Removing this restriction causes slowdowns. -->
-                    {% if club_items|length < 15 %}
-                        You have <span class="num-club-announcements">{{ club_items|length }}</span> new club announcement{{ club_items|length|pluralize }}
-                    {% else %}
-                        You have <span class="num-club-announcements">15+</span> new club announcements
-                    {% endif %}
+                    You have <span class="num-club-announcements">{{ club_items|length }}</span> new club announcement{{ club_items|length|pluralize }}
                     <i class="fas fa-chevron-down club-announcements-toggle-icon"></i>
                 </h3>
                 <div class="club-announcements-content">
                     {% for item in club_items %}
                         {% if not hide_announcements or not item.id in user_hidden_announcements %}
-                            {% with announcement=item show_icon=True %}
+                            <div class="{% if forloop.counter >= 15 %}hidden-club-announcements{% endif %}">
+                                {% with announcement=item show_icon=True %}
                                 {% include "announcements/announcement.html" %}
-                            {% endwith %}
+                                {% endwith %}
+                            </div>
                         {% endif %}
                     {% endfor %}
                 </div>


### PR DESCRIPTION
## Proposed changes
- Handle the case for 15+ announcements

## Brief description of rationale
Previously, the counter wouldn't go down as the user read the announcements. Now, it automatically fetches the next announcement as the user reads announcements off. 