### PR TITLE
fix(dash): fix visibility of senior email forwarding header

### DIFF
--- a/intranet/templates/dashboard/dashboard.html
+++ b/intranet/templates/dashboard/dashboard.html
@@ -240,7 +240,7 @@
             </div>
         {% endif %}
 
-        {% if show_near_graduation_message %}
+        {% if show_near_graduation_message and page_num == 1 and view_announcements_url != "announcements_archive" and view_announcements_url != "club_announcements" %}
             {% include "dashboard/senior_forwarding.html" %}
         {% endif %}
 


### PR DESCRIPTION
## Proposed changes
- Only have the announcement header for senior email forwarding show on the first page of the dashboard announcements

## Brief description of rationale
The senior email forwarding announcement currently shows on pages it shouldn't, like the club announcements page (see image below). This fixes that by only showing it on the main dashboard page.

![image](https://github.com/user-attachments/assets/42fd5599-a879-4d4c-b73c-fa85321b1586)