### PR TITLE
feat(auth): tell user if they are locked out

### DIFF
--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -1,36 +1,18 @@
-FROM python:3.8.19
+FROM python:3.8.19-alpine3.18
 
-ENV TZ=America/New_York
-ENV C_FORCE_ROOT=true
+ENV TZ America/New_York
+ENV C_FORCE_ROOT true
 
 COPY config/krb5.conf /etc/krb5.conf
 COPY requirements.txt .
 COPY requirements-dev.txt .
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        bash \
-        git \
-        curl \
-        build-essential \
-        libpq-dev \
-        libfreetype6-dev \
-        libffi-dev \
-        ruby-full \
-        libmagic-dev \
-        krb5-user \
-        rsync \
-        nodejs \
-        npm \
-        tzdata \
-        libxml2-dev \
-        libxslt-dev && \
+RUN apk update && \
+    apk add bash git curl build-base libpq-dev freetype-dev libffi-dev ruby-full libmagic krb5 kinit rsync nodejs npm tzdata libxml2-dev libxslt-dev && \
     npm install -g sass && \
-    ln -fs /usr/share/zoneinfo/$TZ /etc/localtime && \
-    dpkg-reconfigure -f noninteractive tzdata && \
+    ln -s /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     pip3 install -Ir requirements.txt && \
     pip3 install -Ir requirements-dev.txt && \
-    rm requirements.txt requirements-dev.txt && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    rm requirements.txt requirements-dev.txt
 
 WORKDIR /ion

--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -1,18 +1,36 @@
-FROM python:3.8.19-alpine3.18
+FROM python:3.8.19
 
-ENV TZ America/New_York
-ENV C_FORCE_ROOT true
+ENV TZ=America/New_York
+ENV C_FORCE_ROOT=true
 
 COPY config/krb5.conf /etc/krb5.conf
 COPY requirements.txt .
 COPY requirements-dev.txt .
 
-RUN apk update && \
-    apk add bash git curl build-base libpq-dev freetype-dev libffi-dev ruby-full libmagic krb5 kinit rsync nodejs npm tzdata libxml2-dev libxslt-dev && \
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bash \
+        git \
+        curl \
+        build-essential \
+        libpq-dev \
+        libfreetype6-dev \
+        libffi-dev \
+        ruby-full \
+        libmagic-dev \
+        krb5-user \
+        rsync \
+        nodejs \
+        npm \
+        tzdata \
+        libxml2-dev \
+        libxslt-dev && \
     npm install -g sass && \
-    ln -s /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+    ln -fs /usr/share/zoneinfo/$TZ /etc/localtime && \
+    dpkg-reconfigure -f noninteractive tzdata && \
     pip3 install -Ir requirements.txt && \
     pip3 install -Ir requirements-dev.txt && \
-    rm requirements.txt requirements-dev.txt
+    rm requirements.txt requirements-dev.txt && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /ion

--- a/intranet/apps/auth/backends.py
+++ b/intranet/apps/auth/backends.py
@@ -22,7 +22,7 @@ class PamAuthenticationResult(enum.Enum):
     FAILURE = 0  # Authentication failed
     SUCCESS = 1  # Authentication succeeded
     EXPIRED = -1  # Password expired; needs reset
-    LOCKED = -2 # User locked out due to incorrect attempts
+    LOCKED = -2  # User locked out due to incorrect attempts
 
 
 class PamAuthenticationBackend:
@@ -133,7 +133,7 @@ class PamAuthenticationBackend:
             return user
         elif result == PamAuthenticationResult.LOCKED:
             if request is not None:
-                request.session['user_locked_out'] = 1
+                request.session["user_locked_out"] = 1
             return None
         else:
             pam_authenticate_failures.inc()

--- a/intranet/apps/auth/views.py
+++ b/intranet/apps/auth/views.py
@@ -151,6 +151,11 @@ def index_view(request, auth_form=None, force_login=False, added_context=None, h
         }
         schedule = schedule_context(request)
         data.update(schedule)
+
+        if 'user_locked_out' in request.session and request.session['user_locked_out'] == 1:
+            data.update({"auth_message":"You are locked out due to too many incorrect logins. Please try again later."})
+            request.session.pop('user_locked_out')
+
         if added_context is not None:
             data.update(added_context)
         return render(request, "auth/login.html", data)
@@ -178,6 +183,8 @@ class LoginView(View):
             request.session.delete_test_cookie()
         else:
             logger.warning("No cookie support detected! This could cause problems.")
+
+        authenticate(request, username=username, password=request.POST.get("password", ""))
 
         if form.is_valid():
             reset_user, _ = get_user_model().objects.get_or_create(username="RESET_PASSWORD", user_type="service", id=999999)

--- a/intranet/apps/auth/views.py
+++ b/intranet/apps/auth/views.py
@@ -152,9 +152,9 @@ def index_view(request, auth_form=None, force_login=False, added_context=None, h
         schedule = schedule_context(request)
         data.update(schedule)
 
-        if 'user_locked_out' in request.session and request.session['user_locked_out'] == 1:
-            data.update({"auth_message":"You are locked out due to too many incorrect logins. Please try again later."})
-            request.session.pop('user_locked_out')
+        if "user_locked_out" in request.session and request.session["user_locked_out"] == 1:
+            data.update({"auth_message": "You are locked out due to too many incorrect logins. Please try again later."})
+            request.session.pop("user_locked_out")
 
         if added_context is not None:
             data.update(added_context)


### PR DESCRIPTION
Closes #1749

## Proposed changes
- New state added to PamAuthenticationResult to indicate that the user is locked out.
- The authenticate method will update the session data, prompting the index view to show a message to the user, telling them they are locked out. The message goes away once the user reloads the page and will only appear when the user attempts to login while locked out.
- The authenticate method is called in the post_view and the request object is passed through so it is able to access the session data.

## Brief description of rationale
The user will know that they are locked out instead of just knowing that the login did not work.