### PR TITLE
Hoco banner temp shutoff

### DIFF
--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -46,7 +46,7 @@ SCHOOL_END_DATE = datetime.date(end_school_year,
 
 # Dates when hoco starts and ends
 HOCO_START_DATE = datetime.date(start_school_year,
-    9, 18  # UPDATE THIS! Value when last updated: September 18, 2025   # noqa: E128
+    9, 28  # UPDATE THIS! Value when last updated: September 18, 2025   # noqa: E128
 )                                                                       # noqa: E124
 HOCO_END_DATE = datetime.date(start_school_year,
     9, 28  # UPDATE THIS! Value when last updated: September 28, 2025   # noqa: E128


### PR DESCRIPTION
## Proposed changes
- Changed HOCO_START_DATE to 9/28 (same as end date) to shut off the hoco banner on Ion temporarily

## Brief description of rationale
Right now the homecoming site has not been reset yet, so the data displayed is data from last year, and should not be up on Ion.
