### PR TITLE
fix: ui consistency when rejecting/approving events

### DIFF
--- a/intranet/apps/events/views.py
+++ b/intranet/apps/events/views.py
@@ -270,7 +270,7 @@ def join_event_view(request, event_id):
             else:
                 event.attending.remove(request.user)
 
-            return redirect("events")
+            return redirect(request.META.get("HTTP_REFERER", "events"))
 
     context = {"event": event, "is_events_admin": is_events_admin}
     return render(request, "events/join_event.html", context)

--- a/intranet/static/css/page_base.scss
+++ b/intranet/static/css/page_base.scss
@@ -509,9 +509,7 @@ ul.dropdown-menu.absence-notification {
             border-top: 2px solid rgb(161, 161, 161);
         }
     }
-
     .selected {
-        background-color: rgb(252, 252, 252);
 
         a {
             color: $grey;
@@ -521,7 +519,21 @@ ul.dropdown-menu.absence-notification {
     .nav-status-indicator {
         margin-top: 10px;
         display: none; // only show when the nav bar is collapsed
+        border-radius: 8px;
+        margin-left: auto;
+        margin-right: auto;
+        height: 23px;
+        padding: 3px 4px;
+        &.selected {
+            background-color: rgb(223 222 222);
 
+            a {
+                color: blue;
+                background: none;
+                -webkit-background-clip: initial;
+                background-clip: initial;
+            }
+        }
         a {
             all: unset;
             margin-left: 5px;


### PR DESCRIPTION
## Proposed changes
- Updated events page, show's all url from /events to /events?show_all=1 so it doesn't redirect back to /events

Before:
<img width="1091" height="377" alt="Screenshot 2025-09-08 at 9 09 08 PM" src="https://github.com/user-attachments/assets/ae239e29-8438-48bf-b51e-e341eaf66a2c" />


After:

<img width="1021" height="489" alt="Screenshot 2025-09-08 at 9 06 10 PM" src="https://github.com/user-attachments/assets/4416bb52-a011-4237-8cd9-f0c5db1b4e47" />
