### PR TITLE
fix(files): fix file downloads

### DIFF
--- a/intranet/apps/files/views.py
+++ b/intranet/apps/files/views.py
@@ -225,7 +225,7 @@ def files_type(request, fstype=None):
                 content_len = tmpfile.tell()
                 tmpfile.seek(0)
                 chunk_size = 8192
-                response = StreamingHttpResponse(FileWrapper(tmpfile, chunk_size), content_type="application/octet-stream")
+                response = StreamingHttpResponse([*FileWrapper(tmpfile, chunk_size)], content_type="application/octet-stream")
                 response["Content-Length"] = content_len
                 response["Content-Disposition"] = f"attachment; filename={filebase_escaped}"
                 return response
@@ -294,7 +294,7 @@ def files_type(request, fstype=None):
             content_len = tmpfile.tell()
             tmpfile.seek(0)
             chunk_size = 8192
-            response = StreamingHttpResponse(FileWrapper(tmpfile, chunk_size), content_type="application/octet-stream")
+            response = StreamingHttpResponse([*FileWrapper(tmpfile, chunk_size)], content_type="application/octet-stream")
             response["Content-Length"] = content_len
             if not dirbase_escaped:
                 dirbase_escaped = "files"


### PR DESCRIPTION
## Proposed changes
- Allows for downloading files from the files app, including directories as zip files. 
- Before, the connection would timeout. 

## Brief description of rationale
When the response object was returned, the temporary file exited the context manager and closed itself automatically, creating a hidden error with the StreamingHttpResponse. By casting the FileWrapper to a list, the data is loaded into memory before the file is closed. 