### PR TITLE
feat(user): add administrator field (based on counselor) for students

### DIFF
--- a/docs/source/reference_index/apps/dataimport.rst
+++ b/docs/source/reference_index/apps/dataimport.rst
@@ -15,5 +15,6 @@ dataimport
    management.commands.import_students
    management.commands.import_tj_star
    management.commands.import_users
+   management.commands.update_administrators
    management.commands.year_cleanup
    tests

--- a/intranet/apps/dataimport/management/commands/import_students.py
+++ b/intranet/apps/dataimport/management/commands/import_students.py
@@ -1,8 +1,10 @@
 import csv
 import sys
+from typing import Any
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
+from django.db import transaction
 from django.db.models import Q
 
 from ....users.models import Email
@@ -79,7 +81,7 @@ class Command(BaseCommand):
 
         return new_username
 
-    def handle(self, *args, **options):
+    def handle(self, *args: str, **options: Any) -> None:
         # Read the data file
         with open(options["filename"], encoding="utf-8") as csvfile:
             data = list(csv.DictReader(csvfile))
@@ -112,46 +114,62 @@ class Command(BaseCommand):
         # Used to store actual usernames (after they have been deduplicated) to output to that file
         actual_username_list = []
 
-        # Loop through our new users
-        for new_user in data:
-            # Prevent duplication of users
-            if new_user["Student ID"] not in existing_student_ids:
-                # Check to see if username already taken
-                if new_user["TJHSST_username"] in existing_usernames:
-                    new_user["TJHSST_username"] = self.find_next_available_username(new_user["TJHSST_username"], existing_usernames)
+        # An unresolvable row rolls the whole import back, rather than leaving a half-imported class
+        try:
+            with transaction.atomic():
+                # Loop through our new users
+                for new_user in data:
+                    # Prevent duplication of users
+                    if new_user["Student ID"] not in existing_student_ids:
+                        # Check to see if username already taken
+                        if new_user["TJHSST_username"] in existing_usernames:
+                            new_user["TJHSST_username"] = self.find_next_available_username(new_user["TJHSST_username"], existing_usernames)
 
-                # Append username to list
-                actual_username_list.append(new_user["TJHSST_username"])
+                        # Append username to list
+                        actual_username_list.append(new_user["TJHSST_username"])
 
-                # Now we can safely add this user
-                if do_run:
-                    counselor = get_user_model().objects.get(username=new_user["Counselor"].strip()) if "Counselor" in new_user.keys() else None
-                    nickname = new_user["Nick Name"].strip() if "Nick Name" in new_user.keys() else ""
-                    gender = (
-                        new_user["Gender"].strip() == "M" if "Gender" in new_user.keys() else None
-                    )  # TODO: is it "M" or "Male" or something else?
-                    new_user_obj = get_user_model().objects.create(
-                        username=new_user["TJHSST_username"],
-                        student_id=new_user["Student ID"].strip(),
-                        last_name=new_user["Last Name"].strip(),
-                        first_name=new_user["First Name"].strip(),
-                        middle_name=new_user["Middle Name"].strip(),
-                        counselor=counselor,
-                        nickname=nickname,
-                        graduation_year=int(options["grad_year"]),
-                        gender=gender,
-                        receive_news_emails=True,
-                        receive_eighth_emails=True,
-                    )
-                    # We must add their TJ email
-                    Email.objects.create(address=f"{new_user['TJHSST_username']}@tjhsst.edu", user=new_user_obj)
+                        # Now we can safely add this user
+                        if do_run:
+                            counselor = (
+                                get_user_model().objects.get(username=new_user["Counselor"].strip()) if "Counselor" in new_user.keys() else None
+                            )
+                            # Fall back to the counselor's administrator when the CSV does not name one
+                            administrator = (
+                                get_user_model().objects.get(username=new_user["Administrator"].strip())
+                                if (new_user.get("Administrator") or "").strip()
+                                else (counselor.administrator if counselor else None)
+                            )
+                            nickname = new_user["Nick Name"].strip() if "Nick Name" in new_user.keys() else ""
+                            gender = (
+                                new_user["Gender"].strip() == "M" if "Gender" in new_user.keys() else None
+                            )  # TODO: is it "M" or "Male" or something else?
+                            new_user_obj = get_user_model().objects.create(
+                                username=new_user["TJHSST_username"],
+                                student_id=new_user["Student ID"].strip(),
+                                last_name=new_user["Last Name"].strip(),
+                                first_name=new_user["First Name"].strip(),
+                                middle_name=new_user["Middle Name"].strip(),
+                                counselor=counselor,
+                                administrator=administrator,
+                                nickname=nickname,
+                                graduation_year=int(options["grad_year"]),
+                                gender=gender,
+                                receive_news_emails=True,
+                                receive_eighth_emails=True,
+                            )
+                            # We must add their TJ email
+                            Email.objects.create(address=f"{new_user['TJHSST_username']}@tjhsst.edu", user=new_user_obj)
 
-                self.stdout.write(self.style.SUCCESS(f"Created user {new_user['TJHSST_username']}."))
+                        self.stdout.write(self.style.SUCCESS(f"Created user {new_user['TJHSST_username']}."))
 
-                existing_usernames.add(new_user["TJHSST_username"])
+                        existing_usernames.add(new_user["TJHSST_username"])
 
-            else:
-                self.stdout.write(self.style.ERROR(f"User with SID {new_user['Student ID']} already exists."))
+                    else:
+                        self.stdout.write(self.style.ERROR(f"User with SID {new_user['Student ID']} already exists."))
+        except Exception:
+            # The "Created user ..." lines above were rolled back too
+            self.stdout.write(self.style.ERROR("Rolled back: no users were created. Fix the row below and re-run."))
+            raise
 
         if options["username_file"] is not None:
             with open(options["username_file"], "w", encoding="utf-8") as file:

--- a/intranet/apps/dataimport/management/commands/import_users.py
+++ b/intranet/apps/dataimport/management/commands/import_users.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
@@ -12,7 +13,7 @@ class Command(BaseCommand):
         # Positional arguments
         parser.add_argument("data_fname")
 
-    def handle(self, *args, **kwargs):
+    def handle(self, *args: str, **kwargs: Any) -> None:
         try:
             with open(kwargs["data_fname"], encoding="utf-8") as f_obj:
                 data = json.load(f_obj)
