### PR TITLE
Feat/logs path stats

### DIFF
--- a/intranet/apps/eighth/views/admin/attendance.py
+++ b/intranet/apps/eighth/views/admin/attendance.py
@@ -6,7 +6,6 @@ from cacheops import invalidate_obj
 from django import http
 from django.contrib import messages
 from django.contrib.auth import get_user_model
-from django.core.paginator import Paginator
 from django.db.models import Count, Q
 from django.shortcuts import redirect, render
 from django.utils import timezone
@@ -118,22 +117,11 @@ def delinquent_students_view(request):
             return include
 
         delinquents = list(filter(filter_by_grade, delinquents))
-        sort = request.GET.get("sort", "absences")
-        if sort == "last_name":
-            delinquents = sorted(delinquents, key=lambda x: x["user"].last_name)
-        elif sort == "grade":
-            delinquents = sorted(delinquents, key=lambda x: x["user"].grade.number)
-        else:
-            delinquents = sorted(delinquents, key=lambda x: (-1 * x["absences"], x["user"].last_name))
-        if request.resolver_match.url_name == "eighth_admin_view_delinquent_students":
-            paginator = Paginator(delinquents, 25)
-            page_number = request.GET.get("page", 1)
-            delinquents = paginator.get_page(page_number)
+        delinquents = sorted(delinquents, key=lambda x: (-1 * x["absences"], x["user"].last_name))
     else:
         delinquents = None
 
     context["delinquents"] = delinquents
-    context["sort"] = request.GET.get("sort", "absences")
 
     if request.resolver_match.url_name == "eighth_admin_view_delinquent_students":
         context["admin_page_title"] = "Delinquent Students"

--- a/intranet/apps/eighth/views/admin/attendance.py
+++ b/intranet/apps/eighth/views/admin/attendance.py
@@ -6,6 +6,7 @@ from cacheops import invalidate_obj
 from django import http
 from django.contrib import messages
 from django.contrib.auth import get_user_model
+from django.core.paginator import Paginator
 from django.db.models import Count, Q
 from django.shortcuts import redirect, render
 from django.utils import timezone
@@ -117,11 +118,22 @@ def delinquent_students_view(request):
             return include
 
         delinquents = list(filter(filter_by_grade, delinquents))
-        delinquents = sorted(delinquents, key=lambda x: (-1 * x["absences"], x["user"].last_name))
+        sort = request.GET.get("sort", "absences")
+        if sort == "last_name":
+            delinquents = sorted(delinquents, key=lambda x: x["user"].last_name)
+        elif sort == "grade":
+            delinquents = sorted(delinquents, key=lambda x: x["user"].grade.number)
+        else:
+            delinquents = sorted(delinquents, key=lambda x: (-1 * x["absences"], x["user"].last_name))
+        if request.resolver_match.url_name == "eighth_admin_view_delinquent_students":
+            paginator = Paginator(delinquents, 25)
+            page_number = request.GET.get("page", 1)
+            delinquents = paginator.get_page(page_number)
     else:
         delinquents = None
 
     context["delinquents"] = delinquents
+    context["sort"] = request.GET.get("sort", "absences")
 
     if request.resolver_match.url_name == "eighth_admin_view_delinquent_students":
         context["admin_page_title"] = "Delinquent Students"

--- a/intranet/apps/logs/urls.py
+++ b/intranet/apps/logs/urls.py
@@ -5,4 +5,5 @@ from . import views
 urlpatterns = [
     path("", views.logs_view, name="logs"),
     path("/request/<int:request_id>", views.request_view, name="request"),
+    path("/path-stats", views.path_stats_view, name="logs_path_stats"),
 ]

--- a/intranet/apps/logs/views.py
+++ b/intranet/apps/logs/views.py
@@ -3,6 +3,7 @@ import ipaddress
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.db.models import Count
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render
 from django.utils.timezone import make_aware
@@ -202,3 +203,46 @@ def request_view(request, request_id):
     rq = get_object_or_404(Request, id=request_id)
 
     return render(request, "logs/request.html", {"rq": rq})
+
+@login_required
+@reauthentication_required
+def path_stats_view(request):
+    if not request.user.is_global_admin:
+        raise Http404
+    
+    queries = {}
+    selected_from = request.GET.get("from", "")
+    selected_to = request.GET.get("to", "")
+    selected_method = request.GET.get("method", "")
+
+    if selected_from:
+        try:
+            queries["timestamp__gte"] = make_aware(datetime.datetime.strptime(selected_from, "%Y-%m-%d %H:%M:%S"))
+        except ValueError:
+            messages.error(request, "Invalid from time.")
+    
+    if selected_to:
+        try:
+            queries["timestamp__lte"] = make_aware(datetime.datetime.strptime(selected_to, "%Y-%m-%d %H:%M:%S"))
+        except ValueError:
+            messages.error(request, "Invalid to time.")
+    
+    if selected_method:
+        queries["method"] = selected_method
+    
+    path_counts = (Request.objects.filter(**queries).values("path").annotate(count=Count("id")).order_by("-count"))
+    top_paths = list(path_counts[:20])
+    chart_labels = [entry["path"] for entry in top_paths]
+    chart_data = [entry["count"] for entry in top_paths]
+
+    context = {
+        "path_counts": path_counts,
+        "chart_labels": chart_labels,
+        "chart_data": chart_data,
+        "selected_from": selected_from,
+        "selected_to": selected_to,
+        "selected_method": selected_method,
+        "all_methods": HTTP_METHODS,
+        "total_paths": path_counts.count(),
+    }
+    return render(request, "logs/path_stats.html", context)

