### PR TITLE
feat: add authentication with LDAP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,8 @@ pyrankvote==2.0.5
 pysftp==0.2.9
 python-magic==0.4.27
 python-pam==2.0.2
+python-ldap==3.4.4
+django-auth-ldap==5.0.0
 requests-oauthlib==2.0.0
 sentry-sdk==2.32.0
 service-identity==24.2.0


### PR DESCRIPTION
## Proposed changes
- Create `TJHSSTLDAPBackend`, a new LDAP backend that authenticates against FreeIPA
- Remove `PamAuthenticationBackend` in favor of `TJHSSTLDAPBackend`
- Make `TJHSSTLDAPBackend` higher priority than `MasterPasswordAuthenticationBackend` in order to allow for auto-creation in all scenarios

## Brief description of rationale
This will further streamline the account creation process by removing the need to create Ion accounts separately from FreeIPA accounts.

Please look over/test this carefully for security holes -- the whole thing was written by Claude Code as an experiment.