@@ -59,6 +60,8 @@ class Command(BaseCommand):
                     first_name=first_name,
                     username=username,
                     counselor=counselor,
+                    # Students are assigned administrators through their counselor
+                    administrator=counselor.administrator,
                     gender=(gender == "M"),
                     graduation_year=graduation_year,
                     middle_name=middle_name,

--- a/intranet/apps/dataimport/management/commands/update_administrators.py
+++ b/intranet/apps/dataimport/management/commands/update_administrators.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+import csv
+import sys
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError, CommandParser
+from django.db import transaction
+
+from intranet.utils.date import get_senior_graduation_year
+
+from ....users.models import User
+
+
+class Command(BaseCommand):
+    help = "Update subschool administrator information, inheriting from each student's counselor"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "filename",
+            type=str,
+            nargs="?",
+            default=None,
+            help="Path to SIS import CSV with a Student ID column, and optionally an Administrator column",
+        )
+
+        parser.add_argument("--all", action="store_true", dest="all", default=False, help="Update every student who has not graduated")
+        parser.add_argument(
+            "--graduation-years",
+            dest="graduation_years",
+            nargs="+",
+            type=int,
+            default=None,
+            metavar="YEAR",
+            help="Update only students graduating in these years (e.g. --graduation-years 2027 2028)",
+        )
+
+        parser.add_argument("--run", action="store_true", dest="run", default=False, help="Actually modifies the DB")
+
+    def handle(self, *args: str, **kwargs: Any) -> None:
+        filename = kwargs["filename"]
+        all_students = kwargs["all"]
+        graduation_years = kwargs["graduation_years"]
+
+        if sum(map(bool, (filename, all_students, graduation_years))) != 1:
+            raise CommandError("Pass exactly one of: a CSV filename, --all, or --graduation-years")
+
+        to_run = kwargs["run"]
+
+        if not to_run:
+            sys.stdout.write(
+                """This script is running in pretend mode.
+Pass --run to actually run this script.
+Please MAKE SURE you have updated info before running this script.
+Actually running is a destructive operation.
+"""
+            )
+
+        # Collect the students to work through, paired with any administrator named for them
+        targets = []
+        if filename:
+            try:
+                with open(filename, encoding="utf-8") as f:
+                    data = list(csv.DictReader(f))
+            except OSError as ex:
+                raise CommandError(str(ex)) from ex
+
+            if data and "Student ID" not in data[0]:
+                raise CommandError(f"{filename} has no 'Student ID' column")
+
+            for row in data:
+                sid = row["Student ID"].strip()
+                user = get_user_model().objects.user_with_student_id(sid)
+                if user is None:
+                    sys.stdout.write(f"There is no Ion account found for SID {sid}\n")
+                    continue
+
+                targets.append((user, (row.get("Administrator") or "").strip()))
+        else:
+            # Every one of these runs through the counselor chain, so pull it in up front
+            students = get_user_model().objects.filter(user_type="student").select_related("counselor__administrator")
+            if graduation_years:
+                students = students.filter(graduation_year__in=graduation_years)
+            else:
+                students = students.filter(graduation_year__gte=get_senior_graduation_year())
+
+            sys.stdout.write(f"Working through {students.count()} student(s).\n")
+            targets = [(user, "") for user in students]
+
+        # One transaction, so a failure part way through does not split students across administrators
+        with transaction.atomic():
+            for user, listed_name in targets:
+                administrator = self.resolve_administrator(user, listed_name)
+                if administrator is None:
+                    continue
+
+                if administrator != user.administrator:
+                    sys.stdout.write(f"Switching administrator for {user.username} from {user.administrator} to {administrator}\n")
+                    if to_run:
+                        user.administrator = administrator
+                        user.save(update_fields=["administrator"])
+
+    def resolve_administrator(self, user: User, listed_name: str) -> User | None:
+        """Returns the administrator to assign ``user``, or ``None`` if it cannot be determined."""
+        # Kept out of handle() because the try/except around the lookup, plus the counselor
+        # fallback, pushes handle() past the complexity limit when inlined.
+        # We assume every administrator has a unique last name
+        name = listed_name.split(",")[0].strip()
+        if name:
+            try:
+                return get_user_model().objects.get(user_type="teacher", last_name=name)
+            except get_user_model().DoesNotExist:
+                sys.stdout.write(f"There is no teacher account found with last name {name}\n")
+                return None
+            except get_user_model().MultipleObjectsReturned:
+                sys.stdout.write(f"There are multiple teacher accounts with last name {name}\n")
+                return None
+
+        # Nothing named explicitly, so inherit from the counselor
+        if user.counselor is None:
+            sys.stdout.write(f"{user.username} has no administrator listed and no counselor to inherit one from\n")
+            return None
+
+        if user.counselor.administrator is None:
+            sys.stdout.write(f"Counselor {user.counselor} has no administrator set, so {user.username} cannot inherit one\n")
+            return None
+
+        return user.counselor.administrator

--- a/intranet/apps/dataimport/tests.py
+++ b/intranet/apps/dataimport/tests.py
@@ -7,8 +7,11 @@ from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
 from django.utils import timezone
 
+from intranet.utils.date import get_senior_graduation_year
+
 from ...test.ion_test import IonTestCase
 from ..eighth.models import EighthActivity, EighthBlock, EighthScheduledActivity, EighthSignup
+from ..users.models import User
 from .management.commands.import_students import Command as import_students
 
 
@@ -151,13 +154,16 @@ class ImportStudentsTest(IonTestCase):
         self.assertEqual("2021ttest8", import_students.find_next_available_username(None, "2021ttest", s))
 
     def test_command(self):
-        # Create a counselor user
-        get_user_model().objects.get_or_create(username="abcounselor", user_type="counselor")
+        # Create an administrator user, and a counselor who reports to them
+        administrator = get_user_model().objects.get_or_create(username="abadmin", user_type="teacher")[0]
+        get_user_model().objects.get_or_create(username="abadmin2", user_type="teacher")
+        get_user_model().objects.get_or_create(username="abcounselor", user_type="counselor", administrator=administrator)
 
