### PR TITLE
refactor(settings): revert back to * import and use method for oidc key

### DIFF
--- a/config/docker/secret.py
+++ b/config/docker/secret.py
@@ -1,6 +1,3 @@
-import os
-
-SECRET_KEY = "_5kc##e7(!4=4)h4slxlgm010l+43zd_84g@82771ay6no-1&i"
 SECRET_DATABASE_URL = "postgres://ion:pwd@postgres:5432/ion"
 SESSION_REDIS_HOST = "redis"
 SESSION_REDIS_PORT = 6379
@@ -20,7 +17,6 @@ CHANNEL_LAYERS = {"default": {"BACKEND": "channels_redis.core.RedisChannelLayer"
 # notfish
 MASTER_PASSWORD = "argon2$argon2id$v=19$m=512,t=2,p=2$1JlK3UX2Ho1we5W8MPo2hA$cCXDGVyPD6olv/PbxdDTlA"
 CELERY_BROKER_URL = "redis://redis:6379/0"
-KEY_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../keys/oidc/oidc.key"))
 OIDC_RSA_PRIVATE_KEY = """
 -----BEGIN RSA PRIVATE KEY-----
 MIIJKAIBAAKCAgEArnjKrurrRZpKqSftw30nNXns/pbT2D/Erun71t6CABGy2kfE

--- a/intranet/settings/ci_secret.py
+++ b/intranet/settings/ci_secret.py
@@ -1,28 +1,9 @@
 # secret.py file for CI runs
-from typing import Any
-
 SECRET_KEY = "*t%yf&0+q!(a3@k(1#!hzr#u%1b*_ta-n-jf)aby5&2kbg6k&)"
 SECRET_DATABASE_URL = "postgres://postgres:postgres@127.0.0.1/ion"
 
 # 'password'
 MASTER_PASSWORD = "pbkdf2_sha256$12000$91eMu4Mn8Orv$Ep+D8cxD9TH+HzoeOq8gSrJXtxYvtHNY3RN4kG2c7lo="
-CELERY_BROKER_URL = "amqp://localhost"
-CACHEOPS_REDIS = {"host": "127.0.0.1", "port": 6379, "db": 1, "socket_timeout": 1}
-CHANNEL_LAYERS = {"default": {"BACKEND": "channels_redis.core.RedisChannelLayer", "CONFIG": {"hosts": [("127.0.0.1", 6379)]}}}
-SESSION_REDIS_HOST = "127.0.0.1"
-SESSION_REDIS_PORT = 6379
-SESSION_REDIS_DB = 0
-SESSION_REDIS_PREFIX = "ion:session"
-SESSION_REDIS = {"host": SESSION_REDIS_HOST, "port": SESSION_REDIS_PORT, "db": SESSION_REDIS_DB,
-                 "prefix": SESSION_REDIS_PREFIX}
-CACHES: dict[str, dict[str, Any]] = {
-    "default": {
-        "BACKEND": "intranet.utils.cache.DummyCache",
-        "OPTIONS": {
-            "DB": 2
-        },
-    }
-}
 
 OIDC_RSA_PRIVATE_KEY = """
 -----BEGIN RSA PRIVATE KEY-----


### PR DESCRIPTION
Settings in production is a little different and necessitates this.
Allow early import via method (in production, moving the `from .secret import *` causes a circular import since the settings secret.py relies on already defined settings in `__init__.py`)