--- a/intranet/apps/logs/views.py
+++ b/intranet/apps/logs/views.py
@@ -204,12 +204,13 @@ def request_view(request, request_id):
 
     return render(request, "logs/request.html", {"rq": rq})
 
+
 @login_required
 @reauthentication_required
 def path_stats_view(request):
     if not request.user.is_global_admin:
         raise Http404
-    
+
     queries = {}
     selected_from = request.GET.get("from", "")
     selected_to = request.GET.get("to", "")
@@ -220,17 +221,17 @@ def path_stats_view(request):
             queries["timestamp__gte"] = make_aware(datetime.datetime.strptime(selected_from, "%Y-%m-%d %H:%M:%S"))
         except ValueError:
             messages.error(request, "Invalid from time.")
-    
+
     if selected_to:
         try:
             queries["timestamp__lte"] = make_aware(datetime.datetime.strptime(selected_to, "%Y-%m-%d %H:%M:%S"))
         except ValueError:
             messages.error(request, "Invalid to time.")
-    
+
     if selected_method:
         queries["method"] = selected_method
-    
-    path_counts = (Request.objects.filter(**queries).values("path").annotate(count=Count("id")).order_by("-count"))
+
+    path_counts = Request.objects.filter(**queries).values("path").annotate(count=Count("id")).order_by("-count")
     top_paths = list(path_counts[:20])
     chart_labels = [entry["path"] for entry in top_paths]
     chart_data = [entry["count"] for entry in top_paths]

--- a/intranet/templates/eighth/admin/delinquent_students.html
+++ b/intranet/templates/eighth/admin/delinquent_students.html
@@ -3,17 +3,10 @@
 {% load pipeline %}
 
 {% block js %}
-    <script src="{% static 'vendor/sorttable.js' %}"></script>
     {{ block.super }}
-    <script>
-        $(function() {
-            Sortable.init();
-        });
-    </script>
 {% endblock %}
 
 {% block css %}
-    <link rel="stylesheet" href="{% static 'vendor/sortable-0.8.0/css/sortable-theme-minimal.css' %}">
     {{ block.super }}
 {% endblock %}
 
@@ -52,14 +45,14 @@
     <br>
     <br>
     {% if delinquents != None %}
-        Click on column titles to sort. Showing {{ delinquents|length }} result{{ delinquents|length|pluralize }}.
-        <table data-sortable class="sortable fancy-table">
+        Showing page {{ delinquents.number }} of {{ delinquents.paginator.num_pages }}, {{ delinquents.paginator.count }} total result{{ delinquents.paginator.count|pluralize }}.
+        <table class="fancy-table">
             <thead>
                 <tr>
-                    <th>Student</th>
+                    <th><a href="?lower={{ lower_absence_limit }}&upper={{ upper_absence_limit }}&start={{ start_date|date:'Y-m-d' }}&end={{ end_date|date:'Y-m-d' }}&sort=last_name">Student {% if sort == 'last_name' %}▲{% endif %}</a></th>
                     <th>ID</th>
-                    <th>Absences</th>
-                    <th>Grade</th>
+                    <th><a href="?lower={{ lower_absence_limit }}&upper={{ upper_absence_limit }}&start={{ start_date|date:'Y-m-d' }}&end={{ end_date|date:'Y-m-d' }}&sort=absences">Absences {% if sort == 'absences' %}▲{% endif %}</a></th>
+                    <th><a href="?lower={{ lower_absence_limit }}&upper={{ upper_absence_limit }}&start={{ start_date|date:'Y-m-d' }}&end={{ end_date|date:'Y-m-d' }}&sort=grade">Grade {% if sort == 'grade' %}▲{% endif %}</a></th>
                     <th>Counselor</th>
                     <th>TJ Email</th>
                     <th>Personal Email</th>
@@ -107,6 +100,12 @@
             </tbody>
         </table>
         <br>
+        {% if delinquents.has_previous %}
+            <a class="button" href = "?{{ request.GET.urlencode }}&page={{ delinquents.previous_page_number }}">Previous</a>
+        {% endif %}
+        {% if delinquents.has_next %}
+            <a class="button" href = "?{{ request.GET.urlencode }}&page={{ delinquents.next_page_number }}">Next</a>
+        {% endif %}
         <a class="button" href="{% url 'eighth_admin_download_delinquent_students_csv' %}?{{ request.META.QUERY_STRING }}">Download as CSV</a>
     {% endif %}
 

--- a/intranet/templates/logs/home.html
+++ b/intranet/templates/logs/home.html
@@ -45,6 +45,7 @@
         NOTICE: Access logs are confidential and may contain sensitive information. Disclosure to unauthorized parties is prohibited.
         <br>
         <a href="?" style="float: right"><button class="button small-button">Reset</button></a>
