### PR TITLE
feat: fix club announcements for 15+ announcements

### DIFF
--- a/intranet/apps/api/urls.py
+++ b/intranet/apps/api/urls.py
@@ -7,11 +7,13 @@ from ..emerg import api as emerg_api
 from ..schedule import api as schedule_api
 from ..users import api as users_api
 from .views import api_root
+from ..dashboard.views import load_more_club_announcements
 
 urlpatterns = [
     re_path(r"^$", api_root, name="api_root"),
     re_path(r"^/announcements$", announcements_api.ListCreateAnnouncement.as_view(), name="api_announcements_list_create"),
     re_path(r"^/announcements/(?P<pk>\d+)$", announcements_api.RetrieveUpdateDestroyAnnouncement.as_view(), name="api_announcements_detail"),
+    re_path(r"^/announcements/load-more-club-announcements", load_more_club_announcements, name="api_announcements_load_more"),
     re_path(r"^/blocks$", eighth_api.EighthBlockList.as_view(), name="api_eighth_block_list"),
     re_path(r"^/blocks/(?P<pk>\d+)$", eighth_api.EighthBlockDetail.as_view(), name="api_eighth_block_detail"),
     re_path(r"^/search/(?P<query>.+)$", users_api.Search.as_view(), name="api_user_search"),

--- a/intranet/static/css/dashboard.scss
+++ b/intranet/static/css/dashboard.scss
@@ -419,3 +419,7 @@ div[data-placeholder]:not(:focus):not([data-div-placeholder-content]):before {
     padding-right: 432px;
   }
 }
+
+.next-club-announcement-to-show {
+  display: none;
+}

--- a/intranet/templates/announcements/announcement.html
+++ b/intranet/templates/announcements/announcement.html
@@ -24,6 +24,9 @@
     {% endif %}
     {% if announcement.pinned %}
         pinned
+    {% endif %}
+    {% if forloop and forloop.counter > 15 %}
+        next-club-announcement-to-show
     {% endif %}">
 
     <h3>

--- a/intranet/templates/dashboard/dashboard.html
+++ b/intranet/templates/dashboard/dashboard.html
@@ -217,16 +217,11 @@
             <div class="club-announcements">
                 <h3 class="club-announcements-header">
                     <i class="fas fa-users"></i>&nbsp;
-                    <!-- This only goes up to 15 items. Removing this restriction causes slowdowns. -->
-                    {% if club_items|length < 15 %}
-                        You have <span class="num-club-announcements">{{ club_items|length }}</span> new club announcement{{ club_items|length|pluralize }}
-                    {% else %}
-                        You have <span class="num-club-announcements">15+</span> new club announcements
-                    {% endif %}
+                    You have <span class="num-club-announcements">{{ club_items|length }}</span> new club announcement{{ club_items|length|pluralize }}
                     <i class="fas fa-chevron-down club-announcements-toggle-icon"></i>
                 </h3>
                 <div class="club-announcements-content">
-                    {% for item in club_items %}
+                    {% for item in club_items|slice:":30" %}
                         {% if not hide_announcements or not item.id in user_hidden_announcements %}
                             {% with announcement=item show_icon=True can_subscribe=item.can_subscribe %}
                                 {% include "announcements/announcement.html" %}


### PR DESCRIPTION
## Proposed changes
- Handle the case for 15+ announcements

## Brief description of rationale
Previously, the counter wouldn't go down as the user read the announcements. Now, it automatically fetches the next announcement as the user reads announcements off. New API endpoint that fetches the next announcements and AJAX requests. 

New approach to the problem. Previous PR was #1737. 