### PR TITLE
fix(security): enforce CSRF protection on REST API endpoints

### DIFF
--- a/intranet/apps/api/authentication.py
+++ b/intranet/apps/api/authentication.py
@@ -14,8 +14,3 @@ class ApiBasicAuthentication(authentication.BasicAuthentication):
             raise exceptions.AuthenticationFailed("Invalid username/password.")
 
         return (user, None)
-
-
-class CsrfExemptSessionAuthentication(authentication.SessionAuthentication):
-    def enforce_csrf(self, request):
-        return

--- a/intranet/apps/api/tests.py
+++ b/intranet/apps/api/tests.py
@@ -190,7 +190,11 @@ class ApiTest(IonTestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_no_credentials_read(self):
-        if "intranet.apps.api.authentication.ApiBasicAuthentication" in settings.REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"]:
+        first_auth = settings.REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"][0]
+        if first_auth in (
+            "intranet.apps.api.authentication.ApiBasicAuthentication",
+            "oauth2_provider.contrib.rest_framework.OAuth2Authentication",
+        ):
             status_code = 401
         else:
             status_code = 403

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -615,8 +615,8 @@ REST_FRAMEWORK = {
     "PAGE_SIZE": 50,
     "DEFAULT_AUTHENTICATION_CLASSES": (
         # "intranet.apps.api.authentication.ApiBasicAuthentication",  # Disabled for security
-        "intranet.apps.api.authentication.CsrfExemptSessionAuthentication",  # exempts CSRF checking on API
         "oauth2_provider.contrib.rest_framework.OAuth2Authentication",
+        "rest_framework.authentication.SessionAuthentication",
     ),
 }
 


### PR DESCRIPTION
remove CsrfExemptSessionAuthentication which disabled CSRF checking for all session-auth API requests. replaced with DRF's built in SessionAuthentication which enforces CSRF validation.

## Proposed changes
- removed CsrfExemptSessionAuthentication class from intranet/apps/api/authentication.py
- replaced the custom class with rest_framework.authentication.SessionAuthentication in intranet/settings/__init__.py

## Brief description of rationale
CsrfExemptSessionAuthentication overrides enforce_csrf() to be a no-op, meaning any session-authenticated API request bypasses CSRF protection. a malicious webpage could make API calls on behalf of a logged-in user by exploiting their session cookie. replacing with DRF's built in SessionAuthentication enforces CSRF validation which fixes this vulnerability.