### PR TITLE
style: improve responsiveness and ux

### DIFF
--- a/intranet/static/css/bus.scss
+++ b/intranet/static/css/bus.scss
@@ -284,6 +284,12 @@ div.selectize-input.full {
     width: 220px;
 }
 
+@media (min-width: 1400px) {
+    .selectize-input {
+        width: 90%;
+    }
+}
+
 .update-button {
     display: block;
 

--- a/intranet/static/css/dashboard.scss
+++ b/intranet/static/css/dashboard.scss
@@ -12,7 +12,6 @@
   }
 
   h2 {
-    padding-left: 10px;
     line-height: 38px;
     float: left;
   }
@@ -39,7 +38,7 @@
 }
 
 .announcements-header {
-  height: 38px;
+  overflow: hidden;
   margin-bottom: 4px;
 }
 
@@ -120,9 +119,10 @@ a.club-announcement-meta-link:visited {
 }
 
 .announcements-icon-wrapper:has(> .club-announcements-button) {
-  @media (max-width: 800px) {
+  @media (max-width: 1120px) {
     display: block !important;
     width: 100%;
+    margin-bottom: 6px;
   }
 
   @media (max-width: 550px) {
@@ -236,6 +236,12 @@ a.club-announcement-meta-link:visited {
   float: right;
 }
 
+@media (max-width: 515px) {
+  .announcements-icon-wrapper {
+    float: left;
+  }
+}
+
 .announcement-metadata {
   color: rgb(144, 144, 144);
   font-size: 12px;
@@ -320,17 +326,6 @@ a.button {
 .content-center {
   width: 100%;
   text-align: center;
-}
-
-@media (max-width: 800px) {
-  /*
-     * widgets that fall underneath nav shouldn't float
-     * all the way to the left in 800-500px tablet view.
-     * mainly affects student admins
-     */
-  ul.nav {
-    margin-bottom: 100%;
-  }
 }
 
 /*

--- a/intranet/static/css/dashboard.widgets.scss
+++ b/intranet/static/css/dashboard.widgets.scss
@@ -84,9 +84,9 @@ $font-stack: "Open Sans", "Helvetica Neue", sans-serif;
     color: red;
 }
 
-.widget .widget-title .warning i {
-    //color: rgb(255, 72, 72);
-}
+// .widget .widget-title .warning i {
+//     //color: rgb(255, 72, 72);
+// }
 
 .main div.widgets {
     @media (max-width: 355px) {
@@ -398,14 +398,14 @@ a#eighth-sponsor {
 
         @media (max-width: 800px) {
             display: block;
-            width: calc(100% - 75px);
+            width: calc(100% - 78px);
 
             body.show-extra-widgets & {
                 display: none;
             }
         }
 
-        @media (max-width: 550px) {
+        @media (max-width: 680px) {
             width: 100%;
         }
     }

--- a/intranet/static/css/events.scss
+++ b/intranet/static/css/events.scss
@@ -1,26 +1,28 @@
 @import "colors";
 
+.primary-content {
+    position: relative;
+}
+
 .events {
     min-width: 290px; // for 320x480 screens
     max-width: 1000px;
-    margin-bottom: 100px;
 
     h2 {
-        padding-left: 10px;
         line-height: 38px;
 
         &.category {
             font-size: 18px;
             font-weight: normal;
-            padding-left: 10px;
             height: 33px;
         }
     }
 }
 
 .button-container {
-    float: right;
-    margin-top: -38px;
+    position: absolute;
+    right: 0;
+    top: 0;
 }
 
 .button-subcontainer {
@@ -28,31 +30,29 @@
     margin-right: 5px;
 }
 
-@media (max-width: 1080px) {
-    .button-container {
-      margin-top: auto;
-      margin-bottom: 5px;
+@media (max-width: 570px) {
+    .events {
+        max-width: none;
     }
+    .button-container {
+        position: static;
+    }
+}
+
+@media (max-width: 1225px) {
     .arrow-container {
         margin-bottom: -20px !important;
     }
 
-    .events-container > .event:nth-child(2) {
-        margin-top: 43px;
-        @media (max-width: 387px) {
-            margin-top: 80px;
-        }
-    }
-
     .week-only {
         position: relative;
-        right: 8.5%;
+        right: 0;
 
         & > tbody > tr > td {
             display: block;
             border-bottom: 1px solid lightgrey;
             padding: 20px 0 !important;
-            width: 120%;
+            width: 100%;
 
             &:first-child {
                 border-top: 1px solid lightgrey;
@@ -139,13 +139,14 @@
         }
     }
 
-    @media (max-width: 710px) {
+    /* these values are mostly arbitrary but were collected manually and do work */
+    @media (max-width: 710px), (min-width: 960px) and (max-width: 1000px), (min-width: 800px) and (max-width: 880px) {
         .bottom-row {
-            margin-bottom: 23px;
+            margin-bottom: 15px;
 
             .attend-status {
                 left: 0;
-                bottom: -27px;
+                bottom: -15px;
             }
         }
     }
@@ -321,6 +322,7 @@ span.approve-reject {
         width: 19%;
         padding: 10px !important;
         border: 1px solid lightgrey;
+        vertical-align: top;
 
         h2 {
             font-weight: normal;

--- a/intranet/static/css/page_base.scss
+++ b/intranet/static/css/page_base.scss
@@ -200,7 +200,7 @@ h1 {
 .header .csl-apps {
     display: inline-block;
     position: relative;
-    padding: 0 10px 0 0;
+    padding: 0 6px 0 0;
     line-height: normal;
 
     .fa-user, .fa-th {
@@ -239,10 +239,6 @@ h1 {
     width: 22px;
     height: 22px;
     color: white;
-}
-
-.header .username {
-    margin-right: 10px;
 }
 
 .header .dropdown-menu {

--- a/intranet/static/css/printing.scss
+++ b/intranet/static/css/printing.scss
@@ -12,6 +12,12 @@
     width: 60%;
 }
 
+@media (max-width: 600px) {
+    .primary-content form {
+        width: 100%;
+    }
+}
+
 .print-status-container {
     float: left;
     padding: 10px;

--- a/intranet/static/css/responsive.core.scss
+++ b/intranet/static/css/responsive.core.scss
@@ -12,7 +12,7 @@ body.disable-scroll {
 
 @media (max-width: 800px) {
     .header .search input[type="text"] {
-        width: 158px;
+        width: 250px;
         font-size: 12px;
         padding-right: 3px;
     }
@@ -45,6 +45,10 @@ body.disable-scroll {
         position: absolute !important;
         top: 4px;
         left: 60px;
+
+        body.mobile-nav-show & {
+            display: none;
+        }
     }
 
     .status-icon {
@@ -88,10 +92,10 @@ body.disable-scroll {
             }
         }
 
-        &.has-badge .left > form.search {
+        //&.has-badge .left > form.search {
             //width: 50%;
             //left: 20%;
-        }
+        //}
     }
     .left > a.intranet-title {
         position: absolute;
@@ -158,8 +162,6 @@ body.disable-scroll {
         height: 100%;
         height: calc(100% - 42px);
         overflow-y: auto;
-        background-color: rgb(242, 242, 244);
-        //background-color: rgb(56, 56, 56);
         border-radius: 0;
         border: none;
         /*
@@ -273,6 +275,7 @@ body.disable-scroll {
         cursor: pointer;
     }
     .intranet-title,
+    .status-link,
     .search {
         transition: all 0.2s ease;
         -webkit-transition: all 0.2s ease;
@@ -287,9 +290,30 @@ body.disable-scroll {
  * screens (320x480, iPhone 4)
  */
 
-@media (max-width: 325px) {
+@media (max-width: 420px) {
     body {
         padding-left: 6px;
         padding-right: 6px;
+    }
+
+    // overlaps with the search bar otherwise
+    body.mobile-nav-show {
+        .right {
+            display: none;
+        }
+
+        .left {
+            text-align: center;
+
+            // otherwise the search bar is too close to the back button
+            > form.search {
+                left: 20%;;
+            }
+        }
+
+        // search bar only shows when the mobile nav menu is active
+        .search input[type="text"] {
+            width: 180px; // using the space freed by no right buttons
+        }
     }
 }

--- a/intranet/static/css/responsive.scss
+++ b/intranet/static/css/responsive.scss
@@ -29,16 +29,22 @@
             position: static;
             height: auto;
             width: 100%;
+        }
+
+        div.announcements {
+            padding-right: 0;
+        }
+    }
+
+    /* if the min isnt 680 everything will be slightly shifted to the left on mobile */
+    @media (min-width: 681px) and (max-width: 800px) {
+        div.widgets {
             width: calc(100% - 16px);
-            margin-bottom: 10px;
 
             .widget {
                 position: relative;
                 left: 16px;
             }
-        }
-        div.announcements {
-            padding-right: 0;
         }
     }
 }

--- a/intranet/static/css/schedule.scss
+++ b/intranet/static/css/schedule.scss
@@ -148,7 +148,7 @@ tr.schedule-block.current {
 .primary-content {
     position: relative;
     top: 5px;
-
+    max-width: 1450px;
     h2 {
         left: 5px;
     }
@@ -178,15 +178,13 @@ tr.schedule-block.current {
     }
 }
 
-@media (max-width: 1080px) {
+
+
+/* 1225 is where the everything can fit on the screen with the header */
+@media (max-width: 1225px) {
     .arrow-container {
         margin-top: 20px;
         margin-bottom: -20px !important;
-    }
-
-    .week-only {
-        position: relative;
-        right: 8.5%;
     }
 
     .week-table {
@@ -197,7 +195,9 @@ tr.schedule-block.current {
             display: block;
             border-bottom: 1px solid lightgrey;
             padding: 20px 0 !important;
-            width: 120%;
+            width: 100%;
+            margin-left: auto;
+            margin-right: auto;
 
             &:first-child {
                 border-top: 1px solid lightgrey;
@@ -216,5 +216,16 @@ tr.schedule-block.current {
 
     .schedule:first-child {
         margin-top: 20px;
+    }
+}
+
+@media(max-width: 680px) {
+    .week-table {
+        & > tbody > tr > td {
+            width: 120%;
+            position: relative;
+            left: 50%;
+            transform: translateX(-50%);
+        }
     }
 }

--- a/intranet/static/css/welcome.scss
+++ b/intranet/static/css/welcome.scss
@@ -71,13 +71,9 @@ body {
 }
 
 #step-3 .ion-welcome-logo {
-    top: 150px;
-}
-
-@media (max-width: 675px) {
-    #step-3 .ion-welcome-logo {
-        top: 180px;
-    }
+    position: static;
+    margin: 20px auto 20px;
+    display: block;
 }
 
 @-webkit-keyframes animBg {

--- a/intranet/static/themes/halloween/halloween.css
+++ b/intranet/static/themes/halloween/halloween.css
@@ -13,10 +13,6 @@ body.login-page .day-name {
     color: orange !important;
 }
 
-a.logout-button {
-    color: rgb(242,242,244) !important;
-}
-
 .footer, .sidebar-trigger, .sidebar {
     display: none !important;
 }
@@ -60,10 +56,6 @@ ul.nav .selected {
 
 ul.nav .selected a {
     color: white !important;
-}
-
-.logout-button {
-    color: rgb(242,242,244) !important;
 }
 
 .btn-link {

--- a/intranet/templates/dashboard/dashboard.html
+++ b/intranet/templates/dashboard/dashboard.html
@@ -89,7 +89,6 @@
     {% if DJANGO_SETTINGS.ENABLE_SENIOR_DESTINATIONS and is_student %}
         {% include "dashboard/seniors.html" %}
     {% endif %}
-    <br />
 </div>
 {% endif %}
 

--- a/intranet/templates/enrichment/home.html
+++ b/intranet/templates/enrichment/home.html
@@ -49,16 +49,6 @@
     {% stylesheet 'dashboard' %}
     {% stylesheet 'events' %}
     {% stylesheet 'enrichment' %}
-
-    {% if is_enrichment_admin %}
-    <style>
-        @media (max-width: 1080px) {
-            .enrichment-container > .enrichment:nth-child(2) {
-                margin-top: 80px !important;
-            }
-        }
-    </style>
-    {% endif %}
 {% endblock %}
 
 {% block head %}
@@ -116,9 +106,9 @@
                     <a id="week-button" class="button" href="#">Week</a>
                 </div>
             {% endif %}
-
         </div>
-        <div class="enrichment-container">
+        <br />
+
         {% if show_all or classic %}
             <div class="enrichment-container">
                 {% for category in enrichments %}
@@ -135,9 +125,6 @@
             </div>
         {% endif %}
 
-            <br />
-            <br />
-        </div>
 
         {% if not show_all and not classic %}
             <div class="enrichment-container" id="view-div"></div>

--- a/intranet/templates/events/home.html
+++ b/intranet/templates/events/home.html
@@ -47,16 +47,6 @@
     {{ block.super }}
     {% stylesheet 'dashboard' %}
     {% stylesheet 'events' %}
-
-    {% if is_events_admin %}
-    <style>
-        @media (max-width: 1080px) {
-            .events-container > .event:nth-child(2) {
-                margin-top: 80px !important;
-            }
-        }
-    </style>
-    {% endif %}
 {% endblock %}
 
 {% block head %}
@@ -165,8 +155,6 @@
             {% endfor %}
         {% endif %}
 
-            <br />
-            <br />
         </div>
 
         {% if not show_all and not classic %}

--- a/intranet/templates/events/month.html
+++ b/intranet/templates/events/month.html
@@ -21,9 +21,9 @@
 </table>
 <br />
 <div class="schedule" data-prev-date="{{ month_data.last_month }}" data-next-date="{{ month_data.next_month }}" data-date="{{ week_data.today }}">
-    {% for week in month_data.weeks %}
     <table class="month-table">
         <tbody>
+        {% for week in month_data.weeks %}
         <tr>
             {% for day in week.days %}
                 {% if day.events_ctx.display == True %}
@@ -44,7 +44,7 @@
                 {% endif %}
             {% endfor %}
         </tr>
+        {% endfor %}
         </tbody>
     </table>
-    {% endfor %}
 </div>

--- a/intranet/templates/nav.html
+++ b/intranet/templates/nav.html
@@ -16,7 +16,7 @@
                     <div class="nav-alert-container">
                         <i class="nav-icon eighth-icon"></i>
                         {% if not request.user.signed_up_next_few_days %}
-                        <i class="fas fa-exclamation-circle nav-alert" style="right: 18px"></i>
+                        <i class="fas fa-exclamation-circle nav-alert"></i>
                         {% endif %}
                     </div>
                     Signup

--- a/intranet/templates/page_with_header.html
+++ b/intranet/templates/page_with_header.html
@@ -61,7 +61,7 @@
             {% endif %}
         </div>
 
-        <div class="right" style="padding-right:20px;">
+        <div class="right" style="padding-right: 10px;">
             <ul style="float:left;">
                 {% if request.user.is_student and eighth_absence_count > 0 %}
                     <li class="badged-item has-dropdown{% if eighth_absence_notif %} dropdown-open{% endif %}">
@@ -187,7 +187,6 @@
                     </ul>
                 </li>
             </ul>
-            <a class="logout-button" href="{% url 'logout'%}" style="color:rgb(242,242,244);"><i class="fas fa-sign-out-alt"></i></a>
         </div>
     </div>
     <div class="main">

--- a/intranet/templates/welcome/base.html
+++ b/intranet/templates/welcome/base.html
@@ -114,9 +114,7 @@
                 </p>
 
                 <div class="ion-welcome-logo"></div>
-                <br><br><br>
-                <br><br><br>
-                <br>
+
                 {% include "credits.html" %}
 
                 <hr>


### PR DESCRIPTION
## Proposed changes
The following changes make Ion more responsive across all devices and improve the UX. Most changes are given a before and after image to hopefully make reviewing this PR easier, but very minor changes don't.

`dashboard.scss`
- Removed unnecessary left padding on all h2 tags which made some titles look strange ([before](https://github.com/user-attachments/assets/2da27b28-22b9-4eef-b4f6-39f55e0a4f73) / [after](https://github.com/user-attachments/assets/3d07067e-6a0d-49dd-a3c0-7728572a9046))
- Changed media queries for action buttons on the dashboard, allowing them to fit properly on mobile devices ([before](https://github.com/user-attachments/assets/5536cfb4-4269-44b9-aedc-d5fb72c86f5e) / [after](https://github.com/user-attachments/assets/50ad3ddb-b3df-4747-97ae-be61b0a9ce35))
- Removed unnecessary margin-bottom which took up unused space ([before](https://github.com/user-attachments/assets/0c4dccfc-e1aa-4f11-a96a-d026ae6e2bc9) / [after](https://github.com/user-attachments/assets/5232fd7b-cb2f-4fbf-9132-ff45fa50a9df))
- Fixed action buttons on club announcements page to not overflow message and float to the left ([before](https://github.com/user-attachments/assets/9523f348-0514-4c16-9594-72b650230aa6) / [after](https://github.com/user-attachments/assets/4174d5e2-d13b-479b-ae0c-e3c4dde84ce8))

`dashboard.widgets.scss`
- Fixed width of "Show Extra Widgets" button on tablet-sized screens which caused lots of empty space on the dashboard in certain cases ([before](https://github.com/user-attachments/assets/14cb5338-ba3c-4d5a-aa69-5ff8734e0703) / [after](https://github.com/user-attachments/assets/25b89f10-0b02-48fa-8844-2c955908cf66))

`events.scss`
- Fixed the width of events so that they didn't overflow horizontally ([before](https://github.com/user-attachments/assets/4b15fcb6-ed27-4e8f-97b4-9df10c314771) / [after](https://github.com/user-attachments/assets/7a2dfd1c-5c24-47f7-a3c1-a5acb7d2abf1))
- Changed the boundaries from the vertical to the horizontal week view, fixing an issue with overflow ([before](https://github.com/user-attachments/assets/6ad4f4f2-7a68-43bd-84ab-424899c9b1ad) / [after](https://github.com/user-attachments/assets/3c4e82a3-8a07-473c-ab92-2d15a9008d1f))
- Made the position of buttons responsive like how it is on the dashboard ([before](https://github.com/user-attachments/assets/a2230719-861e-40e3-ae36-e2bafe949151) / [after](https://github.com/user-attachments/assets/f710f90f-e024-4cfd-bdbd-1c8efd098f2b))
- Changed table entries to align to the top of the element (through `vertical-align: top;`)
- Fixed the status display of events on the dashboard ([before](https://github.com/user-attachments/assets/a894f385-b0d9-4f3a-af6b-d5f53f38dbeb) / [after](https://github.com/user-attachments/assets/d6d03a85-169c-4690-a40d-24f0b5ed3ca2))

`page_base.scss`
- Changed padding and margins for the right header actions to account for the removed logout button (see below)

`printing.scss`
- Changed the width of the printing form (including the notes at the bottom) to 100% on mobile devices to fully utilize the available space ([before](https://github.com/user-attachments/assets/44ce13ac-ad3e-4213-a5c3-5cb0cddade04) / [after](https://github.com/user-attachments/assets/1fe21b74-d6d0-4b7f-a8c9-fc8fbaadeccb))

`responsive.core.scss`
- Changed the width of the search bar on tablet-sized screens to fully utilize the available space ([before](https://github.com/user-attachments/assets/ecfaea0e-52c3-4f26-b7bd-5c4533c0977d) / [after](https://github.com/user-attachments/assets/03a571c1-b980-42d8-8608-4e490ec30f20))
- Stopped showing the BetterStack status icon and link in the header when mobile navigation is open ([before](https://github.com/user-attachments/assets/856a77c9-bd00-48aa-9f82-cee3db0d6e29) / [after](https://github.com/user-attachments/assets/c62a36d9-3ed2-41f3-b7dd-a18b68521091))
- Fixed the color of mobile navigation which is visible when dark mode is enabled ([before](https://github.com/user-attachments/assets/10bdb010-94ae-435a-9313-270251c1b619) / [after](https://github.com/user-attachments/assets/604e6699-0d8f-4943-b9f7-5a9c2690f7d3))
- Stopped displaying app and user icons (the icons on the right) when the mobile navigation menu is open. It takes up too much space (which could be better used by the search bar) whilst being already visible with the mobile navigation menu closed. ([before](https://github.com/user-attachments/assets/a258592e-76e4-4831-a33e-bda3062f375a) / [after](https://github.com/user-attachments/assets/fbda4b2d-7ceb-49fd-8d0c-f5e8fc1ab496))

`responsive.scss`
- Fixed widgets and announcements to display properly on tablet-sized screens (same issue as the padding earlier)

`schedule.scss`
- Added a max-width on the schedule page for consistency across `events`, `enrichment`, and `schedule`
- Fixed line overflow issues with the schedule week table ([before](https://github.com/user-attachments/assets/8468477a-380d-4ff1-901d-014eda11a2d6) / [after](https://github.com/user-attachments/assets/6efbc858-502e-406a-9df5-9adde4d3c9cb)) 

`welcome.scss`
- Fixed the positioning of the Ion logo on the welcome screen ([before](https://github.com/user-attachments/assets/7050bcea-b3ab-48d0-b14c-fa4f97a0b25d) / [after](https://github.com/user-attachments/assets/6f06ef83-2ad0-4cda-8e6d-0a455cd502a0))

`bus.scss`
- Changed the width of the bus selector (used by admin accounts) as to not overlap with the bus announcements ([before](https://github.com/user-attachments/assets/4cf2ae34-524d-4f0e-aecf-7ce602919b47) / [after](https://github.com/user-attachments/assets/6defd24b-31b1-49ab-98bd-400974994628))

`nav.html`
- Changed the position of the 8th period alert icon to the right of the nav item for consistency with the event icon ([before](https://github.com/user-attachments/assets/bd3e92fc-7f48-49a7-ac7c-f850a4c6c725) / [after](https://github.com/user-attachments/assets/c7e3a35c-a174-410e-a75a-adedce05463b))

`page_with_header.html` and `halloween.css`
- Removed the logout icon button (the one under the user menu still exists). Done for UX and simplicity. ([before](https://github.com/user-attachments/assets/efe8f5a5-d4bf-4dd9-b20c-7779ded1138f) / [after](https://github.com/user-attachments/assets/b888a881-d8a6-48da-8a86-4b069e1a9dcd))

`home.html` (both of them)
- Removed extra margin-top on the events and enrichment page ([before](https://github.com/user-attachments/assets/67ba9d1c-4e48-48ce-9648-dd9d50b1371e) / [after](https://github.com/user-attachments/assets/9c72e764-93b1-42d9-969e-481b945943d6))

`month.html`
- Changed the formatting from multiple tables (in rows) to one big table for consistency in size between rows

## Brief description of rationale
Having a responsive and mobile-first UI is a necessity for Ion. Rationale for individual fixes is within the proposed changes for clarity.