### PR TITLE
fix: poll question reset on validation error

### DIFF
--- a/intranet/apps/polls/views.py
+++ b/intranet/apps/polls/views.py
@@ -648,6 +648,8 @@ def add_poll_view(request):
     if not request.user.has_admin_permission("polls"):
         return redirect("polls")
 
+    poll_questions = "[]"
+    poll_choices = "[]"
     if request.method == "POST":
         form = PollForm(data=request.POST)
         question_data = request.POST.get("question_data", None)
@@ -664,10 +666,18 @@ def add_poll_view(request):
 
             messages.success(request, "The poll has been created.")
             return redirect("polls")
+        poll_questions = question_data or "[]"
     else:
         form = PollForm()
 
-    context = {"action": "add", "action_title": "Add", "poll_questions": "[]", "poll_choices": "[]", "form": form, "is_polls_admin": True}
+    context = {
+        "action": "add",
+        "action_title": "Add",
+        "poll_questions": poll_questions,
+        "poll_choices": poll_choices,
+        "form": form,
+        "is_polls_admin": True,
+    }
 
     return render(request, "polls/add_modify.html", context)
 
@@ -690,8 +700,8 @@ def modify_poll_view(request, poll_id):
         if not question_data:
             messages.error(request, "No question information was sent with your request!")
             flag = False
-        question_data = json.loads(question_data)
         if flag and form.is_valid():
+            question_data = json.loads(question_data)
             instance = form.save()
 
             process_question_data(instance, question_data)
@@ -701,12 +711,19 @@ def modify_poll_view(request, poll_id):
     else:
         form = PollForm(instance=poll)
 
+    if request.method == "POST":
+        poll_questions = question_data or "[]"
+        poll_choices = "[]"
+    else:
+        poll_questions = serialize("json", poll.question_set.all())
+        poll_choices = serialize("json", Choice.objects.filter(question__in=poll.question_set.all()))
+
     context = {
         "action": "modify",
         "action_title": "Modify",
         "poll": poll,
-        "poll_questions": serialize("json", poll.question_set.all()),
-        "poll_choices": serialize("json", Choice.objects.filter(question__in=poll.question_set.all())),
+        "poll_questions": poll_questions,
+        "poll_choices": poll_choices,
         "form": form,
         "is_polls_admin": True,
     }

--- a/intranet/static/js/polls.js
+++ b/intranet/static/js/polls.js
@@ -36,21 +36,50 @@ $(function() {
         format: "Y-m-d H:i:s"
     });
 
-    poll_questions.sort(function(a, b) {
-        return a.fields.num - b.fields.num;
-    });
+    var actual_question = poll_questions.length && !poll_questions[0].fields; // for if it's the actual django question or the json fielded question in the poll
 
-    poll_choices.sort(function(a, b) {
-        return a.fields.num - b.fields.num;
-    });
+    if (actual_question) {
+        $.each(poll_questions, function(index, question) {
+            var fixed_question = {
+                "pk": question.pk || null,
+                "fields": {
+                    "num": index + 1,
+                    "question": question.question || "",
+                    "type": question.type || "STD",
+                    "max_choices": question.max_choices || 1
+                }
+            };
+            var question_element = $(questionTemplate(fixed_question));
+            $("#questions").append(question_element);
 
-    $.each(poll_questions, function(k, v) {
-        $("#questions").append(questionTemplate(v));
-    });
+            $.each(question.choices || [], function(choiceIndex, choice) {
+                var fixed_choice = {
+                    "pk": choice.pk || null,
+                    "fields": {
+                        "num": choiceIndex + 1,
+                        "info": choice.info || ""
+                    }
+                };
+                question_element.find(".choices").append(choiceTemplate(fixed_choice));
+            });
+        });
+    } else {
+        poll_questions.sort(function(a, b) {
+            return a.fields.num - b.fields.num;
+        });
 
-    $.each(poll_choices, function(k, v) {
-        $("#questions .question[data-id='" + v.fields.question + "']").find(".choices").append(choiceTemplate(v));
-    });
+        poll_choices.sort(function(a, b) {
+            return a.fields.num - b.fields.num;
+        });
+
+        $.each(poll_questions, function(k, v) {
+            $("#questions").append(questionTemplate(v));
+        });
+
+        $.each(poll_choices, function(k, v) {
+            $("#questions .question[data-id='" + v.fields.question + "']").find(".choices").append(choiceTemplate(v));
+        });
+    }
 
     $("#questions .type").selectize();
 


### PR DESCRIPTION
## Proposed changes
- fixed poll question reset on validation error

## Brief description of rationale
originally, poll questions would reset when fields were missing. this pr fixes that by returning the submitted question data to the client and the client parsing that question data.

Closes #1843