+        # Jane's administrator is named explicitly; John's is blank, so it comes from his counselor
         csv_contents = (
-            "Last Name,First Name,Middle Name,Student ID,Grade,Gender,Nick Name,Counselor\n"
-            "Doe,Jane,Test,2222222,09,F,,abcounselor\n"
-            "Doe,John,,1111111,09,M,,abcounselor"
+            "Last Name,First Name,Middle Name,Student ID,Grade,Gender,Nick Name,Counselor,Administrator\n"
+            "Doe,Jane,Test,2222222,09,F,,abcounselor,abadmin2\n"
+            "Doe,John,,1111111,09,M,,abcounselor,"
         )
 
         with patch("intranet.apps.dataimport.management.commands.import_students.open", mock_open(read_data=csv_contents)) as m:
@@ -175,6 +181,179 @@ class ImportStudentsTest(IonTestCase):
 
         self.assertEqual(1, get_user_model().objects.filter(username="2021jdoe", first_name="Jane").count())
         self.assertEqual(1, get_user_model().objects.filter(username="2021jdoe1", first_name="John").count())
+
+        self.assertEqual("abadmin2", get_user_model().objects.get(username="2021jdoe").administrator.username)
+        self.assertEqual("abadmin", get_user_model().objects.get(username="2021jdoe1").administrator.username)
+
+
+class UpdateAdministratorsTest(IonTestCase):
+    def setUp(self) -> None:
+        # Two subschool administrators, and a counselor assigned to each
+        self.adminone = get_user_model().objects.get_or_create(username="adminone", last_name="AdminOne", user_type="teacher")[0]
+        self.admintwo = get_user_model().objects.get_or_create(username="admintwo", last_name="AdminTwo", user_type="teacher")[0]
+
+        self.counselorone = get_user_model().objects.get_or_create(
+            username="counselorone", last_name="CounselorOne", user_type="counselor", administrator=self.adminone
+        )[0]
+        self.counselortwo = get_user_model().objects.get_or_create(
+            username="counselortwo", last_name="CounselorTwo", user_type="counselor", administrator=self.admintwo
+        )[0]
+        # A counselor nobody has assigned an administrator to yet
+        self.counselorthree = get_user_model().objects.get_or_create(username="counselorthree", last_name="CounselorThree", user_type="counselor")[0]
+
+    def run_command(self, file_contents: str, *args: str) -> None:
+        with patch("intranet.apps.dataimport.management.commands.update_administrators.open", mock_open(read_data=file_contents)):
+            call_command("update_administrators", "foo.csv", *args)
+
+    def administrator_of(self, username: str) -> User | None:
+        return get_user_model().objects.get(username=username).administrator
+
+    def test_inherits_from_counselor(self) -> None:
+        """With no Administrator column at all, every student takes their counselor's administrator."""
+        file_contents = "Student ID\n1111111\n2222222\n3333333"
+
+        get_user_model().objects.get_or_create(username="2021atest", student_id=1111111, user_type="student", counselor=self.counselorone)
+        get_user_model().objects.get_or_create(username="2021atest2", student_id=2222222, user_type="student", counselor=self.counselortwo)
+        # Already correct, so this one should simply be left alone
+        get_user_model().objects.get_or_create(
+            username="2021atest3", student_id=3333333, user_type="student", counselor=self.counselortwo, administrator=self.admintwo
+        )
+
+        # Pretend mode should not change anything
+        self.run_command(file_contents)
+        self.assertIsNone(self.administrator_of("2021atest"))
+
+        self.run_command(file_contents, "--run")
+
+        self.assertEqual("adminone", self.administrator_of("2021atest").username)
+        self.assertEqual("admintwo", self.administrator_of("2021atest2").username)
+        self.assertEqual("admintwo", self.administrator_of("2021atest3").username)
+
+    def test_reassigns_when_counselor_changes(self) -> None:
+        """A student whose counselor moved subschools follows their counselor's administrator."""
+        file_contents = "Student ID,Administrator\n1111111,"
+
+        get_user_model().objects.get_or_create(
+            username="2021atest", student_id=1111111, user_type="student", counselor=self.counselorone, administrator=self.admintwo
+        )
+
+        self.run_command(file_contents, "--run")
+
+        self.assertEqual("adminone", self.administrator_of("2021atest").username)
+
+    def test_explicit_administrator_wins(self) -> None:
+        """An Administrator named in the CSV overrides what the counselor would imply."""
+        file_contents = 'Student ID,Administrator\n1111111,AdminTwo\n2222222,"AdminTwo, Alice"'
+
+        get_user_model().objects.get_or_create(username="2021atest", student_id=1111111, user_type="student", counselor=self.counselorone)
+        get_user_model().objects.get_or_create(username="2021atest2", student_id=2222222, user_type="student", counselor=self.counselorone)
+
+        self.run_command(file_contents, "--run")
+
+        # Both the bare last name and the SIS "Last, First" form should resolve
+        self.assertEqual("admintwo", self.administrator_of("2021atest").username)
+        self.assertEqual("admintwo", self.administrator_of("2021atest2").username)
+
+    def test_unresolvable_rows_are_skipped(self) -> None:
+        """Rows that cannot be resolved are reported and skipped rather than aborting the run."""
+        file_contents = (
+            "Student ID,Administrator\n"
+            "1111111,NoSuchAdmin\n"  # no staff account by that name
+            "2222222,\n"  # counselor has no administrator to inherit
+            "3333333,\n"  # no counselor at all
+            "4444444,\n"  # no Ion account for this SID
+        )
+
+        get_user_model().objects.get_or_create(username="2021atest", student_id=1111111, user_type="student", counselor=self.counselorone)
+        get_user_model().objects.get_or_create(username="2021atest2", student_id=2222222, user_type="student", counselor=self.counselorthree)
+        get_user_model().objects.get_or_create(username="2021atest3", student_id=3333333, user_type="student")
+
+        self.run_command(file_contents, "--run")
+
+        self.assertIsNone(self.administrator_of("2021atest"))
+        self.assertIsNone(self.administrator_of("2021atest2"))
+        self.assertIsNone(self.administrator_of("2021atest3"))
+
+    def test_only_teachers_match_a_surname(self) -> None:
+        """Administrators are teachers, so no other user type may be matched by surname."""
+        for user_type in ("counselor", "user", "alum", "service", "simple_user", "tjstar_presenter", "student"):
+            with self.subTest(user_type=user_type):
+                get_user_model().objects.filter(last_name="Uniquesurname").delete()
+                get_user_model().objects.create(username=f"n{user_type}", last_name="Uniquesurname", user_type=user_type)
+
+                student = get_user_model().objects.update_or_create(
+                    username="2021anonstaff", defaults={"student_id": 7777777, "user_type": "student", "administrator": None}
+                )[0]
+
+                self.run_command("Student ID,Administrator\n7777777,Uniquesurname", "--run")
+
+                student.refresh_from_db()
+                self.assertIsNone(student.administrator)
+
+        # ...while a teacher with that surname does match
+        get_user_model().objects.filter(last_name="Uniquesurname").delete()
+        teacher = get_user_model().objects.create(username="realteacher", last_name="Uniquesurname", user_type="teacher")
+
+        self.run_command("Student ID,Administrator\n7777777,Uniquesurname", "--run")
+
+        self.assertEqual(teacher, self.administrator_of("2021anonstaff"))
+
+    def test_all_students_from_db(self) -> None:
+        """--all runs the counselor chain over every student who has not graduated, with no CSV."""
+        senior_year = get_senior_graduation_year()
+
+        get_user_model().objects.get_or_create(
+            username="atest", student_id=1111111, user_type="student", counselor=self.counselorone, graduation_year=senior_year
+        )
+        get_user_model().objects.get_or_create(
+            username="atest2", student_id=2222222, user_type="student", counselor=self.counselortwo, graduation_year=senior_year + 1
+        )
+        # Already graduated, so left alone
+        get_user_model().objects.get_or_create(
+            username="atest3", student_id=3333333, user_type="student", counselor=self.counselorone, graduation_year=senior_year - 1
+        )
+
+        # Pretend mode should not change anything
+        call_command("update_administrators", "--all")
+        self.assertIsNone(self.administrator_of("atest"))
+
+        call_command("update_administrators", "--all", "--run")
+
+        self.assertEqual("adminone", self.administrator_of("atest").username)
+        self.assertEqual("admintwo", self.administrator_of("atest2").username)
+        self.assertIsNone(self.administrator_of("atest3"))
+
+    def test_graduation_years_from_db(self) -> None:
+        """--graduation-years narrows the run to the given classes."""
+        get_user_model().objects.get_or_create(
+            username="2027atest", student_id=1111111, user_type="student", counselor=self.counselorone, graduation_year=2027
+        )
+        get_user_model().objects.get_or_create(
+            username="2028atest", student_id=2222222, user_type="student", counselor=self.counselortwo, graduation_year=2028
+        )
+        get_user_model().objects.get_or_create(
+            username="2029atest", student_id=3333333, user_type="student", counselor=self.counselorone, graduation_year=2029
+        )
+
+        call_command("update_administrators", "--graduation-years", "2027", "2028", "--run")
+
+        self.assertEqual("adminone", self.administrator_of("2027atest").username)
+        self.assertEqual("admintwo", self.administrator_of("2028atest").username)
+        self.assertIsNone(self.administrator_of("2029atest"))
+
+    def test_requires_exactly_one_selection(self) -> None:
+        """A CSV and a database selection are mutually exclusive, and one of them is required."""
+        # Nothing selected
+        with self.assertRaises(CommandError):
+            call_command("update_administrators", "--run")
+
+        # Both database selections
+        with self.assertRaises(CommandError):
+            call_command("update_administrators", "--all", "--graduation-years", "2027")
+
+        # A CSV and a database selection
+        with self.assertRaises(CommandError):
+            call_command("update_administrators", "foo.csv", "--all")
 
 
 class ImportStaffTest(IonTestCase):

