### PR TITLE
fix: tjstar banner styling on mobile

### DIFF
--- a/intranet/static/css/tjstar_ribbon.scss
+++ b/intranet/static/css/tjstar_ribbon.scss
@@ -5,6 +5,9 @@
     padding: 1rem;
     border: 1px solid #e3e3e3;
     margin-bottom: 6px;
+    @media (max-width: 992px) {
+      margin-top: 40px;
+    }
 }
 
 .tjstar-ribbon-toggle {
@@ -14,6 +17,9 @@
     margin-bottom: 6px;
     padding-left: 1rem;
     cursor: pointer;
+    @media (max-width: 992px) {
+      margin-top: 40px;
+    }
 }
 
 .tjstar-ribbon-toggle-text {


### PR DESCRIPTION
**Before:**
<img width="324" alt="image" src="https://github.com/user-attachments/assets/5c3d491a-aa94-40d2-8120-fb40ecc87d09" />
<img width="328" alt="image" src="https://github.com/user-attachments/assets/62d9b519-00b9-4098-b89a-8c21b2e52f3e" />

**After:**
<img width="326" alt="image" src="https://github.com/user-attachments/assets/acdaf832-3458-435c-9c46-a1b436b4076a" />
<img width="328" alt="image" src="https://github.com/user-attachments/assets/eebc7cb4-c413-497d-89ea-fc3ca9ae2460" />
