### PR TITLE
fix(signage): update pages to work unauthenticated

### DIFF
--- a/config/docker/secret.py
+++ b/config/docker/secret.py
@@ -9,7 +9,7 @@ CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": "redis://redis:6379",
-        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient", "PICKLE_VERSION": 4 },
+        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient", "PICKLE_VERSION": 4},
         "KEY_PREFIX": "ion",
     }
 }

--- a/intranet/apps/eighth/models.py
+++ b/intranet/apps/eighth/models.py
@@ -433,7 +433,10 @@ class EighthActivity(AbstractBaseEighthModel):
         Returns:
             Whether the user can subscribe to the activity.
         """
-        return user.is_eighth_admin or (
+        return (
+            user.is_authenticated
+            and user.is_eighth_admin
+        ) or (
             self.subscriptions_enabled
             and user.is_authenticated
             and (

--- a/intranet/apps/eighth/serializers.py
+++ b/intranet/apps/eighth/serializers.py
@@ -102,7 +102,8 @@ class EighthBlockDetailSerializer(serializers.Serializer):
         available_restricted_acts=None,
     ):
         activity = scheduled_activity.activity
-        if user:
+        # Check if user exists in database before accessing properties that require database relationships (bc of signage_user)
+        if user and user.pk and get_user_model().objects.filter(pk=user.pk).exists():
             is_non_student_admin = user.is_eighth_admin and not user.is_student
         else:
             is_non_student_admin = False
@@ -206,7 +207,8 @@ class EighthBlockDetailSerializer(serializers.Serializer):
     def fetch_activity_list_with_metadata(self, block):
         user = self.context.get("user", self.context["request"].user)
 
-        if user:
+        # Check if user exists and is saved in the database before accessing relationships
+        if user and user.pk and get_user_model().objects.filter(pk=user.pk).exists():
             favorited_activities = set(user.favorited_activity_set.values_list("id", flat=True))
             recommended_activities = user.recommended_activities
             subscribed_activities = set(user.subscribed_activity_set.values_list("id", flat=True))

--- a/intranet/apps/signage/pages.py
+++ b/intranet/apps/signage/pages.py
@@ -16,9 +16,7 @@ def announcements(page, sign, request):  # pylint: disable=unused-argument
 
     for ann in announcement_list:
         ann.content = nullify_links(ann.content)
-        
     return {"public_announcements": announcement_list}
-
 
 def bus(page, sign, request):  # pylint: disable=unused-argument
     now = timezone.localtime()

--- a/intranet/apps/signage/pages.py
+++ b/intranet/apps/signage/pages.py
@@ -6,14 +6,18 @@ from django.utils import timezone
 
 from ..announcements.models import Announcement
 from ..schedule.models import Day
-
+from ...utils.html import nullify_links
 
 def hello_world(page, sign, request):
     return {"message": f"{page.name} from {sign.name} says Hello"}
 
-
 def announcements(page, sign, request):  # pylint: disable=unused-argument
-    return {"public_announcements": Announcement.objects.filter(groups__isnull=True, expiration_date__gt=timezone.now())}
+    announcement_list = Announcement.objects.filter(groups__isnull=True, expiration_date__gt=timezone.now())
+
+    for ann in announcement_list:
+        ann.content = nullify_links(ann.content)
+        
+    return {"public_announcements": announcement_list}
 
 
 def bus(page, sign, request):  # pylint: disable=unused-argument

--- a/intranet/apps/signage/views.py
+++ b/intranet/apps/signage/views.py
@@ -30,7 +30,6 @@ def check_internal_ip(request) -> HttpResponse | None:
         a 403 if the request is unauthorized or None if the request is authorized
     """
     remote_addr = request.headers["x-real-ip"] if "x-real-ip" in request.headers else request.META.get("REMOTE_ADDR", "")
-    
     # in development, allow all requests
     if not settings.PRODUCTION:
         return None

--- a/intranet/apps/signage/views.py
+++ b/intranet/apps/signage/views.py
@@ -30,6 +30,11 @@ def check_internal_ip(request) -> HttpResponse | None:
         a 403 if the request is unauthorized or None if the request is authorized
     """
     remote_addr = request.headers["x-real-ip"] if "x-real-ip" in request.headers else request.META.get("REMOTE_ADDR", "")
+    
+    # in development, allow all requests
+    if not settings.PRODUCTION:
+        return None
+    
     if (not request.user.is_authenticated or request.user.is_restricted) and remote_addr not in settings.TJ_IPS:
         return render(request, "error/403.html", {"reason": "You are not authorized to view this page."}, status=403)
 

--- a/intranet/static/css/signage.page.scss
+++ b/intranet/static/css/signage.page.scss
@@ -6,3 +6,10 @@ html, body {
 ::-webkit-scrollbar {
     display: none;
 }
+
+/* make links "invisible" */
+a:link, a:visited, a:hover, a:active, a:focus {
+    text-decoration: none;
+    color: inherit;
+    cursor: default;
+}


### PR DESCRIPTION
## Proposed changes
- Properly check for user authentication on 8th period pages
- Nullify links on signage announcement pages
- Make links "invisible" (through CSS) on all signage pages
- Allow all IPs for signage on Ion dev server

## Brief description of rationale
Signage pages don't work right now and people are playing Law & Order on the signages.

Closes #1832 