--- a/intranet/apps/eighth/tests/test_profile.py
+++ b/intranet/apps/eighth/tests/test_profile.py
@@ -205,3 +205,56 @@ class EighthProfileTest(EighthAbstractTest):
         self.assertIsNotNone("A", user2.nickname)
         self.assertIsNotNone(get_senior_graduation_year(), Grade.year_from_grade(user2.grade.number))
         self.assertIsNotNone("female", user2.gender)
+
+    def test_edit_profile_view_counselor_and_administrator(self) -> None:
+        """Tests setting the counselor and administrator via ``edit_profile_view``."""
+        get_user_model().objects.all().delete()
+
+        self.make_admin()
+        counselor = get_user_model().objects.get_or_create(username="acounselor", user_type="counselor")[0]
+        administrator = get_user_model().objects.get_or_create(username="anadmin", user_type="teacher")[0]
+        user2 = get_user_model().objects.get_or_create(username="2021awilliam", user_type="student")[0]
+
+        base_data = {
+            "first_name": "Angela",
+            "last_name": "William",
+            "gender": "female",
+        }
+
+        # Both selections should be saved onto the user
+        response = self.client.post(
+            reverse("eighth_edit_profile", kwargs={"user_id": user2.id}),
+            data={**base_data, "counselor": counselor.id, "administrator": administrator.id},
+            follow=True,
+        )
+        self.assertEqual(200, response.status_code)
+        user2 = get_user_model().objects.get(id=user2.id)
+        self.assertEqual(counselor, user2.counselor)
+        self.assertEqual(administrator, user2.administrator)
+
+        # Administrators are teachers, so a student, a counselor or an unused ID is a form error
+        missing_id = get_user_model().objects.order_by("-id").first().id + 100
+        for bad_value in (missing_id, user2.id, counselor.id):
+            response = self.client.post(
+                reverse("eighth_edit_profile", kwargs={"user_id": user2.id}),
+                data={**base_data, "counselor": counselor.id, "administrator": bad_value},
+                follow=True,
+            )
+            self.assertEqual(200, response.status_code)
+            self.assertFalse(response.context["user_form"].is_valid())
+
+            # ...and nothing is changed by the rejected submission
+            user2 = get_user_model().objects.get(id=user2.id)
+            self.assertEqual(administrator, user2.administrator)
+            self.assertEqual(counselor, user2.counselor)
+
+        # An empty selection unassigns, since these are dropdowns rather than ID boxes
+        response = self.client.post(
+            reverse("eighth_edit_profile", kwargs={"user_id": user2.id}),
+            data={**base_data, "counselor": "", "administrator": ""},
+            follow=True,
+        )
+        self.assertEqual(200, response.status_code)
+        user2 = get_user_model().objects.get(id=user2.id)
+        self.assertIsNone(user2.counselor)
+        self.assertIsNone(user2.administrator)

