### PR TITLE
Restore waitlist metadata in eighth signup payload

### DIFF
--- a/intranet/apps/eighth/serializers.py
+++ b/intranet/apps/eighth/serializers.py
@@ -9,7 +9,7 @@ from django.db.models import Count
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
-from .models import EighthActivity, EighthBlock, EighthScheduledActivity, EighthSignup, EighthSponsor
+from .models import EighthActivity, EighthBlock, EighthScheduledActivity, EighthSignup, EighthSponsor, EighthWaitlist
 
 logger = logging.getLogger(__name__)
 
@@ -251,6 +251,26 @@ class EighthBlockDetailSerializer(serializers.Serializer):
 
         for activity_id, user_count in activities_with_signups:
             activity_list[activity_id]["roster"]["count"] = user_count
+
+        if user and getattr(user, "id", None) and activity_list:
+            user_waitlist = EighthWaitlist.objects.filter(user_id=user.id, block_id=block.id).select_related("scheduled_activity__activity").first()
+            if user_waitlist:
+                user_waitlist_activity_id = user_waitlist.scheduled_activity.activity_id
+                if user_waitlist_activity_id in activity_list:
+                    activity_list[user_waitlist_activity_id]["waitlisted"] = True
+                    activity_list[user_waitlist_activity_id]["waitlist_position"] = EighthWaitlist.objects.position_in_waitlist(
+                        user_waitlist.scheduled_activity_id, user.id
+                    )
+
+        waitlist_counts = (
+            EighthWaitlist.objects.filter(scheduled_activity__block=block)
+            .exclude(scheduled_activity__activity__deleted=True)
+            .values_list("scheduled_activity__activity_id")
+            .annotate(waitlist_user_count=Count("id"))
+        )
+        for activity_id, waitlist_user_count in waitlist_counts:
+            if activity_id in activity_list:
+                activity_list[activity_id]["waitlist_count"] = waitlist_user_count
 
         sponsors_dict = EighthSponsor.objects.values_list("id", "user_id", "first_name", "last_name", "show_full_name")
 

--- a/intranet/apps/eighth/tests/test_signup.py
+++ b/intranet/apps/eighth/tests/test_signup.py
@@ -1,6 +1,7 @@
 import json
 
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 from django.utils import timezone
@@ -9,7 +10,7 @@ from intranet.utils.date import get_senior_graduation_year
 
 from ...schedule.models import Block, Day, DayType, Time
 from ..exceptions import SignupException
-from ..models import EighthActivity, EighthBlock, EighthScheduledActivity, EighthSignup
+from ..models import EighthActivity, EighthBlock, EighthScheduledActivity, EighthSignup, EighthWaitlist
 from .eighth_test import EighthAbstractTest
 
 
@@ -294,6 +295,43 @@ class EighthSignupTest(EighthAbstractTest):
         response = self.client.get(reverse("eighth_signup"), data={"block": block1.id, "user": user.id})
         self.assertEqual(302, response.status_code)
         self.assertEqual(reverse("eighth_signup", kwargs={"block_id": block1.id}) + f"?user={user.id}", response.url)
+
+    @override_settings(ENABLE_WAITLIST=True)
+    def test_eighth_signup_view_includes_waitlist_metadata(self):
+        get_user_model().objects.all().delete()
+        user = self.login("2021awilliam")
+        user.user_type = "student"
+        user.graduation_year = get_senior_graduation_year()
+        user.save()
+
+        today = timezone.localtime().date()
+        block = EighthBlock.objects.get_or_create(date=today, block_letter="A")[0]
+
+        activity_waitlisted = EighthActivity.objects.get_or_create(name="Waitlisted Activity", default_capacity=1)[0]
+        scheduled_waitlisted = EighthScheduledActivity.objects.get_or_create(block=block, activity=activity_waitlisted, capacity=1)[0]
+
+        activity_other = EighthActivity.objects.get_or_create(name="Other Activity", default_capacity=1)[0]
+        scheduled_other = EighthScheduledActivity.objects.get_or_create(block=block, activity=activity_other, capacity=1)[0]
+
+        other_user = get_user_model().objects.create(username="someone_else", graduation_year=get_senior_graduation_year())
+        EighthWaitlist.objects.create(user=user, block=block, scheduled_activity=scheduled_waitlisted)
+        EighthWaitlist.objects.create(user=other_user, block=block, scheduled_activity=scheduled_waitlisted)
+        EighthWaitlist.objects.create(user=other_user, block=block, scheduled_activity=scheduled_other)
+
+        response = self.client.get(reverse("eighth_signup", kwargs={"block_id": block.id}))
+        self.assertEqual(200, response.status_code)
+
+        act_list = json.loads(str(response.context["activities_list"]).encode().decode("unicode-escape"))
+        waitlisted_info = act_list[str(activity_waitlisted.id)]
+        other_info = act_list[str(activity_other.id)]
+
+        self.assertTrue(waitlisted_info["waitlisted"])
+        self.assertEqual(1, waitlisted_info["waitlist_position"])
+        self.assertEqual(2, waitlisted_info["waitlist_count"])
+
+        self.assertFalse(other_info["waitlisted"])
+        self.assertEqual(0, other_info["waitlist_position"])
+        self.assertEqual(1, other_info["waitlist_count"])
 
     def test_eighth_multi_signup_view(self):
         """Tests :func:`~intranet.apps.eighth.views.signup.eighth_multi_signup_view`."""


### PR DESCRIPTION
## Summary
- restore waitlist metadata in the eighth signup serializer so the UI receives real waitlist values
- compute waitlist values using block-scoped aggregate queries to avoid loading full waitlists
- add regression coverage for signup JSON waitlist metadata in `test_signup.py`


- Full suite in Docker:
  - `docker exec intranet_django python -m pytest -o filterwarnings="ignore::django.utils.deprecation.RemovedInDjango60Warning"`

## Issue
- Addresses #1679
