### PR TITLE
fix overlap between full and favorite

### DIFF
--- a/intranet/static/js/eighth/signup.search.js
+++ b/intranet/static/js/eighth/signup.search.js
@@ -133,7 +133,7 @@ $(function() {
                         show = true;
                     }
                     // favorite
-                    if (cmd[1].substring(0, 1) === "f" && activity.favorited === fl) {
+                    if (cmd[1].substring(0, 1) === "fa" && activity.favorited === fl) {
                         show = true;
                     }
                     // special
@@ -154,7 +154,7 @@ $(function() {
                         show = true;
                     }
                     // full
-                    if (cmd[1].substring(0, 1) === "f" && (activity.roster.capacity >= activity.roster.count) === fl) {
+                    if (cmd[1].substring(0, 2) === "fu" && (activity.roster.capacity >= activity.roster.count) === fl) {
                         show = true;
                     }
                     // open

--- a/intranet/static/js/eighth/signup.search.js
+++ b/intranet/static/js/eighth/signup.search.js
@@ -133,7 +133,7 @@ $(function() {
                         show = true;
                     }
                     // favorite
-                    if (cmd[1].substring(0, 1) === "fa" && activity.favorited === fl) {
+                    if (cmd[1].substring(0, 2) === "fa" && activity.favorited === fl) {
                         show = true;
                     }
                     // special


### PR DESCRIPTION
This pull request makes targeted improvements to the search command parsing logic in `intranet/static/js/eighth/signup.search.js` to ensure more precise filtering for favorite and full activities. The changes clarify which commands trigger specific filters, reducing ambiguity and potential conflicts.

**Improvements to command parsing:**

* Updated the favorite activity filter to check for the `"fa"` command prefix instead of just `"f"`, making the favorite filter more explicit and less likely to overlap with other filters.
* Updated the full activity filter to check for the `"fu"` command prefix instead of just `"f"`, ensuring that the full filter is only triggered when intended and does not conflict with the favorite filter.

see: #1881 