--- a/intranet/apps/eighth/views/profile.py
+++ b/intranet/apps/eighth/views/profile.py
@@ -25,7 +25,7 @@ def date_fmt(date):
 
 @eighth_admin_required
 @deny_restricted
-def edit_profile_view(request, user_id=None):
+def edit_profile_view(request: http.HttpRequest, user_id: int | None = None) -> http.HttpResponse:
     user = get_object_or_404(get_user_model(), id=user_id)
     # Disable address form temporarily -- okulkarni, 08/30/2018
     address_form = None
@@ -34,10 +34,6 @@ def edit_profile_view(request, user_id=None):
         # address_form = AddressForm(request.POST, instance=user.properties.address)
         if user_form.is_valid():
             user = user_form.save()
-            counselor_id = user_form.cleaned_data["counselor_id"]
-            if counselor_id:
-                counselor = get_user_model().objects.get(id=counselor_id)
-                user.counselor = counselor
             # user.properties.address = address_form.save()
             # user.properties.save()
             user.save()
@@ -45,7 +41,7 @@ def edit_profile_view(request, user_id=None):
         else:
             messages.error(request, "An error occurred updating user profile.")
     else:
-        user_form = ProfileEditForm(initial={"counselor_id": "" if not user.counselor else user.counselor.id}, instance=user)
+        user_form = ProfileEditForm(instance=user)
         # address_form = AddressForm(instance=user.properties.address)
 
     context = {"profile_user": user, "user_form": user_form, "address_form": address_form}

--- a/intranet/apps/search/views.py
+++ b/intranet/apps/search/views.py
@@ -47,6 +47,7 @@ def query(q, admin=False):
             "id": ("id",),
             "username": ("username",),
             "counselor": ("counselor__last_name",),
+            "administrator": ("administrator__last_name",),
             "type": ("user_type",),
         }
 

--- a/intranet/apps/users/admin.py
+++ b/intranet/apps/users/admin.py
@@ -33,6 +33,8 @@ class UserAdmin(admin.ModelAdmin):
         "receive_schedule_notifications",
         "bus_route",
         "counselor",
