### PR TITLE
fix: prevent postgres from crashing docker

### DIFF
--- a/config/docker/docker-compose.yml
+++ b/config/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - POSTGRES_USER=ion
       - POSTGRES_PASSWORD=pwd
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
 
   django:
     container_name: intranet_django


### PR DESCRIPTION
## Proposed changes
See diff

## Brief description of rationale
A new postgres version was recently released, which broke the docker compose.