### PR TITLE
Added Thanksgiving Theme

### DIFF
--- a/intranet/apps/context_processors.py
+++ b/intranet/apps/context_processors.py
@@ -128,6 +128,13 @@ def global_custom_theme(request) -> dict[str, dict[str, dict[str, str]] | list[s
         theme.setdefault("js", []).append("themes/halloween/halloween-cookie.js")
         theme.setdefault("css", []).append("themes/halloween/halloween-button.css")
 
+    if "thanksgiving" in theme_names and request.COOKIES.get("disable-thanksgiving", None) == "1":
+        if "js" in theme and "themes/thanksgiving/thanksgiving.js" in theme["js"]:
+            theme["js"].remove("themes/thanksgiving/thanksgiving.js")
+        if "css" in theme and "themes/thanksgiving/thanksgiving.css" in theme["css"]:
+            theme["css"].remove("themes/thanksgiving/thanksgiving.css")
+        theme.setdefault("js", []).append("themes/thanksgiving/thanksgiving-cookie.js")
+
     return {"theme": theme, "theme_names": theme_names}
 
 

--- a/intranet/static/themes/thanksgiving/thanksgiving-cookie.js
+++ b/intranet/static/themes/thanksgiving/thanksgiving-cookie.js
@@ -1,0 +1,21 @@
+
+$(function () {
+    $('.header > .right > ul').prepend(
+        '<a onclick="toggleThanksgivingCookie()" style="color:#ffffff !important;cursor:pointer;text-decoration:none;margin-right:10px;font-family:inherit;font-size:inherit;">&#127810; Turn On Thanksgiving Theme</a>'
+    );
+
+    if (window.innerWidth < 1000) {
+        var li = document.createElement('li');
+        li.innerHTML = '<a onclick="toggleThanksgivingCookie()" style="color:inherit !important;cursor:pointer;">' +
+            '<i class="fas fa-leaf" style="font-size:16pt;position:relative;top:3px;left:6px;"></i>' +
+            '<span style="position:relative;bottom:9px;left:15px;">Turn On<br>Thanksgiving Theme</span>' +
+            '</a>';
+        document.querySelector('ul.nav').appendChild(li);
+    }
+});
+
+function toggleThanksgivingCookie() {
+    var enabled = Cookies.get('disable-thanksgiving') == '1' ? '0' : '1';
+    Cookies.set('disable-thanksgiving', enabled, { expires: 7 });
+    location.reload();
+}

--- a/intranet/static/themes/thanksgiving/thanksgiving.css
+++ b/intranet/static/themes/thanksgiving/thanksgiving.css
@@ -1,0 +1,144 @@
+/* Ion Thanksgiving Theme */
+
+/* colors for UI */
+body, input[type="text"], ::placeholder, a, a:active, a:visited,
+.git-version, .schedule .chevron i {
+    color: #5a3e1b !important;
+}
+
+.header {
+    background-color: #c0622a !important;
+    opacity: 0.95;
+    z-index: 1050;
+}
+
+ul.nav .selected {
+    background-color: #c0622a !important;
+    opacity: 0.85;
+}
+
+ul.nav .selected a {
+    color: #fff7ed !important;
+}
+
+.widget, .widget-title, .widget-content,
+.announcement, .event {
+    background-color: rgba(255, 247, 230, 0.92) !important;
+    border-left: none !important;
+    border-radius: 6px !important;
+    box-shadow: 0 2px 8px rgba(120, 60, 10, 0.13), 0 0 0 1px rgba(192, 98, 42, 0.18) !important;
+}
+
+.widget-title {
+    color: #7a3b10 !important;
+    border-radius: 6px 6px 0 0 !important;
+}
+
+/* gradient */
+html {
+    min-height: 100%;
+    background-color: #f5e6c8;
+    background-image:
+        radial-gradient(ellipse at 15% 80%, rgba(192, 98, 42, 0.10) 0%, transparent 55%),
+        radial-gradient(ellipse at 85% 15%, rgba(160, 120, 40, 0.10) 0%, transparent 55%),
+        radial-gradient(ellipse at 50% 50%, rgba(192, 98, 42, 0.05) 0%, transparent 70%);
+}
+
+body {
+    min-height: 100%;
+    background: transparent !important;
+}
+
+/* footer */
+.footer {
+    background: rgba(245, 230, 200, 0.85);
+}
+
+.footer a {
+    color: #7a3b10;
+}
+
+/* leaf animations */
+@keyframes leaf-fall {
+    0%   { transform: translateY(-60px) rotate(0deg)    translateX(0px);   opacity: 0; }
+    10%  { opacity: 0.75; }
+    85%  { opacity: 0.6; }
+    100% { transform: translateY(var(--leaf-floor)) rotate(340deg)  translateX(-15px); opacity: 0.7; }
+}
+
+@keyframes leaf-fall-2 {
+    0%   { transform: translateY(-60px) rotate(20deg)   translateX(0px);   opacity: 0; }
+    10%  { opacity: 0.65; }
+    85%  { opacity: 0.55; }
+    100% { transform: translateY(var(--leaf-floor)) rotate(-300deg) translateX(20px);  opacity: 0.6; }
+}
+
+/* leaf elements */
+.tg-leaf {
+    position: fixed;
+    top: -80px;
+    font-size: 1.6em;
+    opacity: 0;
+    z-index: -1000;
+    pointer-events: none;
+    animation-timing-function: ease-in;
+    animation-iteration-count: infinite;
+    animation-direction: normal;
+    user-select: none;
+    /* leaves don't stack; left this to make implementation easier */
+    --leaf-floor: 92vh;
+}
+
+/* turkey */
+@keyframes turkey-waddle {
+    0%   { left: -120px; }
+    100% { left: calc(100vw + 120px); }
+}
+
+.tg-turkey {
+    position: fixed;
+    bottom: 8px;
+    left: -120px;
+    font-size: 2.8em;
+    z-index: -999;
+    opacity: 0.55;
+    pointer-events: none;
+    animation: turkey-waddle 40s linear infinite;
+    animation-delay: 5s;
+    user-select: none;
+    transform: scaleX(-1);
+    display: inline-block;
+}
+
+.toggle-thanksgiving-theme {
+    color: #ffffff !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
+    font-family: inherit !important;
+    cursor: pointer !important;
+    text-decoration: none !important;
+    vertical-align: middle !important;
+    white-space: nowrap !important;
+    margin-right: 10px !important;
+    background: none !important;
+    border: none !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    line-height: inherit !important;
+}
+
+.toggle-thanksgiving-theme:hover {
+    text-decoration: underline !important;
+    color: #ffffff !important;
+}
+
+@media (max-width: 550px) {
+    .toggle-thanksgiving-theme {
+        position: fixed;
+        bottom: 5px;
+        right: 15px;
+        font-size: inherit;
+        padding: 10px !important;
+    }
+}

--- a/intranet/static/themes/thanksgiving/thanksgiving.js
+++ b/intranet/static/themes/thanksgiving/thanksgiving.js
@@ -1,0 +1,74 @@
+/* Ion Thanksgiving Theme
+ * Falling leaves and a turkey.
+ * Leaves don't stack because it's super laggy with emojis.
+ * Begins a week before Thanksgiving until the end of Thanksgiving day.
+ */
+
+$(function () {
+    //leaves
+    var leaves   = ['\uD83C\uDF42', '\uD83C\uDF41', '\uD83C\uDF43']; // these emojis 🍂 🍁 🍃
+    var anims    = ['leaf-fall', 'leaf-fall-2'];
+    var leafCount = 22;
+
+    var cols = 12;
+    var pileHeights = [];
+    for (var c = 0; c < cols; c++) {
+        pileHeights[c] = 0;
+    }
+    //rotation of the leaves randomized
+    for (var i = 0; i < leafCount; i++) {
+        (function(idx) {
+            var leaf = document.createElement('span');
+            leaf.className = 'tg-leaf';
+            leaf.textContent = leaves[Math.floor(Math.random() * leaves.length)];
+
+            var col = Math.floor(Math.random() * cols);
+            var startX = (col / cols * 100) + (Math.random() * (100 / cols));
+            leaf.style.left = startX + 'vw';
+
+            var duration = 8 + Math.random() * 8;
+            var delay    = Math.random() * 20;
+            var anim     = anims[Math.floor(Math.random() * anims.length)];
+            var size     = 1.0 + Math.random() * 1.3;
+
+            var floorVh = 92 - pileHeights[col];
+            pileHeights[col] += 2.5;
+            if (pileHeights[col] > 32) pileHeights[col] = 0;
+
+            leaf.style.setProperty('--leaf-floor', floorVh + 'vh');
+            leaf.style.animationName     = anim;
+            leaf.style.animationDuration = duration + 's';
+            leaf.style.animationDelay    = '-' + delay + 's';
+            leaf.style.fontSize          = size + 'em';
+
+            document.body.appendChild(leaf);
+        })(i);
+    }
+
+//turkey
+    var turkey = document.createElement('span');
+    turkey.className = 'tg-turkey';
+    turkey.textContent = '\uD83E\uDD83'; // this emoji 🦃
+    document.body.appendChild(turkey);
+
+    //toggle thanksgiving theme
+    $('.header > .right > ul').prepend(
+        '<a class="toggle-thanksgiving-theme" onclick="toggleThanksgivingCookie()">&#127810; Turn Off Thanksgiving Theme</a>'
+    );
+
+    if (window.innerWidth < 1000) {
+        $('.toggle-thanksgiving-theme').first().hide();
+        var liOff = document.createElement('li');
+        liOff.innerHTML = '<a class="toggle-thanksgiving-theme" onclick="toggleThanksgivingCookie()">' +
+            '<i class="fas fa-leaf" style="font-size:16pt;position:relative;top:3px;left:6px;"></i>' +
+            '<span style="position:relative;bottom:9px;left:15px;">Turn Off<br>Thanksgiving Theme</span>' +
+            '</a>';
+        document.querySelector('ul.nav').appendChild(liOff);
+    }
+});
+
+function toggleThanksgivingCookie() {
+    var enabled = Cookies.get('disable-thanksgiving') == '1' ? '0' : '1';
+    Cookies.set('disable-thanksgiving', enabled, { expires: 7 });
+    location.reload();
+}

--- a/intranet/utils/helpers.py
+++ b/intranet/utils/helpers.py
@@ -192,6 +192,14 @@ def get_ap_week_warning(request):
     return False
 
 
+def _get_thanksgiving(year: int) -> datetime.date:
+    """Returns the date of Thanksgiving (4th Thursday of November) for each year."""
+    nov1 = datetime.date(year, 11, 1)
+    days_until_thu = (3 - nov1.weekday()) % 7
+    first_thu = nov1 + datetime.timedelta(days=days_until_thu)
+    return first_thu + datetime.timedelta(weeks=3)
+
+
 def get_warning_html(warnings, dashboard=False, login=False):
     """
     Returns HTML for announcements.models.WarningAnnouncement objects.
@@ -224,6 +232,7 @@ GLOBAL_THEMES = {
     "piday": {"js": ["themes/piday/piday.js"], "css": "themes/piday/piday.css"},
     "halloween": {"js": ["themes/halloween/halloween.js"], "css": "themes/halloween/halloween.css"},
     "april_fools": {"js": ["themes/april_fools/april_fools.js"], "css": "themes/april_fools/april_fools.css"},
+    "thanksgiving": {"js": ["themes/thanksgiving/thanksgiving.js"], "css": "themes/thanksgiving/thanksgiving.css"},
     "new_years": {"js": ["js/vendor/fireworks.min.js", "themes/new_years/new_years.js"], "css": "themes/new_years/new_years.css"},
 }
 
@@ -254,6 +263,12 @@ def get_theme_names() -> list[str]:
     # Check for april_fools (Mar 30-31, Apr 1-7)
     if (today.month == 3 and (30 <= today.day <= 31)) or (today.month == 4 and (1 <= today.day <= 7)):
         active_themes.append("april_fools")
+
+    # Check for thanksgiving (1 week before to the end of Thanksgiving day)
+    thanksgiving = _get_thanksgiving(today.year)
+    thanksgiving_start = thanksgiving - datetime.timedelta(days=7)
+    if thanksgiving_start <= today <= thanksgiving:
+        active_themes.append("thanksgiving")
 
     return active_themes
 


### PR DESCRIPTION
Added a Thanksgiving theme.
It starts a week before Thanksgiving until the day is over.
Custom autumn colors, and falling leaves.
Leaves do not stack as they are emojis unlike the snowflakes, making it super laggy.
Emojis may render differently per OS, but trivial issue compared to the benefit of not having to load assets.
There is also a turkey trotting at the bottom!
Toggle on/off button for the theme. Preference is stored.

-Ben Ahn 5/22/2026

Closes issue #1852 