### PR TITLE
fix(eighth): distribute students evenly within capacity

### DIFF
--- a/intranet/apps/eighth/tests/admin/test_admin_groups.py
+++ b/intranet/apps/eighth/tests/admin/test_admin_groups.py
@@ -4,6 +4,7 @@ from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from django.utils import timezone
+from django.test import override_settings
 
 from intranet.apps.groups.models import Group
 from intranet.utils.date import get_senior_graduation_year
@@ -253,7 +254,8 @@ class EighthAdminGroupsTest(EighthAbstractTest):
         # Verify signups
         for user in [user1, user2, user3]:
             self.assertEqual(1, EighthSignup.objects.filter(user=user, scheduled_activity=scheduled).count())
-
+    
+    @override_settings(ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1'])
     def test_eighth_admin_distribute_group(self):
         """Tests :func:`~intranet.apps.eighth.views.admin.groups.eighth_admin_distribute_group` - the wizard only."""
 

--- a/intranet/apps/eighth/tests/admin/test_admin_groups.py
+++ b/intranet/apps/eighth/tests/admin/test_admin_groups.py
@@ -2,9 +2,9 @@ import csv
 
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
-from django.test import override_settings
 
 from intranet.apps.groups.models import Group
 from intranet.utils.date import get_senior_graduation_year
@@ -254,8 +254,8 @@ class EighthAdminGroupsTest(EighthAbstractTest):
         # Verify signups
         for user in [user1, user2, user3]:
             self.assertEqual(1, EighthSignup.objects.filter(user=user, scheduled_activity=scheduled).count())
-    
-    @override_settings(ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1'])
+
+    @override_settings(ALLOWED_HOSTS=["testserver", "localhost", "127.0.0.1"])
     def test_eighth_admin_distribute_group(self):
         """Tests :func:`~intranet.apps.eighth.views.admin.groups.eighth_admin_distribute_group` - the wizard only."""
 

--- a/intranet/apps/eighth/tests/admin/test_admin_groups.py
+++ b/intranet/apps/eighth/tests/admin/test_admin_groups.py
@@ -2,7 +2,6 @@ import csv
 
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -255,7 +254,6 @@ class EighthAdminGroupsTest(EighthAbstractTest):
         for user in [user1, user2, user3]:
             self.assertEqual(1, EighthSignup.objects.filter(user=user, scheduled_activity=scheduled).count())
 
-    @override_settings(ALLOWED_HOSTS=["testserver", "localhost", "127.0.0.1"])
     def test_eighth_admin_distribute_group(self):
         """Tests :func:`~intranet.apps.eighth.views.admin.groups.eighth_admin_distribute_group` - the wizard only."""
 
@@ -369,8 +367,10 @@ class EighthAdminGroupsTest(EighthAbstractTest):
         response = self.client.post(
             reverse("eighth_admin_distribute_unsigned"), data={"eighth_admin_distribute_group_wizard-current_step": "block", "block-block": block.id}
         )
+        test_users = [user1, user2, user3]
+        context_users = list(response.context["users"])
         self.assertEqual(200, response.status_code)
-        self.assertEqual([user1, user2, user3], list(response.context["users"]))
+        self.assertEqual(sorted(test_users, key=lambda x: x.username), sorted(context_users, key=lambda x: x.username))
 
         # Select the two activities
         response = self.client.post(
@@ -432,10 +432,11 @@ class EighthAdminGroupsTest(EighthAbstractTest):
 
         # Load the page
         response = self.client.get(reverse("eighth_admin_distribute_action"), data={"schact": [scheduled1.id, scheduled2.id], "group": group.id})
+        test_users = [user1, user2, user3]
         self.assertEqual(200, response.status_code)
         self.assertEqual(group, response.context["group"])
-        self.assertEqual([scheduled1, scheduled2], list(response.context["schacts"]))
-        self.assertEqual([user1, user2, user3], list(response.context["users"]))
+        self.assertEqual([scheduled1, scheduled2], [pair[0] for pair in response.context["schacts"]])
+        self.assertEqual(sorted(test_users, key=lambda x: x.last_name), list(response.context["users"]))
 
         # Perform a signup but manually specifying which user gets which activity
         response = self.client.post(
@@ -455,8 +456,10 @@ class EighthAdminGroupsTest(EighthAbstractTest):
         response = self.client.get(
             reverse("eighth_admin_distribute_action"), data={"schact": [scheduled1.id, scheduled2.id], "unsigned": True, "block": block.id}
         )
+        test_users = [user1, user2]
+        context_users = list(response.context["users"])
         self.assertEqual(200, response.status_code)
-        self.assertEqual([user1, user2], list(response.context["users"]))
+        self.assertEqual(sorted(test_users, key=lambda x: x.username), sorted(context_users, key=lambda x: x.username))
 
         # Actually performing the signup is redundant
 

--- a/intranet/apps/eighth/views/admin/groups.py
+++ b/intranet/apps/eighth/views/admin/groups.py
@@ -697,7 +697,7 @@ def eighth_admin_distribute_action(request):
             "users_type": users_type,
             "group": group if users_type == "group" else None,
             "eighthblock": block if users_type == "unsigned" else None,
-            "schacts": list(zip(schacts, remaining_capacities)),
+            "schacts": list(zip(schacts, remaining_capacities, strict=True)),
             "users": users,
             "show_selection": True,
             "sticky_users_and_activities": sticky_users_and_activities,

--- a/intranet/apps/eighth/views/admin/groups.py
+++ b/intranet/apps/eighth/views/admin/groups.py
@@ -645,10 +645,12 @@ def eighth_admin_distribute_action(request):
         schactids = request.GET.getlist("schact")
 
         schacts = []
+        remaining_capacities = []
         for schact in schactids:
             try:
                 sch = EighthScheduledActivity.objects.get(id=schact)
                 schacts.append(sch)
+                remaining_capacities.append(max(0, sch.capacity - sch.members.count()))
             except EighthScheduledActivity.DoesNotExist as e:
                 raise http.Http404 from e
 
@@ -695,7 +697,7 @@ def eighth_admin_distribute_action(request):
             "users_type": users_type,
             "group": group if users_type == "group" else None,
             "eighthblock": block if users_type == "unsigned" else None,
-            "schacts": schacts,
+            "schacts": list(zip(schacts, remaining_capacities)),
             "users": users,
             "show_selection": True,
             "sticky_users_and_activities": sticky_users_and_activities,

--- a/intranet/static/css/eighth.schedule.scss
+++ b/intranet/static/css/eighth.schedule.scss
@@ -309,3 +309,13 @@ tr.form-row {
         border: 1px solid rgb(102, 102, 102);
     }
 }
+
+.allow-exceed {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    padding-left: 0 !important;
+    margin-block: 15px 5px;
+    width: fit-content;
+}

--- a/intranet/static/js/eighth/distribute_group.js
+++ b/intranet/static/js/eighth/distribute_group.js
@@ -1,22 +1,45 @@
 /* global $ */
 $(function() {
+    $(".select-all").on("click", function(e) {
+        e.stopPropagation();
+    });
+
     $(".select-all").on("change", function() {
-        var chk = $(this).prop("checked");
-        var name = $(this).attr("data-name");
+        let chk = $(this).prop("checked");
+        let name = $(this).attr("data-name");
+
         console.debug(chk, name);
 
         $(".user-item").each(function() {
             if ($(this).attr("name") === name) {
-                $(this).prop("checked", chk);
+                $(this).prop("checked", chk).trigger("change");
             }
         });
     });
 
     $(".user-item").on("change", function() {
-        var chk = $(this).prop("checked");
-        var name = $(this).attr("name");
-        var num_checked = 0;
-        var $checkboxes = $(".user-item[name='" + name + "']");
+        let $box = $(this);
+        let chk = $box.prop("checked");
+        let name = $box.attr("name");
+        let value = $box.attr("value");
+
+        if (chk) {
+            let $adjacent = $(`.user-item[value="${value}"]`);
+            $adjacent.each(function() {
+                let $adj = $(this);
+                if ($adj.attr("name") !== $box.attr("name") && $adj.prop("checked")) {
+                    $adj.prop("checked", false).trigger("change");
+                }
+            });
+        }
+
+        updateCheckboxes(name);
+    });
+
+    function updateCheckboxes(name) {
+        let num_checked = 0;
+        let $checkboxes = $(".user-item[name='" + name + "']");
+        let $e = $(".select-all[data-name='" + name + "']");
 
         $checkboxes.each(function() {
             if ($(this).prop("checked")) {
@@ -24,7 +47,6 @@ $(function() {
             }
         });
 
-        $e = $(".select-all[data-name='" + name + "']");
         if (num_checked === 0) {
             $e.prop("checked", false);
             $e.prop("indeterminate", false);
@@ -35,50 +57,109 @@ $(function() {
             $e.prop("checked", false);
             $e.prop("indeterminate", true);
         }
-    });
+    }
 
     distribute = function() {
-        var acts = [],
+        let totalCapacity = 0;
+        let allowExceed = $("input[name=allow-exceed]").prop("checked");
+        let acts = [],
             act_names = [];
-        var $salls = $(".select-all");
+        let $salls = $(".select-all");
+        let $rows = $("tr.user-row");
+        let $capacities = $(".remaining-capacity");
+        let max = Math.floor($rows.length / $salls.length);
+        let rem = $rows.length % $salls.length;
+        let sus = {};
 
         $salls.each(function() {
             acts.push($(this).attr("data-name"));
             act_names.push($(this).parent().text());
         });
 
-        var $rows = $("tr.user-row");
-        var max = Math.floor($rows.length / $salls.length);
-        console.debug("max:", max);
-        var rowi = 0,
-            acti = 0,
-            curi = 0,
-            done = 0;
-        var maxi = acts.length;
-        var sus = {};
+        if (!allowExceed) {
+            $rows.each(function() {
+                $("input", $(this)).prop("checked", false);
+            });
+            $capacities.each(function() {
+                totalCapacity += Number($(this).text());
+            });
 
-        $rows.each(function() {
-            var act = acts[acti];
-            $("input", $(this)).prop("checked", false);
-            $("input[name='" + act + "']", $(this)).prop("checked", true);
-            curi++;
-            done++;
-            if (curi >= max && (acti + 1) < acts.length) {
-                sus[acti] = curi;
-                acti++;
+            let count = 0;
+            let count2 = 0;
+            let start = 0;
+            let sortedCapacities = $capacities.get().sort((a, b) => {
+                return Number(a.innerText) - Number(b.innerText);
+            });
+            let groups = $salls.get().map((group, i) => {
+                let available = Number(sortedCapacities[i].innerText);
+                let name = sortedCapacities[i].getAttribute("data-name");
+                count2++;
+                if (max > available) {
+                    if ($salls.length - count2 > 0) {
+                        max = Math.floor(($rows.length - available) / ($salls.length - count2));
+                        rem = ($rows.length - available) % ($salls.length - count2);
+                    }
+                    return { num: available, act: name };
+                } else if (max < available) {
+                    count++;
+                    return { num: max + (count <= rem ? 1 : 0), act: name };
+                } else {
+                    return { num: max, act: name };
+                }
+            });
+            let finalGroups = $salls.get().map((finalGroup) => {
+                return groups.find(group => group.act === finalGroup.getAttribute("data-name")).num;
+            });
+
+            console.debug("Groups:", finalGroups);
+
+            finalGroups.forEach((group, j) => {
+                for (let i = start; i < start + group; i++) {
+                    let $row = $rows.eq(i);
+                    let act = acts[j];
+                    $("input", $row).prop("checked", false);
+                    $("input[name='" + act + "']", $row).prop("checked", true);
+                }
+                start += group;
+                sus[j] = group;
+            });
+        } else {
+            let groups = [...Array($salls.length)].map((group, i) => {
+                if (i < rem) {
+                    return max + 1;
+                }
+                return max;
+            });
+
+            console.debug("Groups:", groups);
+
+            let acti = 0,
                 curi = 0;
-            }
-        });
 
-        sus[acti] = curi;
-        console.debug(sus);
+            $rows.each(function() {
+                let act = acts[acti];
+                $("input", $(this)).prop("checked", false);
+                $("input[name='" + act + "']", $(this)).prop("checked", true);
+                curi++;
+                if (curi >= groups[acti] && (acti + 1) < acts.length) {
+                    sus[acti] = curi;
+                    acti++;
+                    curi = 0;
+                }
+            });
 
-        var msg = "";
+            sus[acti] = curi;
+            console.debug(sus);
+        }
+
+        let msg = "";
         for (su in sus) {
             if (sus.hasOwnProperty(su) && sus[su] > 0) {
                 msg += sus[su] + " students were placed into: " + act_names[su] + "\n";
             }
         }
+
+        acts.forEach(name => updateCheckboxes(name));
 
         msg += "\nTo apply these changes, press the Finish button below.";
         alert(msg);

--- a/intranet/templates/eighth/admin/distribute_group.html
+++ b/intranet/templates/eighth/admin/distribute_group.html
@@ -102,19 +102,23 @@
 
             <input type="hidden" name="users" value="true">
             <input type="submit" value="Register Users" onclick="if(confirm('Are you sure you want to sign these users up for these activities?')){showWaitScreen();return true;}else return false;">
-            <button onclick="distribute(); return false">Evenly Distribute</button>
+            <button onclick="distribute(); return false">Evenly Distribute</button><br>
+            <label class="allow-exceed">
+                <input type="checkbox" name="allow-exceed" style="margin: 0" /> Allow exceeding capacity when evenly distributing
+            </label>
             <br>
             Click on column titles to sort.
-            <table data-sortable class="sortable distribute-group-grid fancy-table">
+            <table data-sortable class="distribute-group-grid fancy-table">
                 <thead>
                     <tr>
                         <th>Name</th>
                         <th>Student ID</th>
                         <th>Grade</th>
-                        {% for sch in schacts %}
+                        {% for sch, capacity in schacts %}
                         <th>
                             {{ sch.activity }}<br>
                             {{ sch.block }}<br>
+                            Available: <span class="remaining-capacity" data-name="schact{{ sch.id }}">{{ capacity }}</span>/{{ sch.capacity }}<br>
                             <input type="checkbox" name="select-all-{{ sch.id }}" class="select-all" data-name="schact{{ sch.id }}">
                         </th>
                         {% empty %}
@@ -128,7 +132,7 @@
                     <td>{{ user.last_name }}, {{ user.first_name }}{% if user.nickname %} ({{ user.nickname }}){% endif %}</td>
                     <td>{{ user.student_id }}</td>
                     <td>{{ user.grade_number }}</td>
-                    {% for sch in schacts %}
+                    {% for sch, capacity in schacts %}
                     <td>
                         <input type="checkbox" class="user-item" name="schact{{ sch.id }}" value="{{ user.id }}">
                     </td>


### PR DESCRIPTION
## Proposed changes
- Option to toggle allow exceeding activity capacities when distributing evenly
- Students are distributed evenly across selected activities when possible (either within all activities' capacities or when allow exceeding capacities is checked )
- If some of the activities have a smaller capacity, students are still distributed evenly for the rest
- Improve checkbox behavior and prevent a student from being assigned multiple activities

## Brief description of rationale
- Better calculates student distribution and tries to distribute as evenly as possible
- Improves UX
- Closes #1300 