### PR TITLE
fixed (enrichment): default to next week on weekends

### DIFF
--- a/intranet/apps/enrichment/views.py
+++ b/intranet/apps/enrichment/views.py
@@ -36,11 +36,33 @@ def is_weekday(date):
     return date.isoweekday() in range(1, 6)
 
 
-def enrichment_context(request, date=None):
+def get_default_enrichment_date(request):
     local_time = timezone.localtime()
 
+    if is_weekday(local_time):
+        return local_time
+
+    weekend_start = local_time.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    if timezone.is_naive(weekend_start):
+        weekend_start = timezone.make_aware(weekend_start)
+
+    weekend_end = weekend_start + timedelta(days=(8 - local_time.isoweekday()))
+
+    weekend_enrichments = EnrichmentActivity.objects.visible_to_user(request.user).filter(
+        time__gte=weekend_start,
+        time__lt=weekend_end,
+    )
+
+    if weekend_enrichments.exists():
+        return local_time
+
+    return local_time + timedelta(days=(8 - local_time.isoweekday()))
+
+
+def enrichment_context(request, date=None):
     if date is None:
-        date = local_time
+        date = get_default_enrichment_date(request)
 
     date_today = date.replace(hour=0, minute=0, second=0, microsecond=0)
 

--- a/intranet/apps/events/views.py
+++ b/intranet/apps/events/views.py
@@ -7,6 +7,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core import exceptions
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.utils import timezone
 
 from ...utils.helpers import get_id
@@ -149,6 +150,9 @@ def events_view(request):
                 event.save()
                 messages.success(request, f"Approved event {event}")
                 logger.info("Admin %s approved event: %s (%s)", request.user, event, event.id)
+                query_string = request.GET.urlencode()
+                url = f"{reverse('events')}?{query_string}" if query_string else reverse("events")
+                return redirect(url)
             else:
                 raise http.Http404
 
@@ -162,6 +166,9 @@ def events_view(request):
                 event.save()
                 messages.success(request, f"Rejected event {event}")
                 logger.info("Admin %s rejected event: %s (%s)", request.user, event, event.id)
+                query_string = request.GET.urlencode()
+                url = f"{reverse('events')}?{query_string}" if query_string else reverse("events")
+                return redirect(url)
             else:
                 raise http.Http404
 


### PR DESCRIPTION
closes: https://github.com/tjcsl/ion/issues/1875

## Proposed changes
*  Added helper function to determine default enrichment date
* Updated enrichment_context to use new weekend logic

## Brief description of rationale
Right now, on Saturdays and Sundays, the enrichment page defaults to the last week's activities, even though signups are closed after Friday. This change makes it show the next week instead, unless there are still enrichment activities on that weekend.