### PR TITLE
Improve name of docker volume

### DIFF
--- a/config/docker/docker-compose.yml
+++ b/config/docker/docker-compose.yml
@@ -86,3 +86,4 @@ networks:
 
 volumes:
   pgdata:
+    name: ion-pgdata


### PR DESCRIPTION
## Proposed changes
- Add an explicit name to `pgdata` volume

## Brief description of rationale
By default, docker prefixes volumes in a `compose.yaml` with the name of the folder it's in. For our case, that would make the volume called `docker_pgdata`. However, this means that any other project that has its docker compose in a folder called `docker` and doesn't give a special name to the `pgdata` volume will conflict with Ion.

Yes, this happened to me.

## Things to consider
If there's any important data in the original volume, it may need to be copied over to the new volume. 