+        # List only administrators actually assigned, not every user
+        ("administrator", admin.RelatedOnlyFieldListFilter),
     )
     search_fields = (
         "username",

--- a/intranet/apps/users/forms.py
+++ b/intranet/apps/users/forms.py
@@ -4,6 +4,14 @@ from django.contrib.auth import get_user_model
 from .models import Address
 
 
+class UserChoiceField(forms.ModelChoiceField):
+    """A ModelChoiceField that returns a user's full name instead of their TJ username (which is the
+    default string representation)."""
+
+    def label_from_instance(self, obj):
+        return obj.full_name
+
+
 class ProfileEditForm(forms.ModelForm):
     """A form containing editable fields in the User model."""
 
@@ -17,19 +25,34 @@ class ProfileEditForm(forms.ModelForm):
     nickname = forms.CharField(label="Nickname", required=False)
     graduation_year = forms.IntegerField(label="Graduation Year", required=False)
     gender = forms.ChoiceField(choices=GENDERS, label="Sex (Male, Female, or Non-Binary)")
-    counselor_id = forms.IntegerField(label="Counselor ID", required=False)
+    counselor = UserChoiceField(
+        queryset=get_user_model().objects.filter(user_type="counselor").order_by("last_name", "first_name"),
+        label="Counselor",
+        required=False,
+        empty_label="No Counselor",
+    )
+    administrator = UserChoiceField(
+        queryset=get_user_model().objects.filter(user_type="teacher").order_by("last_name", "first_name"),
+        label="Administrator",
+        required=False,
+        empty_label="No Administrator",
+    )
 
     class Meta:
         model = get_user_model()
-        fields = ["admin_comments", "student_id", "first_name", "middle_name", "last_name", "title", "nickname", "graduation_year", "gender"]
-
-
-class UserChoiceField(forms.ModelChoiceField):
-    """A ModelChoiceField that returns a user's full name instead of their TJ username (which is the
-    default string representation)."""
-
-    def label_from_instance(self, obj):
-        return obj.full_name
+        fields = [
+            "admin_comments",
+            "student_id",
+            "first_name",
+            "middle_name",
+            "last_name",
+            "title",
+            "nickname",
+            "graduation_year",
+            "gender",
+            "counselor",
+            "administrator",
+        ]
 
 
 class SortedUserChoiceField(forms.ModelChoiceField):

--- a/intranet/apps/users/migrations/0043_user_administrator.py
+++ b/intranet/apps/users/migrations/0043_user_administrator.py
@@ -1,0 +1,18 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0042_user_seen_april_fools'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='administrator',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='administered_students', to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/intranet/apps/users/models.py
+++ b/intranet/apps/users/models.py
@@ -228,6 +228,7 @@ class User(AbstractBaseUser, PermissionsMixin):
     user_type = models.CharField(max_length=30, choices=USER_TYPES, default="student")
     admin_comments = models.TextField(blank=True, null=True)
     counselor = models.ForeignKey("self", on_delete=models.SET_NULL, related_name="students", null=True, blank=True)
+    administrator = models.ForeignKey("self", on_delete=models.SET_NULL, related_name="administered_students", null=True, blank=True)
     graduation_year = models.IntegerField(null=True, blank=True)
     title = models.CharField(max_length=5, choices=TITLES, null=True, blank=True)
     first_name = models.CharField(max_length=35, null=True)

--- a/intranet/apps/users/serializers.py
+++ b/intranet/apps/users/serializers.py
@@ -58,6 +58,7 @@ class UserSerializer(serializers.ModelSerializer):
     grade = GradeSerializer()
     address = AddressSerializer()
     counselor = CounselorTeacherSerializer()
+    administrator = CounselorTeacherSerializer()
     ion_username = serializers.CharField(max_length=500)
     display_name = serializers.CharField(max_length=400)
     nickname = serializers.CharField(max_length=200)
@@ -100,6 +101,7 @@ class UserSerializer(serializers.ModelSerializer):
             "phones",
             "websites",
             "counselor",
+            "administrator",
             "address",
             "picture",
             "is_eighth_admin",

--- a/intranet/apps/users/tests.py
+++ b/intranet/apps/users/tests.py
@@ -613,6 +613,121 @@ class ProfileTest(IonTestCase):
                 self.assertTrue(response.context["nominations_active"])
                 self.assertEqual(response.context["nomination_position"], settings.NOMINATION_POSITION)
 
+    def test_subschools_view(self) -> None:
+        """Addresses come from each username's account, or from an address given outright."""
+        self.login()
+
+        subschools = [
+            {
+                "name": "Subschool 1",
+                "administrator": {"name": "Mr. Explicit", "username": "sexplicit"},
+                "administrative_assistant": {"name": "Ms. NoAccount", "email": "no.account@fcps.edu"},
+                "counselors": [
+                    {"name": "Ms. Guessed", "username": "sguessed"},
+                    {"name": "Dr. Nobody", "username": "snobody"},
+                ],
+            }
+        ]
+
+        explicit = get_user_model().objects.get_or_create(username="sexplicit", user_type="teacher")[0]
+        Email.objects.get_or_create(user=explicit, address="chosen.address@fcps.edu")
+        get_user_model().objects.get_or_create(username="sguessed", user_type="counselor")
+        # "snobody" deliberately has no account, and Ms. NoAccount has no username at all
+
+        with self.settings(SUBSCHOOLS=subschools):
+            response = self.client.get(reverse("subschools"))
+
+        self.assertEqual(200, response.status_code)
+        content = response.content.decode()
+
+        # An address on the account wins over the guessed one
+        self.assertIn("mailto:chosen.address@fcps.edu", content)
+        # Otherwise tj_email guesses from the username
+        self.assertIn("mailto:sguessed@fcps.edu", content)
+        # An address configured outright is used as-is, for staff with no Ion account
+        self.assertIn("mailto:no.account@fcps.edu", content)
+        # A username with no account is named but not linked
+        self.assertIn("Dr. Nobody", content)
+        self.assertNotIn("mailto:snobody", content)
+
+        # Settings are not mutated by the lookup
+        self.assertNotIn("email", subschools[0]["administrator"])
+
+    def test_subschools_view_username_must_match_exactly(self) -> None:
+        """A username whose case differs from the account is not matched, and is logged."""
+        self.login()
+
+        subschools = [
+            {
+                "name": "Subschool 1",
+                "administrator": {"name": "Ms. Exact", "username": "SExact1"},
+                "administrative_assistant": {"name": "Mr. Wrongcase", "username": "SWrongcase1"},
+                "counselors": [],
+            }
+        ]
+
+        exact = get_user_model().objects.get_or_create(username="SExact1", user_type="teacher")[0]
+        Email.objects.get_or_create(user=exact, address="exact.spelling@fcps.edu")
+        # Stored lowercase while settings uses mixed case, so it must not resolve
+        get_user_model().objects.get_or_create(username="swrongcase1", user_type="teacher")
+
+        with self.settings(SUBSCHOOLS=subschools):
+            with self.assertLogs("intranet.apps.users.views", level="WARNING") as logs:
+                response = self.client.get(reverse("subschools"))
+
+        content = response.content.decode()
+        self.assertIn("mailto:exact.spelling@fcps.edu", content)
+        self.assertNotIn("mailto:swrongcase1", content)
+        self.assertIn("Mr. Wrongcase", content)
+        self.assertTrue(any("SWrongcase1" in line for line in logs.output))
+
+    def test_subschools_view_last_updated(self) -> None:
+        """The configured last updated date is shown at the bottom of the page."""
+        self.login()
+
+        with self.settings(SUBSCHOOLS_LAST_UPDATED=datetime.date(1999, 3, 4)):
+            response = self.client.get(reverse("subschools"))
+
+        self.assertContains(response, "Last updated March 4, 1999.")
+
+        with self.settings(SUBSCHOOLS_LAST_UPDATED=None):
+            response = self.client.get(reverse("subschools"))
+
+        self.assertNotContains(response, "Last updated")
+
+    def test_subschools_view_requires_login(self) -> None:
+        response = self.client.get(reverse("subschools"))
+        self.assertEqual(302, response.status_code)
+        self.assertIn("/login", response["Location"])
+
+    def test_profile_view_administrator_row(self) -> None:
+        """The Administrator row always shows for staff viewers, blank when the user has none."""
+        admin_user = self.make_admin()
+        administrator = get_user_model().objects.get_or_create(username="anadmin", last_name="Dawson", user_type="teacher")[0]
+        counselor = get_user_model().objects.get_or_create(
+            username="acounselor", last_name="Kim", user_type="counselor", administrator=administrator
+        )[0]
+
+        # A student with a counselor who has an administrator, but no administrator of their own
+        student = get_user_model().objects.get_or_create(username="2021astudent", user_type="student", counselor=counselor)[0]
+
+        response = self.client.get(reverse("user_profile", kwargs={"user_id": student.id}))
+        self.assertEqual(200, response.status_code)
+        # The row is present even though the field is unset...
+        self.assertContains(response, "<th>Administrator</th>")
+        # ...and it must not fall back to the counselor's administrator
+        self.assertNotContains(response, administrator.last_name)
+
+        # Once assigned, the student's own administrator shows
+        student.administrator = administrator
+        student.save(update_fields=["administrator"])
+        response = self.client.get(reverse("user_profile", kwargs={"user_id": student.id}))
+        self.assertContains(response, administrator.last_name)
+
+        # The row also shows on a staff profile, where there is no counselor at all
+        response = self.client.get(reverse("user_profile", kwargs={"user_id": admin_user.id}))
+        self.assertContains(response, "<th>Administrator</th>")
+
     def test_privacy_options(self):
         self.assertEqual(set(PERMISSIONS_NAMES.keys()), {"self", "parent"})
         for k in ["self", "parent"]:

--- a/intranet/apps/users/views.py
+++ b/intranet/apps/users/views.py
@@ -1,4 +1,5 @@
 # pylint: disable=consider-using-with
+import copy
 import io
 import logging
 import os
@@ -7,7 +8,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import MultipleObjectsReturned
-from django.http import Http404, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 
@@ -107,6 +108,30 @@ def profile_view(request, user_id=None):
         "has_been_nominated": has_been_nominated,
     }
     return render(request, "users/profile.html", context)
