### PR TITLE
Change Bus Rollover to 10am

### DIFF
--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -948,7 +948,7 @@ if TJSTAR_MAP is None:
 SIMILAR_THRESHOLD = 5
 
 # Time that the bus page should change from morning to afternoon display
-BUS_PAGE_CHANGEOVER_HOUR = 12
+BUS_PAGE_CHANGEOVER_HOUR = 10
 
 # Age (in days) of a lost and found entry until it is hidden
 LOSTFOUND_EXPIRATION = 180


### PR DESCRIPTION
## Proposed changes
- Make the bus app rollover from morning to afternoon at 10 AM rather than 12 PM

## Brief description of rationale
- EOY early release days end at 11:55 AM and having rollover at 12 PM is not ideal