### PR TITLE
fix(announcements): display events correctly on announcement archive

### DIFF
--- a/intranet/apps/dashboard/views.py
+++ b/intranet/apps/dashboard/views.py
@@ -256,7 +256,7 @@ def get_announcements_list(request, context) -> list[Announcement | Event]:
     if context["events_admin"] and context["show_all"]:
         events = Event.objects.all()
     elif context["show_expired"]:
-        events = Event.objects.visible_to_user(user)
+        events = Event.objects.visible_to_user(user).filter(show_on_dashboard=True)
     else:
         # Unlike announcements, show events for the rest of the day after they occur.
         midnight = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)


### PR DESCRIPTION
Closes #1775. Issue surfaced in eb3cbd9 and hasn't been seen previously as there weren't enough events for the issue to be noticeable.

## Proposed changes
- Filter `Event` objects on dashboard view to `show_on_dashboard=True` for requests with `show_expired` set to True

## Brief description of rationale
The announcements archive page is not supposed to show events through its filters. Before, blank HTML items were in place of the events, which are no longer rendered with this filter.