+
+
+@login_required
+def subschools_view(request: HttpRequest) -> HttpResponse:
+    """Displays the subschool staff listed in ``settings.SUBSCHOOLS``."""
+    # A configured username has its tj_email looked up, keeping the address out of the repository.
+    # An address configured outright is kept as-is, for staff with no Ion account. Anyone who cannot
+    # be resolved is listed without a mailto link.
+    subschools = copy.deepcopy(settings.SUBSCHOOLS)
+    staff = [
+        person for subschool in subschools for person in (subschool["administrator"], subschool["administrative_assistant"], *subschool["counselors"])
+    ]
+
+    # Usernames must be configured with the same case as the account. tj_email filters each user's
+    # addresses, so it costs a query per person; that is fine for a list this small.
+    lookups = [person for person in staff if not person.get("email") and person.get("username")]
+    users = get_user_model().objects.filter(username__in=[person["username"] for person in lookups])
+    emails = {user.username: user.tj_email for user in users}
+    for person in lookups:
+        person["email"] = emails.get(person["username"])
+        if person["email"] is None:
+            logger.warning("SUBSCHOOLS lists username %r, which matches no account", person["username"])
+
+    return render(request, "subschools.html", {"subschools": subschools, "last_updated": settings.SUBSCHOOLS_LAST_UPDATED})
 
 
 @login_required

--- a/intranet/settings/__init__.py
+++ b/intranet/settings/__init__.py
@@ -106,6 +106,52 @@ PARKING_MAX_ABSENCES = 5
 NOMINATIONS_ACTIVE = False
 NOMINATION_POSITION = ""
 
+# Subschool staff, listed at /subschools. Override these in production.
+# Give each person a "username", spelled exactly as the account is, and their tj_email is looked up
+# so that no addresses are committed here. Only use "email" for someone with no Ion account. A
+# username matching no account is logged and shown without a mailto link.
+SUBSCHOOLS = [
+    {
+        "name": "Subschool 1",
+        "administrator": {"name": "Mr. Alpha", "username": "2027admin"},
+        "administrative_assistant": {"name": "Ms. Bravo", "username": "2027admin1"},
+        "counselors": [
+            {"name": "Ms. Charlie", "username": "2027student"},
+            {"name": "Mr. Delta", "username": "2027student1"},
+        ],
+    },
+    {
+        "name": "Subschool 2",
+        "administrator": {"name": "Ms. Echo", "username": "2028admin"},
+        "administrative_assistant": {"name": "Ms. Foxtrot", "username": "2028admin1"},
+        "counselors": [
+            {"name": "Ms. Golf", "username": "2028student"},
+            {"name": "Ms. Hotel", "username": "2028student1"},
+        ],
+    },
+    {
+        "name": "Subschool 3",
+        "administrator": {"name": "Ms. India", "username": "2029admin"},
+        "administrative_assistant": {"name": "Ms. Juliett", "username": "2029admin1"},
+        "counselors": [
+            {"name": "Ms. Kilo", "username": "2029student"},
+            {"name": "Ms. Lima", "username": "2029student1"},
+        ],
+    },
+    {
+        "name": "Subschool 4",
+        # Nobody to look up, so the address is given directly
+        "administrator": {"name": "Mr. Mike", "email": "mmike@fcps.edu"},
+        "administrative_assistant": {"name": "Ms. November", "username": "2030admin1"},
+        "counselors": [
+            {"name": "Ms. Oscar", "username": "2030student"},
+            {"name": "Dr. Papa", "username": "2030student1"},
+        ],
+    },
+]
+
+SUBSCHOOLS_LAST_UPDATED = datetime.date(2026, 8, 7)
+
 # App and functionality availability toggles
 ENABLE_WAITLIST = False  # Eighth waitlist. WARNING: Enabling the waitlist causes severe performance issues
 

--- a/intranet/templates/dashboard/links.html
+++ b/intranet/templates/dashboard/links.html
@@ -28,6 +28,7 @@
         </td>
         <td style="width: 50%">
           <h5 class="link-heading">TJ Resources</h5>
+          <a href="{% url 'subschools' %}">Subschool Information</a><br>
           <a href="https://ion.tjhsst.edu/lostfound">Lost and Found</a><br>
           <a href="https://studyguides.sites.tjhsst.edu">SGA Study Guides</a><br>
           <a href="https://docs.google.com/forms/d/e/1FAIpQLSfNEd_tC9qjZF5bbVPg3k4XLu8qkxFswtMWSdEcBalsFUmcSg/viewform">Submit TJTV Announcement</a><br>

--- a/intranet/templates/eighth/edit_profile.html
+++ b/intranet/templates/eighth/edit_profile.html
@@ -8,6 +8,7 @@
 
 {% block css %}
     {{ block.super }}
+    <link rel="stylesheet" href="{% static 'vendor/selectize.js-0.12.4/dist/css/selectize.default.css' %}">
     {% stylesheet 'eighth.admin' %}
     {% stylesheet 'profile' %}
     {% stylesheet 'eighth.profile' %}
@@ -16,8 +17,18 @@
 {% block js %}
     {{ block.super }}
     <script src="{% static 'vendor/ckeditor/ckeditor.js' %}"></script>
+    <script src="{% static 'vendor/selectize.js-0.12.4/dist/js/standalone/selectize.min.js' %}"></script>
     <script src="{% static 'js/eighth/admin.js' %}"></script>
+    <script>
+        $(function() {
+            $("select#id_counselor, select#id_administrator").selectize();
+        });
+    </script>
     <style>
+    .selectize-control {
+        width: 400px;
+    }
+
     #cke_1_contents {
         height: 100px !important;
     }

--- a/intranet/templates/eighth/multi_signup.html
+++ b/intranet/templates/eighth/multi_signup.html
@@ -509,6 +509,10 @@
                                     <td style="text-align: left"> {{ profile_user.counselor.last_name }} </td>
                                 </div>
                             {% endif %}
+                            <tr>
+                                <th>Administrator</th>
+                                <td style="text-align: left"> {{ profile_user.administrator.last_name }} </td>
+                            </tr>
                             {% if request.user.is_eighth_admin %}
                                 <tr class="comments">
                                     <th>Comments</th>

--- a/intranet/templates/eighth/profile_header.html
+++ b/intranet/templates/eighth/profile_header.html
@@ -52,6 +52,10 @@
                         <td> {{ profile_user.counselor.last_name }} </td>
                     </div>
                 {% endif %}
