### PR TITLE
fix: signage bus format

### DIFF
--- a/intranet/templates/signage/pages/bus.html
+++ b/intranet/templates/signage/pages/bus.html
@@ -357,7 +357,7 @@
         </script>
         {% endverbatim %}
         <div class="primary-content">
-            <div class="info bus-signage">  </div>
+            <div class="info bus-signage" style="width: 65%;">  </div>
             <div class="bus-announcement-container bus-signage">
                 <h2 class="bordered-element bus-announcement-header">
                     <i class="fas fa-bullhorn"></i>&nbsp;


### PR DESCRIPTION
## Proposed changes
- Fixes the format on the bus displays in signage. It moves the bus grid to the left (by changing the bus container div width to 50% of page - and html automatically left-aligns), avoiding overlap with the announcements.

## Brief description of rationale
This prevents the announcements and "School is in session/..." sign from obscuring the buses. 

Top is modified signage, bottom is current signage.
![image](https://github.com/user-attachments/assets/dfc0e4de-d79e-44cb-a44e-678f767144cc)
![image](https://github.com/user-attachments/assets/e91a1954-4bbf-43e0-9de0-ed329730587d)
