### PR TITLE
style(hoco): update homecoming banner styling

### DIFF
--- a/intranet/static/css/hoco_ribbon.scss
+++ b/intranet/static/css/hoco_ribbon.scss
@@ -276,7 +276,7 @@
 }
 
 #hoco-scores {
-    display: none;
+    opacity: 0;
     margin: 15px auto;
     width: 580px;
     text-align: center;
@@ -344,4 +344,3 @@
         top: 440px;
     }
 }
-

--- a/intranet/static/css/hoco_scores.scss
+++ b/intranet/static/css/hoco_scores.scss
@@ -1,5 +1,5 @@
 #hoco-scores {
-    display: none;
+    opacity: 0;
     margin: 15px auto;
     width: 580px;
     text-align: center;

--- a/intranet/static/js/hoco_scores.js
+++ b/intranet/static/js/hoco_scores.js
@@ -6,7 +6,7 @@ $(document).ready(function() {
         $.get("https://homecoming.tjhsst.edu/api/", function(data) {
             didConnect = true;
             if (hocoScoresRef) {  // on reconnect
-                $("#hoco-scores").replaceWith(hocoScoresRef).fadeIn();  // restore the backup
+                $("#hoco-scores").replaceWith(hocoScoresRef).fadeTo("slow", 1);  // restore the backup
                 hocoScoresRef = null;
             }
             $("#score-senior").text(data.senior_total ? data.senior_total : 0);
@@ -15,7 +15,7 @@ $(document).ready(function() {
             $("#score-freshman").text(data.freshman_total ? data.freshman_total : 0);
             removeRibbons();
             giveRibbons();
-            $("#hoco-scores").delay(2000).fadeIn();
+            $("#hoco-scores").delay(1500).fadeTo("slow", 1);
         }).fail(function() {
             if (didConnect) {  // only track failed attempts after first successful attempt
                 numDisconnected += 1;


### PR DESCRIPTION
## Proposed changes
- Change opacity and delay animation to include the score box
- Changed animation delay from 2000 to 1500

## Brief description of rationale
Currently, the score box causes a layout shift on Ion, which is detrimental to the user experience. Additionally, the score box animation delay is set too high, requiring the user to wait an extra 500ms (wow!!!).