### PR TITLE
fix(misc): import teacher photos should only find staff

### DIFF
--- a/intranet/apps/dataimport/management/commands/import_photos.py
+++ b/intranet/apps/dataimport/management/commands/import_photos.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
             if IS_STAFF:
                 if "-" in path.stem:
                     last_name, first_name = path.stem.rsplit("-", 1)
-                    user = get_user_model().objects.filter(first_name=first_name, last_name=last_name).first()
+                    user = get_user_model().objects.filter(first_name=first_name, last_name=last_name, user_type__in=["teacher", "counselor"]).first()
             else:
                 try:
                     int(path.stem)


### PR DESCRIPTION
## Proposed changes
- importing teacher photos should only consider staff users

## Brief description of rationale
- It would be awfully unfortunate if a teacher and a student both had the same names and the wrong image was loaded