+                <tr>
+                    <th>Administrator</th>
+                    <td> {{ profile_user.administrator.last_name }} </td>
+                </tr>
                 {% if request.user.is_eighth_admin %}
                     <tr class="comments">
                         <th>Comments</th>

--- a/intranet/templates/eighth/profile_signup.html
+++ b/intranet/templates/eighth/profile_signup.html
@@ -614,6 +614,10 @@
                                     <td style="text-align: left"> {{ profile_user.counselor.last_name }} </td>
                                 </div>
                             {% endif %}
+                            <tr>
+                                <th>Administrator</th>
+                                <td style="text-align: left"> {{ profile_user.administrator.last_name }} </td>
+                            </tr>
                             {% if request.user.is_eighth_admin %}
                                 <tr class="comments">
                                     <th>Comments</th>

--- a/intranet/templates/subschool_person.html
+++ b/intranet/templates/subschool_person.html
@@ -1,0 +1,5 @@
+{% comment %}
+    One subschool staff member. Their address is resolved from their Ion username in
+    subschools_view, so anyone without a matching account is shown as plain text.
+{% endcomment %}
+{% if person.email %}<a href="mailto:{{ person.email }}">{{ person.name }}</a>{% else %}{{ person.name }}{% endif %}

--- a/intranet/templates/subschools.html
+++ b/intranet/templates/subschools.html
@@ -1,0 +1,95 @@
+{% extends "page_with_nav.html" %}
+{% load pipeline %}
+
+{% block title %}
+    {{ block.super }} - Subschools
+{% endblock %}
+
+{% block head %}
+    {% if dark_mode_enabled %}
+        {% stylesheet 'dark/base' %}
+        {% stylesheet 'dark/nav' %}
+    {% endif %}
+{% endblock %}
+
+{% block js %}
+    {{ block.super }}
+    <style>
+    .subschools h2 {
+        font-size: 1.8em;
+        margin-bottom: 0.8em;
+    }
+
+    /* Two per row; any extra subschools wrap onto further rows on their own */
+    .subschools .subschool-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        column-gap: 3em;
+        row-gap: 2.5em;
+    }
+
+    .subschools .subschool h3 {
+        font-size: 1.55em;
+        margin: 0 0 0.5em;
+    }
+
+    .subschools .subschool ul {
+        margin: 0;
+        padding-left: 2.2em;
+    }
+
+    .subschools .subschool li {
+        font-size: 1.15em;
+        line-height: 2.1;
+    }
+
+    .subschools .last-updated {
+        margin-top: 2.5em;
+        font-style: italic;
+        opacity: 0.75;
+    }
+
+    /* Stack into one column when there is not room for two */
+    @media (max-width: 700px) {
+        .subschools .subschool-grid {
+            grid-template-columns: minmax(0, 1fr);
+        }
+    }
+    </style>
+{% endblock %}
+
+{% block main %}
+    <div class="primary-content subschools">
+        <h2>Subschools</h2>
+
+        <div class="subschool-grid">
+            {% for subschool in subschools %}
+                <div class="subschool">
+                    <h3>{{ subschool.name }}</h3>
+                    <ul>
+                        <li>
+                            <b>Administrator:</b>
+                            {% include "subschool_person.html" with person=subschool.administrator %}
+                        </li>
+                        <li>
+                            <b>Administrative Assistant:</b>
+                            {% include "subschool_person.html" with person=subschool.administrative_assistant %}
+                        </li>
+                        <li>
+                            <b>Counselors:</b>
+                            {% for counselor in subschool.counselors %}
+                                {% include "subschool_person.html" with person=counselor %}{% if not forloop.last %} and {% endif %}
+                            {% endfor %}
+                        </li>
+                    </ul>
+                </div>
+            {% empty %}
+                <p>No subschools have been configured.</p>
+            {% endfor %}
+        </div>
+
+        {% if last_updated %}
+            <p class="last-updated">Last updated {{ last_updated|date:"F j, Y" }}.</p>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/intranet/templates/users/profile.html
+++ b/intranet/templates/users/profile.html
@@ -193,6 +193,12 @@
                                 <td> {{ profile_user.counselor.last_name }} </td>
                             </div>
                         {% endif %}
+                        {% if request.user.is_teacher or request.user.is_eighth_admin %}
+                            <tr>
+                                <th>Administrator</th>
+                                <td> {{ profile_user.administrator.last_name }} </td>
+                            </tr>
+                        {% endif %}
 
                         {% comment "Removing for privacy reasons" %}
                         {% if profile_user.emails.exists %}

--- a/intranet/urls.py
+++ b/intranet/urls.py
@@ -1,11 +1,11 @@
 from django.conf import settings
 from django.contrib import admin
-from django.urls import path
-from django.urls import include, re_path
+from django.urls import include, path, re_path
 from django.views.generic.base import RedirectView, TemplateView
 
 from intranet.apps.error.views import handle_404_view, handle_500_view, handle_503_view
 from intranet.apps.oauth.views import ApplicationDeleteView, ApplicationRegistrationView, ApplicationUpdateView
+from intranet.apps.users.views import subschools_view
 
 admin.autodiscover()
 
@@ -62,6 +62,7 @@ urlpatterns = [
         "docs/api-oauth-aup", TemplateView.as_view(template_name="docs/api-oauth-aup.html", content_type="text/html"), name="docs_api_oauth_aup"
     ),
     path("docs/terminology", TemplateView.as_view(template_name="docs/terminology.html", content_type="text/html"), name="docs_terminology"),
+    path("subschools", subschools_view, name="subschools"),
     path("docs/privacy", TemplateView.as_view(template_name="docs/privacy.html", content_type="text/html"), name="docs_privacy"),
     path(
         "docs/add-to-home-screen-android",


### PR DESCRIPTION
## Proposed changes
- Adds an "administrator" field to students and counselors which links to their subschool administrator's Ion account, similar to how the current student counselor setup works.
- Incorporated this into HTML templates and import student data commands (along with a new command update_administrators to update this for current students).
- Link to list of administrators, counselors, etc. - implemented via a "Subschools" button on the dashboard.
- Closes #1861 in the process by adding dropdowns for both administrator and counselor selection in editing a profile.

## Brief description of rationale
Requested by the administration.