### PR TITLE
fix(polls): preserve question editor state on form validation error

### DIFF
--- a/intranet/apps/polls/tests.py
+++ b/intranet/apps/polls/tests.py
@@ -478,9 +478,8 @@ class ApiTest(IonTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("submitted_question_data", response.context)
-        import json as _json
 
-        restored = _json.loads(response.context["submitted_question_data"])
+        restored = json.loads(response.context["submitted_question_data"])
         self.assertEqual(len(restored), 1)
         self.assertEqual(restored[0]["question"], "Favourite colour?")
         self.assertEqual(len(restored[0]["choices"]), 2)
@@ -516,8 +515,7 @@ class ApiTest(IonTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("submitted_question_data", response.context)
-        import json as _json
 
-        restored = _json.loads(response.context["submitted_question_data"])
+        restored = json.loads(response.context["submitted_question_data"])
         self.assertEqual(len(restored), 1)
         self.assertEqual(restored[0]["question"], "Updated question?")

--- a/intranet/apps/polls/tests.py
+++ b/intranet/apps/polls/tests.py
@@ -454,3 +454,70 @@ class ApiTest(IonTestCase):
         self.assertEqual(answer_set.count(), 1)
         self.assertEqual(answer_set[0].answer, "different test content")
         self.assertEqual(answer_set[0].clear_vote, False)
+
+    def test_add_poll_preserves_questions_on_form_error(self):
+        """Regression test: question data must survive a form validation error on add_poll."""
+        self.make_admin()
+
+        question_data = json.dumps(
+            [{"question": "Favourite colour?", "type": "STD", "max_choices": "1", "choices": [{"info": "Red"}, {"info": "Blue"}]}]
+        )
+
+        # Submit without end_time to trigger a validation error.
+        response = self.client.post(
+            reverse("add_poll"),
+            data={
+                "title": "Poll with error",
+                "description": "test",
+                "start_time": (timezone.now() - datetime.timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S"),
+                # end_time omitted on purpose — causes form validation failure
+                "visible": True,
+                "question_data": question_data,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("submitted_question_data", response.context)
+        import json as _json
+
+        restored = _json.loads(response.context["submitted_question_data"])
+        self.assertEqual(len(restored), 1)
+        self.assertEqual(restored[0]["question"], "Favourite colour?")
+        self.assertEqual(len(restored[0]["choices"]), 2)
+
+    def test_modify_poll_preserves_questions_on_form_error(self):
+        """Regression test: question data must survive a form validation error on modify_poll."""
+        self.make_admin()
+
+        poll = Poll.objects.create(
+            title="Original Poll",
+            description="desc",
+            start_time=timezone.now() - datetime.timedelta(days=1),
+            end_time=timezone.now() + datetime.timedelta(days=1),
+            visible=True,
+        )
+
+        question_data = json.dumps(
+            [{"question": "Updated question?", "type": "STD", "max_choices": "1", "choices": [{"info": "Yes"}, {"info": "No"}]}]
+        )
+
+        # Submit without end_time to trigger a validation error.
+        response = self.client.post(
+            reverse("modify_poll", kwargs={"poll_id": poll.id}),
+            data={
+                "title": "Updated Poll",
+                "description": "updated",
+                "start_time": (timezone.now() - datetime.timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S"),
+                # end_time omitted on purpose — causes form validation failure
+                "visible": True,
+                "question_data": question_data,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("submitted_question_data", response.context)
+        import json as _json
+
+        restored = _json.loads(response.context["submitted_question_data"])
+        self.assertEqual(len(restored), 1)
+        self.assertEqual(restored[0]["question"], "Updated question?")

--- a/intranet/apps/polls/views.py
+++ b/intranet/apps/polls/views.py
@@ -667,7 +667,15 @@ def add_poll_view(request):
     else:
         form = PollForm()
 
-    context = {"action": "add", "action_title": "Add", "poll_questions": "[]", "poll_choices": "[]", "form": form, "is_polls_admin": True}
+    context = {
+        "action": "add",
+        "action_title": "Add",
+        "poll_questions": "[]",
+        "poll_choices": "[]",
+        "submitted_question_data": request.POST.get("question_data", "[]"),
+        "form": form,
+        "is_polls_admin": True,
+    }
 
     return render(request, "polls/add_modify.html", context)
 
@@ -707,6 +715,7 @@ def modify_poll_view(request, poll_id):
         "poll": poll,
         "poll_questions": serialize("json", poll.question_set.all()),
         "poll_choices": serialize("json", Choice.objects.filter(question__in=poll.question_set.all())),
+        "submitted_question_data": request.POST.get("question_data", "[]"),
         "form": form,
         "is_polls_admin": True,
     }

--- a/intranet/static/js/polls.js
+++ b/intranet/static/js/polls.js
@@ -1,3 +1,5 @@
+/* global CKEDITOR, _, poll_questions, poll_choices, submitted_question_data */
+
 var default_question = {
     "pk": null,
     "fields": {

--- a/intranet/static/js/polls.js
+++ b/intranet/static/js/polls.js
@@ -58,6 +58,32 @@ $(function() {
         addInline(v);
     });
 
+    // If the form was re-rendered after a validation error, restore the questions the user
+    // had entered by rebuilding the editor from the previously submitted question_data.
+    if (submitted_question_data.length > 0) {
+        $("#questions").empty();
+        $.each(submitted_question_data, function(k, q) {
+            var q_data = {
+                pk: q.pk || null,
+                fields: {
+                    question: q.question || "",
+                    type: q.type || "STD",
+                    max_choices: q.max_choices || 1
+                }
+            };
+            var q_elem = $(questionTemplate(q_data));
+            q_elem.appendTo("#questions");
+            $.each(q.choices || [], function(j, c) {
+                var c_data = {pk: c.pk || null, fields: {info: c.info || ""}};
+                q_elem.find(".choices").append(choiceTemplate(c_data));
+            });
+        });
+        $("#questions .type").selectize();
+        $("#questions [contenteditable='true']").each(function(k, v) {
+            addInline(v);
+        });
+    }
+
     $("#import_from_csv").on("click", async function (e) {
         e.preventDefault();
         $("#csv_input").trigger("click");

--- a/intranet/templates/polls/add_modify.html
+++ b/intranet/templates/polls/add_modify.html
@@ -18,6 +18,7 @@
     <script>
         var poll_questions = JSON.parse("{{ poll_questions|escapejs }}");
         var poll_choices = JSON.parse("{{ poll_choices|escapejs }}");
+        var submitted_question_data = JSON.parse("{{ submitted_question_data|escapejs }}");
     </script>
 {% endblock %}
 


### PR DESCRIPTION
## What

Preserve the poll question editor's content when an add-poll or modify-poll form fails validation, so users don't have to re-enter their questions.

## Why

Fixes #1843

When a user fills in poll questions and submits the form but a validation error occurs (e.g. missing end time), the page re-renders with the question editor empty. In `add_poll_view` the context always passes `poll_questions: "[]"` and `poll_choices: "[]"` on every render, including error re-renders. In `modify_poll_view` the context uses the DB state, which doesn't reflect the user's unsaved edits. In both cases the dynamically built question editor loses all user input.

## How

Pass the submitted `question_data` string back to the template as a new context variable `submitted_question_data`. If non-empty (i.e. we're re-rendering after a POST error), `polls.js` reinitialises the question editor from that data instead of starting from scratch.

The change is in three small parts:
1. `views.py` — add `"submitted_question_data": request.POST.get("question_data", "[]")` to the render context in both `add_poll_view` and `modify_poll_view`
2. `add_modify.html` — expose the variable to JavaScript alongside the existing `poll_questions`/`poll_choices`
3. `polls.js` — after the normal initialisation from `poll_questions`/`poll_choices`, check whether `submitted_question_data` is non-empty and rebuild the editor from it

Alternatives considered: converting `question_data` back into Django-serialiser format (`poll_questions`/`poll_choices`) in Python. This works for the modify path (questions have PKs) but fails for the add path (no PKs yet), so a uniform JS approach was cleaner.

## Scope

- Included: add-poll form and modify-poll form, both POST-error paths
- NOT included: the vote form or any other form in the polls module

## Verification

- [x] Two regression tests added (`test_add_poll_preserves_questions_on_form_error`, `test_modify_poll_preserves_questions_on_form_error`) that assert `submitted_question_data` is present in the response context and contains the correct question data when the form fails validation
- [ ] Manual check: submit an add-poll form with questions but an invalid end time — questions should remain in the editor after the error message appears
- [x] Existing polls test suite should continue to pass

## AI Disclosure

AI tools were used to assist with implementation. Every line was reviewed for correctness and intent.