+        <a href="{% url 'logs_path_stats' %}" style="float: right"><button class="button small-button">Path Stats</button></a>
     </div>
     <br>
     <form method="GET">

--- a/intranet/templates/logs/path_stats.html
+++ b/intranet/templates/logs/path_stats.html
@@ -1,0 +1,138 @@
+{% extends "page_with_header.html" %}
+{% load static %}
+{% load pipeline %}
+
+{% block title %}{{ block.super }} - Path Stats{% endblock %}
+
+{% block css %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static 'vendor/datetimepicker-2.4.5/jquery.datetimepicker.css' %}">
+    {% stylesheet 'logs' %}
+{% endblock %}
+
+{% block head %}
+    {% if dark_mode_enabled %}
+        {% stylesheet 'dark/base' %}
+        {% stylesheet 'dark/nav' %}
+        {% stylesheet 'dark/logs' %}
+    {% endif %}
+{% endblock %}
+
+{% block js %}
+    {{ block.super }}
+    <script src="{% static 'vendor/datetimepicker-2.4.5/jquery.datetimepicker.js' %}"></script>
+    <script src="{% static 'js/vendor/Chart.min.js' %}"></script>
+    <script>
+        $(function() {
+            $("input.datetimepicker").datetimepicker({format: 'Y-m-d H:i:s'});
+        });
+    </script>
+{% endblock %}
+
+{% block content %}
+<div class="primary-content logs">
+    <h2>Path Stats</h2>
+    <p>NOTICE: Access logs are confidential and may contain sensitive information. Disclosure to unauthorized parties is prohibited.</p>
+    <a href="{% url 'logs' %}"><button class="button small-button">Back to Logs</button></a>
+    <a href="?" style="float: right"><button class="button small-button">Reset Filters</button></a>
+    <br><br>
+
+    <form method="GET">
+        <table class="query-table">
+            <thead>
+                <tr>
+                    <th>Method</th>
+                    <th>From</th>
+                    <th>To</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="method">
+                        <select name="method">
+                            <option value="">Any</option>
+                            {% for m in all_methods %}
+                                <option value="{{ m }}" {% if m == selected_method %}selected{% endif %}>{{ m }}</option>
+                            {% endfor %}
+                        </select>
+                    </td>
+                    <td class="time">
+                        <input type="text" name="from" class="datetimepicker" placeholder="All Time" value="{{ selected_from }}">
+                    </td>
+                    <td class="time">
+                        <input type="text" name="to" class="datetimepicker" placeholder="All Time" value="{{ selected_to }}">
+                    </td>
+                    <td class="submit">
+                        <input type="submit" value="Filter">
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </form>
+    <br>
+
+    <h3>Top 20 Paths by Hit Count</h3>
+    <canvas id="path-chart" width="800" height="350"></canvas>
+    {{ chart_labels|json_script:"chart-labels" }}
+    {{ chart_data|json_script:"chart-data" }}
+    <script>
+        (function() {
+            var labels = JSON.parse(document.getElementById("chart-labels").textContent);
+            var data = JSON.parse(document.getElementById("chart-data").textContent);
+            var ctx = document.getElementById("path-chart").getContext("2d");
+            new Chart(ctx, {
+                type: "bar",
+                data: {
+                    labels: labels,
+                    datasets: [{
+                        label: "Hits",
+                        data: data,
+                        backgroundColor: "rgba(54, 162, 235, 0.6)",
+                        borderColor: "rgba(54, 162, 235, 1)",
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    scales: {
+                        xAxes: [{
+                            ticks: {
+                                maxRotation: 45,
+                                callback: function(label) {
+                                    return label.length > 30 ? label.substring(0, 30) + "..." : label;
+                                }
+                            }
+                        }],
+                        yAxes: [{ ticks: { beginAtZero: true } }]
+                    }
+                }
+            });
+        })();
+    </script>
+
+    <br>
+    <h3>All Paths &mdash; {{ total_paths }} unique</h3>
+    <table class="logs-table">
+        <thead>
+            <tr>
+                <th class="sticky">Rank</th>
+                <th class="sticky">Path</th>
+                <th class="sticky">Hits</th>
+                <th class="sticky">View Requests</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for entry in path_counts %}
+            <tr class="shade">
+                <td>{{ forloop.counter }}</td>
+                <td>{{ entry.path|truncatechars:100 }}</td>
+                <td>{{ entry.count }}</td>
+                <td>
+                    <a href="{% url 'logs' %}?path-type=equals&path={{ entry.path|urlencode }}" target="_blank">View</a>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
Closes #664 
Adds an admin-only path stats dashboard at /logs/path-stats that shows which URL paths are most frequently requested.
- Groups Request objects by path, annotates with hit count, sorts descending
- Bar chart of the top 20 paths using existing Chart.js vendor library
- Ranked table of all unique paths with a link to filter the main logs view by that path
- Optional filters for HTTP method and date range
- Access restricted to global admins
- Added a Path Stats button to the main logs dashboard
